### PR TITLE
Fix error message handling

### DIFF
--- a/client/src/redux/utils.js
+++ b/client/src/redux/utils.js
@@ -2,11 +2,11 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { serverApi } from '../api';
 
 export const getErrorData = (error) => {
-	return (
-		error.response?.data?.message ||
-		error.message ||
-		'An unknown error occurred'
-	);
+        if (error.response?.data) {
+                return error.response.data;
+        }
+
+        return { message: error.message || 'An unknown error occurred' };
 };
 
 export const handlePending = (state) => {


### PR DESCRIPTION
## Summary
- fix `getErrorData` to return full error response data so auth errors display properly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6877d1391294832fa8c050272e0a3acf