### PR TITLE
Return JWT and user data on auth

### DIFF
--- a/server/app/controllers/auth_controller.py
+++ b/server/app/controllers/auth_controller.py
@@ -14,7 +14,8 @@ def register():
         'is_active': True
     })
     if new_user:
-        return jsonify(new_user.to_dict()), 201
+        token = signJWT(new_user.email)
+        return jsonify({'token': token, 'user': new_user.to_dict()}), 201
     return jsonify({'message': 'Invalid email or password'}), 400
 
 
@@ -26,7 +27,7 @@ def login():
     user = User.login(email, password)
     if user:
         token = signJWT(email)
-        return jsonify(token), 200
+        return jsonify({'token': token, 'user': user.to_dict()}), 200
     return jsonify({'message': 'Invalid email or password'}), 401
 
 


### PR DESCRIPTION
## Summary
- include token and user object in responses from `register` and `login`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862df07b88c832fa308128c237e6320