### PR TITLE
Add admin management components for remaining models

### DIFF
--- a/client/src/components/admin/BookingManagement.js
+++ b/client/src/components/admin/BookingManagement.js
@@ -1,0 +1,137 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import AdminDataTable from '../../components/admin/AdminDataTable';
+
+import {
+        fetchBookings,
+        createBooking,
+        updateBooking,
+        deleteBooking,
+} from '../../redux/actions/booking';
+import { FIELD_TYPES, createAdminManager } from './utils';
+import {
+        ENUM_LABELS,
+        FIELD_LABELS,
+        UI_LABELS,
+        VALIDATION_MESSAGES,
+        getEnumOptions,
+} from '../../constants';
+
+const BookingManagement = () => {
+        const dispatch = useDispatch();
+        const { bookings, isLoading, errors } = useSelector((state) => state.bookings);
+
+        useEffect(() => {
+                dispatch(fetchBookings());
+        }, [dispatch]);
+
+        const FIELDS = {
+                id: { key: 'id', apiKey: 'id' },
+                bookingNumber: {
+                        key: 'bookingNumber',
+                        apiKey: 'booking_number',
+                        label: FIELD_LABELS.BOOKING.booking_number,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                },
+                status: {
+                        key: 'status',
+                        apiKey: 'status',
+                        label: FIELD_LABELS.BOOKING.status,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('BOOKING_STATUS'),
+                        formatter: (value) => ENUM_LABELS.BOOKING_STATUS[value] || value,
+                },
+                emailAddress: {
+                        key: 'emailAddress',
+                        apiKey: 'email_address',
+                        label: FIELD_LABELS.BOOKING.email_address,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                        validate: (value) =>
+                                !value ? VALIDATION_MESSAGES.BOOKING.email_address.REQUIRED : null,
+                },
+                phoneNumber: {
+                        key: 'phoneNumber',
+                        apiKey: 'phone_number',
+                        label: FIELD_LABELS.BOOKING.phone_number,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                        validate: (value) =>
+                                !value ? VALIDATION_MESSAGES.BOOKING.phone_number.REQUIRED : null,
+                },
+                firstName: {
+                        key: 'firstName',
+                        apiKey: 'first_name',
+                        label: FIELD_LABELS.BOOKING.first_name,
+                        type: FIELD_TYPES.TEXT,
+                },
+                lastName: {
+                        key: 'lastName',
+                        apiKey: 'last_name',
+                        label: FIELD_LABELS.BOOKING.last_name,
+                        type: FIELD_TYPES.TEXT,
+                },
+                currency: {
+                        key: 'currency',
+                        apiKey: 'currency',
+                        label: FIELD_LABELS.BOOKING.currency,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('CURRENCY'),
+                        formatter: (value) => ENUM_LABELS.CURRENCY[value] || value,
+                },
+                basePrice: {
+                        key: 'basePrice',
+                        apiKey: 'base_price',
+                        label: FIELD_LABELS.BOOKING.base_price,
+                        type: FIELD_TYPES.NUMBER,
+                        float: true,
+                        inputProps: { min: 0, step: 0.01 },
+                },
+                finalPrice: {
+                        key: 'finalPrice',
+                        apiKey: 'final_price',
+                        label: FIELD_LABELS.BOOKING.final_price,
+                        type: FIELD_TYPES.NUMBER,
+                        float: true,
+                        inputProps: { min: 0, step: 0.01 },
+                },
+        };
+
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: UI_LABELS.ADMIN.modules.bookings.add_button,
+                editButtonText: UI_LABELS.ADMIN.modules.bookings.edit_button,
+        });
+
+        const handleAddBooking = (data) => {
+                dispatch(createBooking(adminManager.toApiFormat(data)));
+        };
+
+        const handleEditBooking = (data) => {
+                dispatch(updateBooking(adminManager.toApiFormat(data)));
+        };
+
+        const handleDeleteBooking = (id) => {
+                return dispatch(deleteBooking(id));
+        };
+
+        const formattedBookings = bookings.map(adminManager.toUiFormat);
+
+        return (
+                <AdminDataTable
+                        title={UI_LABELS.ADMIN.modules.bookings.management}
+                        data={formattedBookings}
+                        columns={adminManager.columns}
+                        onAdd={handleAddBooking}
+                        onEdit={handleEditBooking}
+                        onDelete={handleDeleteBooking}
+                        renderForm={adminManager.renderForm}
+                        addButtonText={UI_LABELS.ADMIN.modules.bookings.add_button}
+                        isLoading={isLoading}
+                        error={errors}
+                />
+        );
+};
+
+export default BookingManagement;

