### PR TITLE
Add flight status and currency defaults

### DIFF
--- a/server/app/config.py
+++ b/server/app/config.py
@@ -7,6 +7,8 @@ class Config:
 
     SECRET_KEY = os.environ.get('SECRET_KEY')
 
+    DEFAULT_CURRENCY = os.getenv('DEFAULT_CURRENCY', 'RUB')
+
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URI')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/server/app/models/flight.py
+++ b/server/app/models/flight.py
@@ -1,5 +1,6 @@
 from database import db
 from models.base_model import BaseModel
+from config import Config
 
 
 class Flight(BaseModel):
@@ -15,7 +16,17 @@ class Flight(BaseModel):
     business_seats = db.Column(db.Integer, default=0)
     price_economy = db.Column(db.Numeric(10, 2))
     price_business = db.Column(db.Numeric(10, 2))
-    currency = db.Column(db.String())
+    currency = db.Column(db.String(), default=Config.DEFAULT_CURRENCY,
+                         server_default=Config.DEFAULT_CURRENCY)
+
+    status = db.Column(db.String, nullable=False, default="scheduled",
+                       server_default="scheduled")
+
+    __table_args__ = (
+        db.CheckConstraint(status.in_([
+            'scheduled', 'delayed', 'departed', 'arrived', 'cancelled'
+        ]), name='flight_status_types'),
+    )
 
     def to_dict(self):
         return {


### PR DESCRIPTION
## Summary
- default to `'RUB'` if DEFAULT_CURRENCY is unset
- include Config.DEFAULT_CURRENCY when creating flights
- track the current status of a flight

------
https://chatgpt.com/codex/tasks/task_e_6862c96837d8832f9f045a333ef12523