### PR TITLE
Configure JWT expiration via env

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -2,6 +2,7 @@
 SERVER_DEFAULT_TIMEZONE='Europe/Moscow'
 SERVER_SECRET_KEY='12345678'
 SERVER_DATABASE_URI='postgresql://tech-user:12345678@postgres:5432/avexmar-hub-db'
+SERVER_JWT_EXP_HOURS='72'
 
 CLIENT_SERVER_URL='localhost:5000'
 

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -7,6 +7,8 @@ class Config:
 
     SECRET_KEY = os.environ.get('SERVER_SECRET_KEY')
 
+    JWT_EXP_HOURS = int(os.environ.get('SERVER_JWT_EXP_HOURS', '72'))
+
     SQLALCHEMY_DATABASE_URI = os.environ.get('SERVER_DATABASE_URI')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 

--- a/server/app/utils/jwt.py
+++ b/server/app/utils/jwt.py
@@ -2,13 +2,17 @@ from datetime import datetime, timedelta
 
 import jwt
 
-from flask import current_app
+from config import Config
 
 
 def signJWT(email):
-    token_data = {'email': email, 'exp': datetime.now() + timedelta(hours=24)}
-    return jwt.encode(token_data, current_app.config['SECRET_KEY'], algorithm='HS256')
+    exp_hours = Config.JWT_EXP_HOURS
+    token_data = {
+        'email': email,
+        'exp': datetime.now() + timedelta(hours=exp_hours)
+    }
+    return jwt.encode(token_data, Config.SECRET_KEY, algorithm='HS256')
 
 
 def verifyJWT(token):
-    return jwt.decode(token, current_app.config['SECRET_KEY'], algorithms=['HS256'])
+    return jwt.decode(token, Config.SECRET_KEY, algorithms=['HS256'])


### PR DESCRIPTION
## Summary
- allow JWT token lifetime to be configured
- read new `SERVER_JWT_EXP_HOURS` from environment
- update sample environment file
- jwt utilities import `Config` directly instead of relying on `current_app`

## Testing
- `python -m py_compile server/app/utils/jwt.py server/app/config.py`


------
https://chatgpt.com/codex/tasks/task_e_686500bc9a84832f9a3c5f60f3a54c41