--- a/client/src/components/admin/PassengerManagement.js
+++ b/client/src/components/admin/PassengerManagement.js
@@ -1,0 +1,124 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import AdminDataTable from '../../components/admin/AdminDataTable';
+
+import {
+        fetchPassengers,
+        createPassenger,
+        updatePassenger,
+        deletePassenger,
+} from '../../redux/actions/passenger';
+import { FIELD_TYPES, createAdminManager, formatDate } from './utils';
+import {
+        ENUM_LABELS,
+        FIELD_LABELS,
+        UI_LABELS,
+        VALIDATION_MESSAGES,
+        getEnumOptions,
+} from '../../constants';
+
+const PassengerManagement = () => {
+        const dispatch = useDispatch();
+        const { passengers, isLoading, errors } = useSelector((state) => state.passengers);
+
+        useEffect(() => {
+                dispatch(fetchPassengers());
+        }, [dispatch]);
+
+        const FIELDS = {
+                id: { key: 'id', apiKey: 'id' },
+                firstName: {
+                        key: 'firstName',
+                        apiKey: 'first_name',
+                        label: FIELD_LABELS.PASSENGER.first_name,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                        validate: (value) =>
+                                !value ? VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED : null,
+                },
+                lastName: {
+                        key: 'lastName',
+                        apiKey: 'last_name',
+                        label: FIELD_LABELS.PASSENGER.last_name,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                        validate: (value) =>
+                                !value ? VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED : null,
+                },
+                middleName: {
+                        key: 'middleName',
+                        apiKey: 'middle_name',
+                        label: FIELD_LABELS.PASSENGER.middle_name,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                },
+                gender: {
+                        key: 'gender',
+                        apiKey: 'gender',
+                        label: FIELD_LABELS.PASSENGER.gender,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('GENDER'),
+                        formatter: (value) => ENUM_LABELS.GENDER[value] || value,
+                },
+                birthDate: {
+                        key: 'birthDate',
+                        apiKey: 'birth_date',
+                        label: FIELD_LABELS.PASSENGER.birth_date,
+                        type: FIELD_TYPES.DATE,
+                        formatter: (value) => formatDate(value),
+                },
+                documentType: {
+                        key: 'documentType',
+                        apiKey: 'document_type',
+                        label: FIELD_LABELS.PASSENGER.document_type,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('DOCUMENT_TYPE'),
+                },
+                documentNumber: {
+                        key: 'documentNumber',
+                        apiKey: 'document_number',
+                        label: FIELD_LABELS.PASSENGER.document_number,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                        validate: (value) =>
+                                !value ? VALIDATION_MESSAGES.PASSENGER.document_number.REQUIRED : null,
+                },
+        };
+
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: UI_LABELS.ADMIN.modules.passengers.add_button,
+                editButtonText: UI_LABELS.ADMIN.modules.passengers.edit_button,
+        });
+
+        const handleAddPassenger = (data) => {
+                dispatch(createPassenger(adminManager.toApiFormat(data)));
+        };
+
+        const handleEditPassenger = (data) => {
+                dispatch(updatePassenger(adminManager.toApiFormat(data)));
+        };
+
+        const handleDeletePassenger = (id) => {
+                return dispatch(deletePassenger(id));
+        };
+
+        const formattedPassengers = passengers.map(adminManager.toUiFormat);
+
+        return (
+                <AdminDataTable
+                        title={UI_LABELS.ADMIN.modules.passengers.management}
+                        data={formattedPassengers}
+                        columns={adminManager.columns}
+                        onAdd={handleAddPassenger}
+                        onEdit={handleEditPassenger}
+                        onDelete={handleDeletePassenger}
+                        renderForm={adminManager.renderForm}
+                        addButtonText={UI_LABELS.ADMIN.modules.passengers.add_button}
+                        isLoading={isLoading}
+                        error={errors}
+                />
+        );
+};
+
+export default PassengerManagement;

