### PR TITLE
Fix bulk delete and validation errors

### DIFF
--- a/client/src/components/admin/AirlineManagement.js
+++ b/client/src/components/admin/AirlineManagement.js
@@ -96,10 +96,10 @@ const AirlineManagement = () => {
 	const handleEdit = (data) => dispatch(updateAirline(adminManager.toApiFormat(data))).unwrap();
 	const handleDelete = (id) => dispatch(deleteAirline(id));
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllAirlines());
-		dispatch(fetchAirlines());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllAirlines()).unwrap();
+               dispatch(fetchAirlines());
+       };
 
 	const handleUpload = async (file) => {
 		const res = await uploadFile('airlines', file);

--- a/client/src/components/admin/AirportManagement.js
+++ b/client/src/components/admin/AirportManagement.js
@@ -119,10 +119,10 @@ const AirportManagement = () => {
 		return dispatch(deleteAirport(id));
 	};
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllAirports());
-		dispatch(fetchAirports());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllAirports()).unwrap();
+               dispatch(fetchAirports());
+       };
 
 	const handleUpload = async (file) => {
 		const res = await uploadFile('airports', file);

--- a/client/src/components/admin/BookingManagement.js
+++ b/client/src/components/admin/BookingManagement.js
@@ -109,10 +109,10 @@ const BookingManagement = () => {
 		return dispatch(deleteBooking(id));
 	};
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllBookings());
-		dispatch(fetchBookings());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllBookings()).unwrap();
+               dispatch(fetchBookings());
+       };
 
 	const formattedBookings = bookings.map(adminManager.toUiFormat);
 

--- a/client/src/components/admin/CountryManagement.js
+++ b/client/src/components/admin/CountryManagement.js
@@ -73,10 +73,10 @@ const CountryManagement = () => {
 	const handleEdit = (data) => dispatch(updateCountry(adminManager.toApiFormat(data))).unwrap();
 	const handleDelete = (id) => dispatch(deleteCountry(id));
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllCountries()).unwrap();
-		// dispatch(fetchCountries());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllCountries()).unwrap();
+               dispatch(fetchCountries());
+       };
 
 	const handleUpload = async (file) => {
 		const res = await uploadFile('countries', file);

--- a/client/src/components/admin/DiscountManagement.js
+++ b/client/src/components/admin/DiscountManagement.js
@@ -76,10 +76,10 @@ const DiscountManagement = () => {
 		return dispatch(deleteDiscount(id));
 	};
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllDiscounts());
-		dispatch(fetchDiscounts());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllDiscounts()).unwrap();
+               dispatch(fetchDiscounts());
+       };
 
 	const formattedDiscounts = discounts.map(adminManager.toUiFormat);
 

--- a/client/src/components/admin/FlightManagement.js
+++ b/client/src/components/admin/FlightManagement.js
@@ -318,10 +318,10 @@ const FlightManagement = () => {
 		return dispatch(deleteFlight(id));
 	};
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllFlights());
-		dispatch(fetchFlights());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllFlights()).unwrap();
+               dispatch(fetchFlights());
+       };
 
 	const formattedFlights = flights.map(adminManager.toUiFormat);
 

--- a/client/src/components/admin/PassengerManagement.js
+++ b/client/src/components/admin/PassengerManagement.js
@@ -95,10 +95,10 @@ const PassengerManagement = () => {
 		return dispatch(deletePassenger(id));
 	};
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllPassengers());
-		dispatch(fetchPassengers());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllPassengers()).unwrap();
+               dispatch(fetchPassengers());
+       };
 
 	const formattedPassengers = passengers.map(adminManager.toUiFormat);
 

--- a/client/src/components/admin/RouteManagement.js
+++ b/client/src/components/admin/RouteManagement.js
@@ -86,10 +86,10 @@ const RouteManagement = () => {
 		return dispatch(deleteRoute(id));
 	};
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllRoutes());
-		dispatch(fetchRoutes());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllRoutes()).unwrap();
+               dispatch(fetchRoutes());
+       };
 
 	const formattedRoutes = routes.map(adminManager.toUiFormat);
 

--- a/client/src/components/admin/TicketManagement.js
+++ b/client/src/components/admin/TicketManagement.js
@@ -125,10 +125,10 @@ const TicketManagement = () => {
 		return dispatch(deleteTicket(id));
 	};
 
-	const handleDeleteAll = async () => {
-		dispatch(deleteAllTickets());
-		dispatch(fetchTickets());
-	};
+       const handleDeleteAll = async () => {
+               await dispatch(deleteAllTickets()).unwrap();
+               dispatch(fetchTickets());
+       };
 
 	const formattedTickets = tickets.map(adminManager.toUiFormat);
 

--- a/server/app/controllers/airline_controller.py
+++ b/server/app/controllers/airline_controller.py
@@ -51,10 +51,13 @@ def update_airline(current_user, airline_id):
 
 @admin_required
 def delete_airline(current_user, airline_id):
