### PR TITLE
Implement case-insensitive email login

### DIFF
--- a/server/app/controllers/auth_controller.py
+++ b/server/app/controllers/auth_controller.py
@@ -9,7 +9,7 @@ from app.models._base_model import ModelValidationError
 
 def register():
     body = request.json
-    email = body.get('email', '')
+    email = body.get('email', '').lower()
     password = body.get('password', '')
     if not email or not password:
         return jsonify({'message': 'Email and password are required'}), 400
@@ -20,8 +20,8 @@ def register():
 
     try:
         new_user = User.create(**{
-            'email': body.get('email', ''),
-            'password': body.get('password', ''),
+            'email': email,
+            'password': password,
             'role': Config.DEFAULT_USER_ROLE,
             'is_active': True
         })
@@ -35,19 +35,19 @@ def register():
 
 def login():
     body = request.json
-    email = body.get('email', '')
+    email = body.get('email', '').lower()
     password = body.get('password', '')
 
     user = User.login(email, password)
     if user:
-        token = signJWT(email)
+        token = signJWT(user.email)
         return jsonify({'token': token, 'user': user.to_dict()}), 200
     return jsonify({'message': 'Invalid email or password'}), 401
 
 
 def forgot_password():
     body = request.json
-    email = body.get('email', '')
+    email = body.get('email', '').lower()
 
     if not email:
         return jsonify({'message': 'Email is required'}), 400

--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -8,6 +8,8 @@ from app.models._base_model import ModelValidationError
 @admin_required
 def create_user(current_user):
     body = request.json
+    if 'email' in body and isinstance(body['email'], str):
+        body['email'] = body['email'].lower()
     try:
         new_user = User.create(**body)
         if new_user:

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -26,6 +26,8 @@ class User(BaseModel):
     @classmethod
     def create(cls, session: Session | None = None, **data):
         session = session or db.session
+        if 'email' in data and isinstance(data['email'], str):
+            data['email'] = data['email'].lower()
         existing_user = cls.get_by_email(data.get('email', ''))
         if existing_user:
             raise ModelValidationError({'email': 'must be unique'})
@@ -47,7 +49,9 @@ class User(BaseModel):
 
     @classmethod
     def get_by_email(cls, _email):
-        return cls.query.filter_by(email=_email).first()
+        if not isinstance(_email, str):
+            return None
+        return cls.query.filter_by(email=_email.lower()).first()
 
     @classmethod
     def update(cls, _id, session: Session | None = None, **data):

--- a/server/tests/integration/test_auth_flow.py
+++ b/server/tests/integration/test_auth_flow.py
@@ -7,6 +7,14 @@ def test_register(client):
     assert 'token' in data
 
 
+def test_register_uppercase_email(client):
+    """Registration should store email in lowercase"""
+    resp = client.post('/register', json={'email': 'MIXED@Example.COM', 'password': 'pass'})
+    assert resp.status_code == 201
+    data = resp.get_json()
+    assert data['user']['email'] == 'mixed@example.com'
+
+
 def test_login_and_auth(client, standard_user):
     """Test login and authentication flow using standard user fixture"""
     # Use the standard_user fixture instead of creating a new user
@@ -17,6 +25,15 @@ def test_login_and_auth(client, standard_user):
     assert resp.status_code == 200
     token = resp.get_json()['token']
 
+    auth_resp = client.get('/auth', headers={'Authorization': f'Bearer {token}'})
+    assert auth_resp.status_code == 200
+    assert auth_resp.get_json()['email'] == standard_user.email
+
+
+def test_login_case_insensitive(client, standard_user):
+    resp = client.post('/login', json={'email': 'USER@EXAMPLE.COM', 'password': 'password'})
+    assert resp.status_code == 200
+    token = resp.get_json()['token']
     auth_resp = client.get('/auth', headers={'Authorization': f'Bearer {token}'})
     assert auth_resp.status_code == 200
     assert auth_resp.get_json()['email'] == standard_user.email


### PR DESCRIPTION
## Summary
- normalize emails to lowercase on user creation
- lookup emails in lowercase and return lowercase token emails
- ensure controllers convert incoming emails to lowercase
- allow admin to create users with case-insensitive emails
- test login/registration with mixed-case emails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6878965f3470832f9a7faa8c6b9be6c9