### PR TITLE
Improve admin filters and centralize theme styles

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -61,7 +61,8 @@ const Header = () => {
 				alignItems: 'center',
 				justifyContent: 'space-between',
 				py: 2,
-				borderBottom: '1px solid #E0E0E0',
+                                borderBottom: 1,
+                                borderColor: 'divider',
 				mb: 3,
 			}}
 		>

--- a/client/src/components/admin/AdminDataTable.js
+++ b/client/src/components/admin/AdminDataTable.js
@@ -35,7 +35,7 @@ import FilterListIcon from '@mui/icons-material/FilterList';
 import FilterListOffIcon from '@mui/icons-material/FilterListOff';
 
 import Base from '../Base';
-import { UI_LABELS } from '../../constants';
+import { UI_LABELS, ENUM_LABELS } from '../../constants';
 import { FIELD_TYPES } from './utils';
 
 const AdminDataTable = ({
@@ -200,19 +200,20 @@ const AdminDataTable = ({
 		});
 	};
 
-	const applyFilters = (items) => {
-		return items.filter((item) =>
-			columns.every((col) => {
-				const value = filters[col.field];
-				if (value === undefined || value === '' || value === null) return true;
-				const itemValue = item[col.field];
-				if (col.type === FIELD_TYPES.SELECT || col.type === FIELD_TYPES.BOOLEAN) {
-					return itemValue === value;
-				}
-				return String(itemValue).toLowerCase().includes(String(value).toLowerCase());
-			})
-		);
-	};
+        const applyFilters = (items) => {
+                return items.filter((item) =>
+                        columns.every((col) => {
+                                if (col.type === FIELD_TYPES.CUSTOM) return true;
+                                const value = filters[col.field];
+                                if (value === undefined || value === '' || value === null) return true;
+                                const itemValue = item[col.field];
+                                if (col.type === FIELD_TYPES.SELECT || col.type === FIELD_TYPES.BOOLEAN) {
+                                        return itemValue === value;
+                                }
+                                return String(itemValue).toLowerCase().includes(String(value).toLowerCase());
+                        })
+                );
+        };
 
 	const applySorting = (items) => {
 		if (!sortConfig.field) return items;
@@ -298,7 +299,7 @@ const AdminDataTable = ({
 							{showFilters ? UI_LABELS.ADMIN.filter.hide : UI_LABELS.ADMIN.filter.show}
 						</Button>
 					</Box>
-					<Table stickyHeader>
+                                        <Table stickyHeader sx={{ tableLayout: 'fixed' }}>
 						<TableHead>
 							<TableRow>
 								{columns.map((column, index) => (
@@ -325,86 +326,95 @@ const AdminDataTable = ({
 							</TableRow>
 							{showFilters && (
 								<TableRow>
-									{columns.map((column, index) => (
-										<TableCell key={index} align={column.align || 'left'}>
-											{column.type === FIELD_TYPES.SELECT ||
-											column.type === FIELD_TYPES.BOOLEAN ? (
-												<Select
-													value={filters[column.field] || ''}
-													onChange={(e) => handleFilterChange(column.field, e.target.value)}
-													displayEmpty
-													size='small'
-													sx={{
-														fontSize: '0.75rem',
-														minHeight: 28,
-														height: 28,
-														py: 0,
-													}}
-													MenuProps={{
-														PaperProps: {
-															sx: {
-																fontSize: '0.75rem',
-															},
-														},
-													}}
-												>
-													<MenuItem
-														value=''
-														sx={{
-															fontSize: '0.75rem',
-															minHeight: 28,
-															height: 28,
-														}}
-													>
-														{UI_LABELS.ADMIN.filter.all}
-													</MenuItem>
-													{column.options &&
-														column.options.map((opt) => (
-															<MenuItem
-																key={opt.value}
-																value={opt.value}
-																sx={{
-																	fontSize: '0.75rem',
-																	minHeight: 28,
-																	height: 28,
-																}}
-															>
-																{opt.label}
-															</MenuItem>
-														))}
-												</Select>
-											) : (
-												<TextField
-													value={filters[column.field] || ''}
-													onChange={(e) => handleFilterChange(column.field, e.target.value)}
-													size='small'
-													inputProps={{
-														style: {
-															fontSize: '0.75rem',
-															padding: '4px 8px',
-															height: 20,
-															boxSizing: 'border-box',
-														},
-													}}
-													sx={{
-														minWidth: 0,
-														maxWidth: 150,
-														'& .MuiInputBase-root': {
-															fontSize: '0.75rem',
-															height: 28,
-															minHeight: 28,
-															padding: '0 8px',
-														},
-														'& .MuiInputBase-input': {
-															fontSize: '0.75rem',
-															height: 20,
-															padding: '4px 0',
-														},
-													}}
-												/>
-											)}
-										</TableCell>
-									))}
+                                                                        {columns.map((column, index) => (
+                                                                               column.type === FIELD_TYPES.CUSTOM ? null : (
+                                                                               <TableCell key={index} align={column.align || 'left'}>
+                                                                               {column.type === FIELD_TYPES.SELECT || column.type === FIELD_TYPES.BOOLEAN ? (
+                                                                               <Select
+                                                                               value={filters[column.field] || ''}
+                                                                               onChange={(e) => handleFilterChange(column.field, e.target.value)}
+                                                                               displayEmpty
+                                                                               size='small'
+                                                                               fullWidth
+                                                                               sx={{
+                                                                               fontSize: '0.75rem',
+                                                                               minHeight: 28,
+                                                                               height: 28,
+                                                                               py: 0,
+                                                                               }}
+                                                                               MenuProps={{
+                                                                               PaperProps: {
+                                                                               sx: {
+                                                                               fontSize: '0.75rem',
+                                                                               },
+                                                                               },
+                                                                               }}
+                                                                               >
+                                                                               <MenuItem
+                                                                               value=''
+                                                                               sx={{
+                                                                               fontSize: '0.75rem',
+                                                                               minHeight: 28,
+                                                                               height: 28,
+                                                                               }}
+                                                                               >
+                                                                               {UI_LABELS.ADMIN.filter.all}
+                                                                               </MenuItem>
+                                                                               {(column.options ||
+                                                                               (column.type === FIELD_TYPES.BOOLEAN
+                                                                               ? [
+                                                                               { value: true, label: ENUM_LABELS.BOOLEAN.true },
+                                                                               { value: false, label: ENUM_LABELS.BOOLEAN.false },
+                                                                               ]
+                                                                               : [])
+                                                                               ).map((opt) => (
+                                                                               <MenuItem
+                                                                               key={opt.value}
+                                                                               value={opt.value}
+                                                                               sx={{
+                                                                               fontSize: '0.75rem',
+                                                                               minHeight: 28,
+                                                                               height: 28,
+                                                                               }}
+                                                                               >
+                                                                               {opt.label}
+                                                                               </MenuItem>
+                                                                               ))}
+                                                                               </Select>
+                                                                               ) : (
+                                                                               <TextField
+                                                                               value={filters[column.field] || ''}
+                                                                               onChange={(e) => handleFilterChange(column.field, e.target.value)}
+                                                                               size='small'
+                                                                               fullWidth
+                                                                               inputProps={{
+                                                                               style: {
+                                                                               fontSize: '0.75rem',
+                                                                               padding: '4px 8px',
+                                                                               height: 20,
+                                                                               boxSizing: 'border-box',
+                                                                               },
+                                                                               }}
+                                                                               sx={{
+                                                                               minWidth: 0,
+                                                                               maxWidth: 150,
+                                                                               '& .MuiInputBase-root': {
+                                                                               fontSize: '0.75rem',
+                                                                               height: 28,
+                                                                               minHeight: 28,
+                                                                               padding: '0 8px',
+                                                                               },
+                                                                               '& .MuiInputBase-input': {
+                                                                               fontSize: '0.75rem',
+                                                                               height: 20,
+                                                                               padding: '4px 0',
+                                                                               },
+                                                                               }}
+                                                                               />
+                                                                               )}
+                                                                               </TableCell>
+                                                                               )
+                                                                        ))}
 									<TableCell align='right' />
 								</TableRow>
 							)}

--- a/client/src/components/auth/Login.js
+++ b/client/src/components/auth/Login.js
@@ -17,6 +17,8 @@ import {
 import CloseIcon from '@mui/icons-material/Close';
 import PersonIcon from '@mui/icons-material/Person';
 
+import { authIconContainer, authIcon, authLink } from '../../theme/styles';
+
 import Base from '../Base';
 
 import { login } from '../../redux/actions/auth';
@@ -92,18 +94,9 @@ const Login = ({ isModal = false }) => {
 						my: 3,
 					}}
 				>
-					<Box
-						sx={{
-							bgcolor: '#f0f2ff',
-							borderRadius: '50%',
-							p: 2,
-							display: 'flex',
-							justifyContent: 'center',
-							alignItems: 'center',
-						}}
-					>
-						<PersonIcon sx={{ fontSize: 40, color: '#6c63ff' }} />
-					</Box>
+                                        <Box sx={authIconContainer}>
+                                                <PersonIcon sx={authIcon} />
+                                        </Box>
 				</Box>
 
 				<Fade in={!!errors.message} timeout={300}>
@@ -181,16 +174,12 @@ const Login = ({ isModal = false }) => {
 						<Box sx={{ textAlign: 'center' }}>
 							<Typography variant='body2'>
 								{UI_LABELS.AUTH.no_account}{' '}
-								<Box
-									component='a'
-									href='#'
-									onClick={handleRegisterClick}
-									sx={{
-										color: '#6c63ff',
-										textDecoration: 'none',
-										cursor: 'pointer',
-									}}
-								>
+                                                                <Box
+                                                                        component='a'
+                                                                        href='#'
+                                                                        onClick={handleRegisterClick}
+                                                                        sx={authLink}
+                                                                >
 									<Typography
 										variant='subtitle2'
 										component='span'

--- a/client/src/components/auth/Register.js
+++ b/client/src/components/auth/Register.js
@@ -16,6 +16,8 @@ import {
 import CloseIcon from '@mui/icons-material/Close';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 
+import { authIconContainer, authIcon, authLink } from '../../theme/styles';
+
 import Base from '../Base';
 
 import { register } from '../../redux/actions/auth';
@@ -100,20 +102,9 @@ const Register = ({ isModal = false }) => {
 						my: 3,
 					}}
 				>
-					<Box
-						sx={{
-							bgcolor: '#f0f2ff',
-							borderRadius: '50%',
-							p: 2,
-							display: 'flex',
-							justifyContent: 'center',
-							alignItems: 'center',
-						}}
-					>
-						<PersonAddIcon
-							sx={{ fontSize: 40, color: '#6c63ff' }}
-						/>
-					</Box>
+                                        <Box sx={authIconContainer}>
+                                                <PersonAddIcon sx={authIcon} />
+                                        </Box>
 				</Box>
 
 				<Fade in={!!errors.message} timeout={300}>
@@ -207,16 +198,12 @@ const Register = ({ isModal = false }) => {
 						<Box sx={{ textAlign: 'center' }}>
 							<Typography variant='body2'>
 								{UI_LABELS.AUTH.have_account}{' '}
-								<Box
-									component='a'
-									href='#'
-									onClick={handleLoginClick}
-									sx={{
-										color: '#6c63ff',
-										textDecoration: 'none',
-										cursor: 'pointer',
-									}}
-								>
+                                                                <Box
+                                                                        component='a'
+                                                                        href='#'
+                                                                        onClick={handleLoginClick}
+                                                                        sx={authLink}
+                                                                >
 									<Typography
 										variant='subtitle2'
 										component='span'

--- a/client/src/components/profile/ProfileModal.js
+++ b/client/src/components/profile/ProfileModal.js
@@ -16,6 +16,8 @@ import CloseIcon from '@mui/icons-material/Close';
 import LockIcon from '@mui/icons-material/Lock';
 import ConstructionIcon from '@mui/icons-material/Construction';
 
+import { authIconContainer, authIcon } from '../../theme/styles';
+
 import { changePassword } from '../../redux/actions/user';
 import { useProfileModal } from '../../context/ProfileModalContext';
 import { UI_LABELS } from '../../constants/uiLabels';
@@ -110,18 +112,9 @@ const ProfileModal = () => {
 							my: 3,
 						}}
 					>
-						<Box
-							sx={{
-								bgcolor: '#f0f2ff',
-								borderRadius: '50%',
-								p: 2,
-								display: 'flex',
-								justifyContent: 'center',
-								alignItems: 'center',
-							}}
-						>
-							<LockIcon sx={{ fontSize: 40, color: '#6c63ff' }} />
-						</Box>
+                                                <Box sx={authIconContainer}>
+                                                        <LockIcon sx={authIcon} />
+                                                </Box>
 					</Box>
 
 					<Alert

--- a/client/src/theme/styles.js
+++ b/client/src/theme/styles.js
@@ -1,0 +1,19 @@
+export const authIconContainer = {
+        bgcolor: '#f0f2ff',
+        borderRadius: '50%',
+        p: 2,
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+};
+
+export const authIcon = {
+        fontSize: 40,
+        color: '#6c63ff',
+};
+
+export const authLink = {
+        color: '#6c63ff',
+        textDecoration: 'none',
+        cursor: 'pointer',
+};


### PR DESCRIPTION
## Summary
- add a `theme/styles.js` module and reuse it across auth components
- cleanup header styles to use theme divider
- keep table width fixed and support full width filter controls
- skip custom columns when filtering and add default boolean options

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6877c1fd083c832f96e7784b099427f7