### PR TITLE
Fix async save errors in admin forms

### DIFF
--- a/client/src/components/admin/AdminDataTable.js
+++ b/client/src/components/admin/AdminDataTable.js
@@ -157,17 +157,12 @@ const AdminDataTable = ({
 		setPage(0);
 	};
 
-	const handleSave = (formData) => {
-		try {
-			if (isEditing) {
-				onEdit(formData);
-			} else {
-				onAdd(formData);
-			}
-		} catch (error) {
-			showNotification(`${UI_LABELS.ERRORS.save}: ${error.message}`, 'error');
-		}
-	};
+        const handleSave = (formData) => {
+                if (isEditing) {
+                        return onEdit(formData);
+                }
+                return onAdd(formData);
+        };
 
 	const handleDelete = (id) => {
 		try {

--- a/client/src/components/admin/AdminEntityForm.js
+++ b/client/src/components/admin/AdminEntityForm.js
@@ -60,24 +60,25 @@ const AdminEntityForm = ({
 		return isValid;
 	};
 
-	const handleSubmit = () => {
-		if (!validateForm()) return;
+        const handleSubmit = async () => {
+                if (!validateForm()) return;
 
-		try {
-			onSave(formData);
-			setSuccessMessage(
-				isEditing ? UI_LABELS.SUCCESS.update : UI_LABELS.SUCCESS.add
-			);
-			setErrorMessage('');
+                try {
+                        await onSave(formData);
+                        setSuccessMessage(
+                                isEditing ? UI_LABELS.SUCCESS.update : UI_LABELS.SUCCESS.add
+                        );
+                        setErrorMessage('');
 
-			if (!isEditing) {
-				setTimeout(() => onClose(), 1000);
-			}
-		} catch (error) {
-			setErrorMessage(error);
-			setSuccessMessage('');
-		}
-	};
+                        if (!isEditing) {
+                                setTimeout(() => onClose(), 1000);
+                        }
+                } catch (error) {
+                        const message = error?.message || error;
+                        setErrorMessage(message);
+                        setSuccessMessage('');
+                }
+        };
 
 	return (
 		<>

--- a/client/src/components/admin/AirlineManagement.js
+++ b/client/src/components/admin/AirlineManagement.js
@@ -97,11 +97,11 @@ const AirlineManagement = () => {
 		[FIELDS, getCountryById]
 	);
 
-	const handleAdd = (data) =>
-		dispatch(createAirline(adminManager.toApiFormat(data)));
-	const handleEdit = (data) =>
-		dispatch(updateAirline(adminManager.toApiFormat(data)));
-	const handleDelete = (id) => dispatch(deleteAirline(id));
+        const handleAdd = (data) =>
+                dispatch(createAirline(adminManager.toApiFormat(data))).unwrap();
+        const handleEdit = (data) =>
+                dispatch(updateAirline(adminManager.toApiFormat(data))).unwrap();
+        const handleDelete = (id) => dispatch(deleteAirline(id));
 
 	const handleUpload = async (file) => {
 		const res = await uploadFile('airlines', file);

--- a/client/src/components/admin/AirportManagement.js
+++ b/client/src/components/admin/AirportManagement.js
@@ -117,13 +117,13 @@ const AirportManagement = () => {
 		editButtonText: UI_LABELS.ADMIN.modules.airports.edit_button,
 	});
 
-	const handleAddAirport = (airportData) => {
-		dispatch(createAirport(adminManager.toApiFormat(airportData)));
-	};
+        const handleAddAirport = (airportData) => {
+                return dispatch(createAirport(adminManager.toApiFormat(airportData))).unwrap();
+        };
 
-	const handleEditAirport = (airportData) => {
-		dispatch(updateAirport(adminManager.toApiFormat(airportData)));
-	};
+        const handleEditAirport = (airportData) => {
+                return dispatch(updateAirport(adminManager.toApiFormat(airportData))).unwrap();
+        };
 
 	const handleDeleteAirport = (id) => {
 		return dispatch(deleteAirport(id));

--- a/client/src/components/admin/BookingManagement.js
+++ b/client/src/components/admin/BookingManagement.js
@@ -110,13 +110,13 @@ const BookingManagement = () => {
 		editButtonText: UI_LABELS.ADMIN.modules.bookings.edit_button,
 	});
 
-	const handleAddBooking = (data) => {
-		dispatch(createBooking(adminManager.toApiFormat(data)));
-	};
+        const handleAddBooking = (data) => {
+                return dispatch(createBooking(adminManager.toApiFormat(data))).unwrap();
+        };
 
-	const handleEditBooking = (data) => {
-		dispatch(updateBooking(adminManager.toApiFormat(data)));
-	};
+        const handleEditBooking = (data) => {
+                return dispatch(updateBooking(adminManager.toApiFormat(data))).unwrap();
+        };
 
 	const handleDeleteBooking = (id) => {
 		return dispatch(deleteBooking(id));

--- a/client/src/components/admin/CountryManagement.js
+++ b/client/src/components/admin/CountryManagement.js
@@ -73,11 +73,11 @@ const CountryManagement = () => {
 		editButtonText: UI_LABELS.ADMIN.modules.countries.edit_button,
 	});
 
-	const handleAdd = (data) =>
-		dispatch(createCountry(adminManager.toApiFormat(data)));
-	const handleEdit = (data) =>
-		dispatch(updateCountry(adminManager.toApiFormat(data)));
-	const handleDelete = (id) => dispatch(deleteCountry(id));
+        const handleAdd = (data) =>
+                dispatch(createCountry(adminManager.toApiFormat(data))).unwrap();
+        const handleEdit = (data) =>
+                dispatch(updateCountry(adminManager.toApiFormat(data))).unwrap();
+        const handleDelete = (id) => dispatch(deleteCountry(id));
 
 	const handleUpload = async (file) => {
 		const res = await uploadFile('countries', file);

--- a/client/src/components/admin/DiscountManagement.js
+++ b/client/src/components/admin/DiscountManagement.js
@@ -78,13 +78,13 @@ const DiscountManagement = () => {
 		editButtonText: UI_LABELS.ADMIN.modules.discounts.edit_button,
 	});
 
-	const handleAddDiscount = (discountData) => {
-		dispatch(createDiscount(adminManager.toApiFormat(discountData)));
-	};
+        const handleAddDiscount = (discountData) => {
+                return dispatch(createDiscount(adminManager.toApiFormat(discountData))).unwrap();
+        };
 
-	const handleEditDiscount = (discountData) => {
-		dispatch(updateDiscount(adminManager.toApiFormat(discountData)));
-	};
+        const handleEditDiscount = (discountData) => {
+                return dispatch(updateDiscount(adminManager.toApiFormat(discountData))).unwrap();
+        };
 
 	const handleDeleteDiscount = (id) => {
 		return dispatch(deleteDiscount(id));

--- a/client/src/components/admin/FlightManagement.js
+++ b/client/src/components/admin/FlightManagement.js
@@ -367,13 +367,13 @@ const FlightManagement = () => {
 		[FIELDS, getRouteById, getAirlineById]
 	);
 
-	const handleAddFlight = (flightData) => {
-		dispatch(createFlight(adminManager.toApiFormat(flightData)));
-	};
+        const handleAddFlight = (flightData) => {
+                return dispatch(createFlight(adminManager.toApiFormat(flightData))).unwrap();
+        };
 
-	const handleEditFlight = (flightData) => {
-		dispatch(updateFlight(adminManager.toApiFormat(flightData)));
-	};
+        const handleEditFlight = (flightData) => {
+                return dispatch(updateFlight(adminManager.toApiFormat(flightData))).unwrap();
+        };
 
 	const handleDeleteFlight = (id) => {
 		return dispatch(deleteFlight(id));

--- a/client/src/components/admin/PassengerManagement.js
+++ b/client/src/components/admin/PassengerManagement.js
@@ -99,13 +99,13 @@ const PassengerManagement = () => {
 		editButtonText: UI_LABELS.ADMIN.modules.passengers.edit_button,
 	});
 
-	const handleAddPassenger = (data) => {
-		dispatch(createPassenger(adminManager.toApiFormat(data)));
-	};
+        const handleAddPassenger = (data) => {
+                return dispatch(createPassenger(adminManager.toApiFormat(data))).unwrap();
+        };
 
-	const handleEditPassenger = (data) => {
-		dispatch(updatePassenger(adminManager.toApiFormat(data)));
-	};
+        const handleEditPassenger = (data) => {
+                return dispatch(updatePassenger(adminManager.toApiFormat(data))).unwrap();
+        };
 
 	const handleDeletePassenger = (id) => {
 		return dispatch(deletePassenger(id));

--- a/client/src/components/admin/RouteManagement.js
+++ b/client/src/components/admin/RouteManagement.js
@@ -87,13 +87,13 @@ const RouteManagement = () => {
 		[FIELDS, getAirportById]
 	);
 
-	const handleAddRoute = (routeData) => {
-		dispatch(createRoute(adminManager.toApiFormat(routeData)));
-	};
+        const handleAddRoute = (routeData) => {
+                return dispatch(createRoute(adminManager.toApiFormat(routeData))).unwrap();
+        };
 
-	const handleEditRoute = (routeData) => {
-		dispatch(updateRoute(adminManager.toApiFormat(routeData)));
-	};
+        const handleEditRoute = (routeData) => {
+                return dispatch(updateRoute(adminManager.toApiFormat(routeData))).unwrap();
+        };
 
 	const handleDeleteRoute = (id) => {
 		return dispatch(deleteRoute(id));

--- a/client/src/components/admin/TariffManagement.js
+++ b/client/src/components/admin/TariffManagement.js
@@ -104,18 +104,23 @@ export const TariffManagement = ({
 		}
 	}, [isEditing, tariffId, dispatch]);
 
-	const handleSaveTariff = (tariffData) => {
-		const formattedData = tariffManager.toApiFormat({
-			...tariffData,
-			flightId,
-		});
-		dispatch(
-			isEditing
-				? updateTariff(formattedData)
-				: createTariff(formattedData)
-		);
-		onClose();
-	};
+        const handleSaveTariff = async (tariffData) => {
+                const formattedData = tariffManager.toApiFormat({
+                        ...tariffData,
+                        flightId,
+                });
+
+                try {
+                        await dispatch(
+                                isEditing
+                                        ? updateTariff(formattedData)
+                                        : createTariff(formattedData)
+                        ).unwrap();
+                        onClose();
+                } catch (error) {
+                        throw error;
+                }
+        };
 
 	if (isEditing && isLoading) {
 		return (

--- a/client/src/components/admin/TicketManagement.js
+++ b/client/src/components/admin/TicketManagement.js
@@ -120,13 +120,13 @@ const TicketManagement = () => {
 		editButtonText: UI_LABELS.ADMIN.modules.tickets.edit_button,
 	});
 
-	const handleAddTicket = (data) => {
-		dispatch(createTicket(adminManager.toApiFormat(data)));
-	};
+        const handleAddTicket = (data) => {
+                return dispatch(createTicket(adminManager.toApiFormat(data))).unwrap();
+        };
 
-	const handleEditTicket = (data) => {
-		dispatch(updateTicket(adminManager.toApiFormat(data)));
-	};
+        const handleEditTicket = (data) => {
+                return dispatch(updateTicket(adminManager.toApiFormat(data))).unwrap();
+        };
 
 	const handleDeleteTicket = (id) => {
 		return dispatch(deleteTicket(id));

--- a/client/src/components/admin/UserManagement.js
+++ b/client/src/components/admin/UserManagement.js
@@ -59,13 +59,13 @@ const UserManagement = () => {
 		editButtonText: UI_LABELS.ADMIN.modules.users.edit_button,
 	});
 
-	const handleAddUser = (data) => {
-		dispatch(createUser(adminManager.toApiFormat(data)));
-	};
+        const handleAddUser = (data) => {
+                return dispatch(createUser(adminManager.toApiFormat(data))).unwrap();
+        };
 
-	const handleEditUser = (data) => {
-		dispatch(updateUser(adminManager.toApiFormat(data)));
-	};
+        const handleEditUser = (data) => {
+                return dispatch(updateUser(adminManager.toApiFormat(data))).unwrap();
+        };
 
 	const handleDeleteUser = (id) => {
 		return dispatch(deleteUser(id));


### PR DESCRIPTION
## Summary
- make `AdminEntityForm` await `onSave` before showing success message
- propagate promises from `AdminDataTable` `handleSave`
- return `.unwrap()` results from admin create/update actions to surface errors
- handle tariff form save with async logic

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest` *(fails: could not install deps due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6877cd0ca50c832fa50941b0e67a2f43