### PR TITLE
Implement modal-based password reset

### DIFF
--- a/client/src/components/auth/AuthModal.js
+++ b/client/src/components/auth/AuthModal.js
@@ -4,12 +4,13 @@ import { Modal, Fade } from '@mui/material';
 import Login from './Login';
 import Register from './Register';
 import ForgotPassword from './ForgotPassword';
+import ResetPassword from './ResetPassword';
 
 import { useAuthModal } from '../../context/AuthModalContext';
 
 const AuthModal = () => {
-	const { authModal, closeAuthModal } = useAuthModal();
-	const { isOpen, type } = authModal;
+        const { authModal, closeAuthModal } = useAuthModal();
+        const { isOpen, type, token } = authModal;
 
 	const lastFocusedRef = useRef(null);
 
@@ -43,7 +44,10 @@ const AuthModal = () => {
 				<div>
 					{type === 'login' && <Login isModal={true} />}
 					{type === 'register' && <Register isModal={true} />}
-					{type === 'forgotPassword' && <ForgotPassword isModal={true} />}
+                                        {type === 'forgotPassword' && <ForgotPassword isModal={true} />}
+                                        {type === 'resetPassword' && (
+                                                <ResetPassword isModal={true} token={token} />
+                                        )}
 				</div>
 			</Fade>
 		</Modal>

--- a/client/src/components/auth/ResetPassword.js
+++ b/client/src/components/auth/ResetPassword.js
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import {
+        Box,
+        Button,
+        Container,
+        TextField,
+        Typography,
+        Paper,
+        Alert,
+        Fade,
+        CircularProgress,
+} from '@mui/material';
+import LockResetIcon from '@mui/icons-material/LockReset';
+
+import { authIconContainer, authIcon } from '../../theme/styles';
+import { resetPassword } from '../../redux/actions/auth';
+import { UI_LABELS } from '../../constants/uiLabels';
+import Base from '../Base';
+import { useAuthModal } from '../../context/AuthModalContext';
+import IconButton from '@mui/material/IconButton';
+import CloseIcon from '@mui/icons-material/Close';
+
+const ResetPassword = ({ isModal = false, token: tokenProp = null }) => {
+        const dispatch = useDispatch();
+        const navigate = useNavigate();
+        const [searchParams] = useSearchParams();
+        const { closeAuthModal } = useAuthModal();
+        const token = tokenProp || searchParams.get('token') || '';
+
+        const [formData, setFormData] = useState({
+                password: '',
+                confirm: '',
+        });
+        const [errors, setErrors] = useState({});
+        const [successMessage, setSuccessMessage] = useState('');
+
+        const onChange = (e) => setFormData({ ...formData, [e.target.name]: e.target.value });
+
+        const onSubmit = async (e) => {
+                e.preventDefault();
+
+                if (formData.password !== formData.confirm) {
+                        setErrors({ confirm: UI_LABELS.PROFILE.passwords_dont_match });
+                        return;
+                }
+
+                setErrors({});
+                dispatch(resetPassword({ token, password: formData.password }))
+                        .unwrap()
+                        .then(() => {
+                                setSuccessMessage(UI_LABELS.PROFILE.password_changed);
+                                setTimeout(() => navigate('/'), 1500);
+                        })
+                        .catch((res) => setErrors(res));
+        };
+
+        const content = (
+                <Fade in={true} timeout={500}>
+                        <Paper
+                                sx={{
+                                        p: 4,
+                                        position: 'relative',
+                                        maxWidth: '300px',
+                                        mx: 'auto',
+                                        outline: 'none',
+                                }}
+                        >
+                                {isModal && (
+                                        <IconButton aria-label='close' onClick={closeAuthModal} sx={{ position: 'absolute', right: 8, top: 8 }}>
+                                                <CloseIcon />
+                                        </IconButton>
+                                )}
+                                <Typography variant='h4' component='h4' align='center' gutterBottom>
+                                        {UI_LABELS.TITLES.forgot_password}
+                                </Typography>
+                                <Box sx={{ display: 'flex', justifyContent: 'center', my: 3 }}>
+                                        <Box sx={authIconContainer}>
+                                                <LockResetIcon sx={authIcon} />
+                                        </Box>
+                                </Box>
+
+                                <Fade in={!!errors.message} timeout={300}>
+                                        <div>{errors.message && <Alert severity='error' sx={{ mb: 2 }}>{errors.message}</Alert>}</div>
+                                </Fade>
+
+                                <Fade in={!!successMessage} timeout={300}>
+                                        <div>
+                                                {successMessage && (
+                                                        <Alert severity='success' sx={{ mb: 2 }}>
+                                                                {successMessage}
+                                                        </Alert>
+                                                )}
+                                        </div>
+                                </Fade>
+
+                                {!successMessage ? (
+                                        <Box component='form' onSubmit={onSubmit}>
+                                                <TextField
+                                                        margin='dense'
+                                                        required
+                                                        fullWidth
+                                                        name='password'
+                                                        label={UI_LABELS.AUTH.new_password}
+                                                        type='password'
+                                                        id='password'
+                                                        autoFocus
+                                                        value={formData.password}
+                                                        onChange={onChange}
+                                                        error={!!errors.password}
+                                                        helperText={errors.password ? errors.password : ''}
+                                                />
+                                                <TextField
+                                                        margin='dense'
+                                                        required
+                                                        fullWidth
+                                                        name='confirm'
+                                                        label={UI_LABELS.AUTH.confirm_password}
+                                                        type='password'
+                                                        id='confirm'
+                                                        value={formData.confirm}
+                                                        onChange={onChange}
+                                                        error={!!errors.confirm}
+                                                        helperText={errors.confirm ? errors.confirm : ''}
+                                                />
+                                                <Button type='submit' fullWidth variant='contained' sx={{ mt: 2 }}>
+                                                        {UI_LABELS.BUTTONS.send}
+                                                </Button>
+                                        </Box>
+                                ) : (
+                                        <Box sx={{ height: '160px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                                                <CircularProgress color='primary' size={40} />
+                                        </Box>
+                                )}
+                        </Paper>
+                </Fade>
+        );
+
+        return isModal ? (
+                content
+        ) : (
+                <Base
+                        sx={{
+                                position: 'fixed',
+                                top: 0,
+                                left: 0,
+                                width: '100%',
+                                height: '100%',
+                                display: 'flex',
+                                justifyContent: 'center',
+                                alignItems: 'center',
+                        }}
+                >
+                        <Container maxWidth='sm'>{content}</Container>
+                </Base>
+        );
+};
+
+export default ResetPassword;

--- a/client/src/components/auth/ResetPasswordEntry.js
+++ b/client/src/components/auth/ResetPasswordEntry.js
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import { useSearchParams, Navigate } from 'react-router-dom';
+import { useAuthModal } from '../../context/AuthModalContext';
+
+const ResetPasswordEntry = () => {
+        const { openResetPasswordModal } = useAuthModal();
+        const [searchParams] = useSearchParams();
+        const token = searchParams.get('token') || '';
+
+        useEffect(() => {
+                openResetPasswordModal(token);
+        }, [openResetPasswordModal, token]);
+
+        return <Navigate to='/' replace />;
+};
+
+export default ResetPasswordEntry;

--- a/client/src/context/AuthModalContext.js
+++ b/client/src/context/AuthModalContext.js
@@ -5,7 +5,8 @@ const AuthModalContext = createContext();
 export const AuthModalProvider = ({ children }) => {
         const [authModal, setAuthModal] = useState({
                 isOpen: false,
-                type: null, // 'login', 'register' or 'forgotPassword'
+                type: null, // 'login', 'register', 'forgotPassword' or 'resetPassword'
+                token: null,
         });
 
 	const openLoginModal = () => {
@@ -17,12 +18,16 @@ export const AuthModalProvider = ({ children }) => {
         };
 
         const openForgotPasswordModal = () => {
-                setAuthModal({ isOpen: true, type: 'forgotPassword' });
+                setAuthModal({ isOpen: true, type: 'forgotPassword', token: null });
         };
 
-	const closeAuthModal = () => {
-		setAuthModal({ isOpen: false, type: null });
-	};
+        const openResetPasswordModal = (token) => {
+                setAuthModal({ isOpen: true, type: 'resetPassword', token });
+        };
+
+        const closeAuthModal = () => {
+                setAuthModal({ isOpen: false, type: null, token: null });
+        };
 
 	return (
 		<AuthModalContext.Provider
@@ -31,6 +36,7 @@ export const AuthModalProvider = ({ children }) => {
 				openLoginModal,
                                 openRegisterModal,
                                 openForgotPasswordModal,
+                                openResetPasswordModal,
                                 closeAuthModal,
 			}}
 		>

--- a/client/src/redux/actions/auth.js
+++ b/client/src/redux/actions/auth.js
@@ -42,10 +42,19 @@ export const auth = createAsyncThunk('auth/verify', async (_, { rejectWithValue 
 });
 
 export const forgotPassword = createAsyncThunk('auth/forgotPassword', async (data, { rejectWithValue }) => {
-	try {
-		const res = await serverApi.post('/forgot_password', data);
-		return res.data;
-	} catch (err) {
-		return rejectWithValue(getErrorData(err));
-	}
+        try {
+                const res = await serverApi.post('/forgot_password', data);
+                return res.data;
+        } catch (err) {
+                return rejectWithValue(getErrorData(err));
+        }
+});
+
+export const resetPassword = createAsyncThunk('auth/resetPassword', async (data, { rejectWithValue }) => {
+        try {
+                const res = await serverApi.post('/reset_password', data);
+                return res.data;
+        } catch (err) {
+                return rejectWithValue(getErrorData(err));
+        }
 });

--- a/client/src/routes/PublicRoutes.js
+++ b/client/src/routes/PublicRoutes.js
@@ -2,10 +2,12 @@ import React from 'react';
 
 import Home from '../components/Home';
 import About from '../components/About';
+import ResetPasswordEntry from '../components/auth/ResetPasswordEntry';
 
 const PublicRoutes = () => [
-	{ path: '/', element: <Home /> },
-	{ path: '/about', element: <About /> },
+        { path: '/', element: <Home /> },
+        { path: '/about', element: <About /> },
+        { path: '/reset_password', element: <ResetPasswordEntry /> },
 ];
 
 export default PublicRoutes;

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -52,6 +52,7 @@ def __create_app(_config_class, _db):
     app.route('/login', methods=['POST'])(login)
     app.route('/auth', methods=['GET'])(auth)
     app.route('/forgot_password', methods=['POST'])(forgot_password)
+    app.route('/reset_password', methods=['POST'])(reset_password)
 
     # users
     app.route('/users', methods=['GET'])(get_users)

--- a/server/app/models/password_reset_token.py
+++ b/server/app/models/password_reset_token.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta
+import secrets
+
+from app.database import db
+from app.models._base_model import BaseModel
+
+
+class PasswordResetToken(BaseModel):
+    __tablename__ = 'password_reset_tokens'
+
+    token = db.Column(db.String, unique=True, index=True, nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+    used = db.Column(db.Boolean, default=False, nullable=False)
+
+    user = db.relationship('User')
+
+    @classmethod
+    def create_token(cls, user, expires_in_hours=1):
+        token = secrets.token_urlsafe(32)
+        expires_at = datetime.utcnow() + timedelta(hours=expires_in_hours)
+        instance = cls(token=token, user_id=user.id, expires_at=expires_at, used=False)
+        db.session.add(instance)
+        db.session.commit()
+        return instance
+
+    @classmethod
+    def verify_token(cls, token):
+        instance = cls.query.filter_by(token=token, used=False).first()
+        if not instance:
+            return None
+        if instance.expires_at < datetime.utcnow():
+            return None
+        return instance

--- a/server/app/templates/forgot_password.txt
+++ b/server/app/templates/forgot_password.txt
@@ -3,4 +3,6 @@ Hello,
 To reset your password, visit the following link:
 {{ reset_url }}
 
+This link expires after one hour or after it is used once.
+
 If you did not request a password reset, please ignore this email.

--- a/server/tests/integration/test_password_reset.py
+++ b/server/tests/integration/test_password_reset.py
@@ -1,0 +1,38 @@
+from app.models.password_reset_token import PasswordResetToken
+from app.models.user import User
+
+
+def test_password_reset_flow(client, standard_user):
+    resp = client.post('/forgot_password', json={'email': standard_user.email})
+    assert resp.status_code == 200
+
+    token = PasswordResetToken.query.filter_by(user_id=standard_user.id).first()
+    assert token is not None
+
+    resp = client.post('/reset_password', json={'token': token.token, 'password': 'newpass'})
+    assert resp.status_code == 200
+    assert resp.get_json()['message'] == 'Password reset successful'
+
+    # token should be marked used
+    assert token.used is True
+
+    # password should be changed
+    assert User.login(standard_user.email, 'newpass') is not None
+
+    # reuse should fail
+    resp = client.post('/reset_password', json={'token': token.token, 'password': 'another'})
+    assert resp.status_code == 400
+
+
+def test_password_reset_expired_token(client, standard_user):
+    resp = client.post('/forgot_password', json={'email': standard_user.email})
+    assert resp.status_code == 200
+    token = PasswordResetToken.query.filter_by(user_id=standard_user.id).first()
+    assert token is not None
+
+    token.expires_at = token.expires_at.replace(year=2000)
+    from app.database import db
+    db.session.commit()
+
+    resp = client.post('/reset_password', json={'token': token.token, 'password': 'newpass'})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- remove migration file for password reset tokens
- use `AuthModal` to display password reset form
- add `ResetPasswordEntry` route component to open the modal
- extend context to support `resetPassword` modal type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6878b90f7ebc832fb50e7cf0b78579a9