-    deleted = Airline.delete(airline_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Airline not found'}), 404
+    try:
+        deleted = Airline.delete(airline_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Airline not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400
 
 
 @admin_required

--- a/server/app/controllers/airport_controller.py
+++ b/server/app/controllers/airport_controller.py
@@ -44,10 +44,13 @@ def update_airport(current_user, airport_id):
 
 @admin_required
 def delete_airport(current_user, airport_id):
-    deleted = Airport.delete(airport_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Airport not found'}), 404
+    try:
+        deleted = Airport.delete(airport_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Airport not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400
 
 
 @admin_required

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -43,7 +43,10 @@ def update_booking(current_user, booking_id):
 
 @admin_required
 def delete_booking(current_user, booking_id):
-    deleted = Booking.delete(booking_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Booking not found'}), 404
+    try:
+        deleted = Booking.delete(booking_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Booking not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/country_controller.py
+++ b/server/app/controllers/country_controller.py
@@ -44,10 +44,13 @@ def update_country(current_user, country_id):
 
 @admin_required
 def delete_country(current_user, country_id):
-    deleted = Country.delete(country_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Country not found'}), 404
+    try:
+        deleted = Country.delete(country_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Country not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400
 
 
 @admin_required

--- a/server/app/controllers/discount_controller.py
+++ b/server/app/controllers/discount_controller.py
@@ -43,7 +43,10 @@ def update_discount(current_user, discount_id):
 
 @admin_required
 def delete_discount(current_user, discount_id):
-    deleted = Discount.delete(discount_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Discount not found'}), 404
+    try:
+        deleted = Discount.delete(discount_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Discount not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/flight_controller.py
+++ b/server/app/controllers/flight_controller.py
@@ -60,7 +60,10 @@ def update_flight(current_user, flight_id):
 
 @admin_required
 def delete_flight(current_user, flight_id):
-    deleted = Flight.delete(flight_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Flight not found'}), 404
+    try:
+        deleted = Flight.delete(flight_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Flight not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/passenger_controller.py
+++ b/server/app/controllers/passenger_controller.py
@@ -43,7 +43,10 @@ def update_passenger(current_user, passenger_id):
 
 @admin_required
 def delete_passenger(current_user, passenger_id):
-    deleted = Passenger.delete(passenger_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Passenger not found'}), 404
+    try:
+        deleted = Passenger.delete(passenger_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Passenger not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/payment_controller.py
+++ b/server/app/controllers/payment_controller.py
@@ -49,7 +49,10 @@ def update_payment(current_user, payment_id):
 
 @admin_required
 def delete_payment(current_user, payment_id):
-    deleted = Payment.delete(payment_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Payment not found'}), 404
+    try:
+        deleted = Payment.delete(payment_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Payment not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/route_controller.py
+++ b/server/app/controllers/route_controller.py
@@ -52,7 +52,10 @@ def update_route(current_user, route_id):
 
 @admin_required
 def delete_route(current_user, route_id):
-    deleted = Route.delete(route_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Route not found'}), 404
+    try:
+        deleted = Route.delete(route_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Route not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/seat_controller.py
+++ b/server/app/controllers/seat_controller.py
@@ -61,7 +61,10 @@ def update_seat(current_user, seat_id):
 
 @admin_required
 def delete_seat(current_user, seat_id):
-    deleted = Seat.delete(seat_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Seat not found'}), 404
+    try:
+        deleted = Seat.delete(seat_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Seat not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/tariff_controller.py
+++ b/server/app/controllers/tariff_controller.py
@@ -49,7 +49,10 @@ def update_tariff(current_user, tariff_id):
 
 @admin_required
 def delete_tariff(current_user, tariff_id):
-    deleted = Tariff.delete(tariff_id)
-    if deleted:
-        return jsonify(deleted.to_dict())
-    return jsonify({'message': 'Tariff not found'}), 404
+    try:
+        deleted = Tariff.delete(tariff_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Tariff not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -47,10 +47,13 @@ def update_user(current_user, user_id):
 
 @admin_required
 def delete_user(current_user, user_id):
-    deleted_user = User.delete(user_id)
-    if deleted_user:
-        return jsonify(deleted_user.to_dict())
-    return jsonify({'message': 'User not found'}), 404
+    try:
+        deleted_user = User.delete(user_id)
+        if deleted_user:
+            return jsonify(deleted_user.to_dict())
+        return jsonify({'message': 'User not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400
 
 
 def __set_user_activity(user_id, is_active):


### PR DESCRIPTION
## Summary
- ensure countries page reloads data after deleting all
- add ModelValidationError handling to single delete endpoints
- ensure all bulk delete handlers wait for completion and refresh data

## Testing
- `pytest server/tests/integration/test_auth_flow.py -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68796eca5240832f890ef21cb629411c