--- a/client/src/components/admin/TicketManagement.js
+++ b/client/src/components/admin/TicketManagement.js
@@ -1,0 +1,151 @@
+import React, { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import AdminDataTable from '../../components/admin/AdminDataTable';
+
+import {
+        fetchTickets,
+        createTicket,
+        updateTicket,
+        deleteTicket,
+} from '../../redux/actions/ticket';
+import { fetchFlights } from '../../redux/actions/flight';
+import { fetchBookings } from '../../redux/actions/booking';
+import { fetchPassengers } from '../../redux/actions/passenger';
+import { fetchDiscounts } from '../../redux/actions/discount';
+import { FIELD_TYPES, createAdminManager } from './utils';
+import { ENUM_LABELS, FIELD_LABELS, UI_LABELS, getEnumOptions } from '../../constants';
+
+const TicketManagement = () => {
+        const dispatch = useDispatch();
+        const { tickets, isLoading, errors } = useSelector((state) => state.tickets);
+        const { flights } = useSelector((state) => state.flights);
+        const { bookings } = useSelector((state) => state.bookings);
+        const { passengers } = useSelector((state) => state.passengers);
+        const { discounts } = useSelector((state) => state.discounts);
+
+        useEffect(() => {
+                dispatch(fetchTickets());
+                dispatch(fetchFlights());
+                dispatch(fetchBookings());
+                dispatch(fetchPassengers());
+                dispatch(fetchDiscounts());
+        }, [dispatch]);
+
+        const flightOptions = useMemo(
+                () =>
+                        flights.map((f) => ({
+                                value: f.id,
+                                label: f.id,
+                        })),
+                [flights]
+        );
+
+        const bookingOptions = useMemo(
+                () =>
+                        bookings.map((b) => ({
+                                value: b.id,
+                                label: b.booking_number,
+                        })),
+                [bookings]
+        );
+
+        const passengerOptions = useMemo(
+                () =>
+                        passengers.map((p) => ({
+                                value: p.id,
+                                label: `${p.first_name} ${p.last_name}`,
+                        })),
+                [passengers]
+        );
+
+        const discountOptions = useMemo(
+                () =>
+                        discounts.map((d) => ({
+                                value: d.id,
+                                label: d.discount_name,
+                        })),
+                [discounts]
+        );
+
+        const FIELDS = {
+                id: { key: 'id', apiKey: 'id' },
+                ticketNumber: {
+                        key: 'ticketNumber',
+                        apiKey: 'ticket_number',
+                        label: FIELD_LABELS.TICKET.ticket_number,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                },
+                flightId: {
+                        key: 'flightId',
+                        apiKey: 'flight_id',
+                        label: FIELD_LABELS.TICKET.flight_id,
+                        type: FIELD_TYPES.SELECT,
+                        options: flightOptions,
+                },
+                bookingId: {
+                        key: 'bookingId',
+                        apiKey: 'booking_id',
+                        label: FIELD_LABELS.TICKET.booking_id,
+                        type: FIELD_TYPES.SELECT,
+                        options: bookingOptions,
+                },
+                passengerId: {
+                        key: 'passengerId',
+                        apiKey: 'passenger_id',
+                        label: FIELD_LABELS.TICKET.passenger_id,
+                        type: FIELD_TYPES.SELECT,
+                        options: passengerOptions,
+                },
+                discountId: {
+                        key: 'discountId',
+                        apiKey: 'discount_id',
+                        label: FIELD_LABELS.DISCOUNT.discount_name,
+                        type: FIELD_TYPES.SELECT,
+                        options: discountOptions,
+                },
+                seatId: {
+                        key: 'seatId',
+                        apiKey: 'seat_id',
+                        label: 'Seat ID',
+                        type: FIELD_TYPES.NUMBER,
+                },
+        };
+
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: UI_LABELS.ADMIN.modules.tickets.add_button,
+                editButtonText: UI_LABELS.ADMIN.modules.tickets.edit_button,
+        });
+
+        const handleAddTicket = (data) => {
+                dispatch(createTicket(adminManager.toApiFormat(data)));
+        };
+
+        const handleEditTicket = (data) => {
+                dispatch(updateTicket(adminManager.toApiFormat(data)));
+        };
+
+        const handleDeleteTicket = (id) => {
+                return dispatch(deleteTicket(id));
+        };
+
+        const formattedTickets = tickets.map(adminManager.toUiFormat);
+
+        return (
+                <AdminDataTable
+                        title={UI_LABELS.ADMIN.modules.tickets.management}
+                        data={formattedTickets}
+                        columns={adminManager.columns}
+                        onAdd={handleAddTicket}
+                        onEdit={handleEditTicket}
+                        onDelete={handleDeleteTicket}
+                        renderForm={adminManager.renderForm}
+                        addButtonText={UI_LABELS.ADMIN.modules.tickets.add_button}
+                        isLoading={isLoading}
+                        error={errors}
+                />
+        );
+};
+
+export default TicketManagement;

--- a/client/src/components/admin/UserManagement.js
+++ b/client/src/components/admin/UserManagement.js
@@ -1,0 +1,106 @@
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import AdminDataTable from '../../components/admin/AdminDataTable';
+
+import {
+        fetchUsers,
+        createUser,
+        updateUser,
+        deleteUser,
+} from '../../redux/actions/user';
+import { FIELD_TYPES, createAdminManager } from './utils';
+import {
+        ENUM_LABELS,
+        FIELD_LABELS,
+        UI_LABELS,
+        VALIDATION_MESSAGES,
+        getEnumOptions,
+} from '../../constants';
+
+const UserManagement = () => {
+        const dispatch = useDispatch();
+        const { users, isLoading, errors } = useSelector((state) => state.users);
+
+        useEffect(() => {
+                dispatch(fetchUsers());
+        }, [dispatch]);
+
+        const FIELDS = {
+                id: { key: 'id', apiKey: 'id' },
+                email: {
+                        key: 'email',
+                        apiKey: 'email',
+                        label: FIELD_LABELS.USER.email,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                        validate: (value) =>
+                                !value ? VALIDATION_MESSAGES.USER.email.REQUIRED : null,
+                },
+                password: {
+                        key: 'password',
+                        apiKey: 'password',
+                        label: FIELD_LABELS.USER.password,
+                        type: FIELD_TYPES.TEXT,
+                        fullWidth: true,
+                        excludeFromTable: true,
+                        validate: (value) =>
+                                !value
+                                        ? VALIDATION_MESSAGES.USER.password.REQUIRED
+                                        : value.length < 6
+                                        ? VALIDATION_MESSAGES.USER.password.MIN_LENGTH
+                                        : null,
+                },
+                role: {
+                        key: 'role',
+                        apiKey: 'role',
+                        label: FIELD_LABELS.USER.role,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('USER_ROLE'),
+                        formatter: (value) => ENUM_LABELS.USER_ROLE[value] || value,
+                },
+                isActive: {
+                        key: 'isActive',
+                        apiKey: 'is_active',
+                        label: FIELD_LABELS.USER.is_active,
+                        type: FIELD_TYPES.BOOLEAN,
+                        formatter: (value) => (value ? 'Yes' : 'No'),
+                },
+        };
+
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: UI_LABELS.ADMIN.modules.users.add_button,
+                editButtonText: UI_LABELS.ADMIN.modules.users.edit_button,
+        });
+
+        const handleAddUser = (data) => {
+                dispatch(createUser(adminManager.toApiFormat(data)));
+        };
+
+        const handleEditUser = (data) => {
+                dispatch(updateUser(adminManager.toApiFormat(data)));
+        };
+
+        const handleDeleteUser = (id) => {
+                return dispatch(deleteUser(id));
+        };
+
+        const formattedUsers = users.map(adminManager.toUiFormat);
+
+        return (
+                <AdminDataTable
+                        title={UI_LABELS.ADMIN.modules.users.management}
+                        data={formattedUsers}
+                        columns={adminManager.columns}
+                        onAdd={handleAddUser}
+                        onEdit={handleEditUser}
+                        onDelete={handleDeleteUser}
+                        renderForm={adminManager.renderForm}
+                        addButtonText={UI_LABELS.ADMIN.modules.users.add_button}
+                        isLoading={isLoading}
+                        error={errors}
+                />
+        );
+};
+
+export default UserManagement;

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -9,6 +9,8 @@ import tariffsReducer from './reducers/tariff';
 import ticketsReducer from './reducers/ticket';
 import discountReducer from './reducers/discount';
 import userReducer from './reducers/user';
+import bookingReducer from './reducers/booking';
+import passengerReducer from './reducers/passenger';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const middleware = [thunk];
@@ -16,11 +18,13 @@ const rootReducer = combineReducers({
 	auth: authReducer,
 	airports: airportReducer,
 	routes: routesReducer,
-	flights: flightReducer,
-	tariffs: tariffsReducer,
-	tickets: ticketsReducer,
-	discounts: discountReducer,
-	users: userReducer,
+        flights: flightReducer,
+        tariffs: tariffsReducer,
+        tickets: ticketsReducer,
+        discounts: discountReducer,
+        bookings: bookingReducer,
+        passengers: passengerReducer,
+        users: userReducer,
 });
 
 const store = createStore(

--- a/client/src/routes/AdminRoutes.js
+++ b/client/src/routes/AdminRoutes.js
@@ -5,6 +5,10 @@ import AirportManagement from '../components/admin/AirportManagement';
 import RouteManagement from '../components/admin/RouteManagement';
 import DiscountManagement from '../components/admin/DiscountManagement';
 import FlightManagement from '../components/admin/FlightManagement';
+import BookingManagement from '../components/admin/BookingManagement';
+import TicketManagement from '../components/admin/TicketManagement';
+import PassengerManagement from '../components/admin/PassengerManagement';
+import UserManagement from '../components/admin/UserManagement';
 
 import ProtectedRoute from './ProtectedRoute';
 
@@ -42,15 +46,51 @@ const AdminRoutes = ({ isAdmin }) => [
 			/>
 		),
 	},
-	{
-		path: '/admin/flights',
-		element: (
-			<ProtectedRoute
-				children={<FlightManagement />}
-				condition={isAdmin}
-			/>
-		),
-	},
+        {
+                path: '/admin/flights',
+                element: (
+                        <ProtectedRoute
+                                children={<FlightManagement />}
+                                condition={isAdmin}
+                        />
+                ),
+        },
+        {
+                path: '/admin/bookings',
+                element: (
+                        <ProtectedRoute
+                                children={<BookingManagement />}
+                                condition={isAdmin}
+                        />
+                ),
+        },
+        {
+                path: '/admin/tickets',
+                element: (
+                        <ProtectedRoute
+                                children={<TicketManagement />}
+                                condition={isAdmin}
+                        />
+                ),
+        },
+        {
+                path: '/admin/passengers',
+                element: (
+                        <ProtectedRoute
+                                children={<PassengerManagement />}
+                                condition={isAdmin}
+                        />
+                ),
+        },
+        {
+                path: '/admin/users',
+                element: (
+                        <ProtectedRoute
+                                children={<UserManagement />}
+                                condition={isAdmin}
+                        />
+                ),
+        },
 ];
 
 export default AdminRoutes;


### PR DESCRIPTION
## Summary
- add bookings, passengers, tickets and users management components
- expose new admin routes for these pages
- register bookings and passengers reducers in store

## Testing
- `npm test --prefix client --silent` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68714b741470832fa12c9a0099d3d2da