### PR TITLE
Add drag-and-drop upload with loading state and optimize selects

### DIFF
--- a/client/src/components/admin/utils.js
+++ b/client/src/components/admin/utils.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import {
-	TextField,
-	Select,
-	MenuItem,
-	FormControl,
-	InputLabel,
-	Checkbox,
-	FormControlLabel,
-	FormHelperText,
+        TextField,
+        Select,
+        MenuItem,
+        FormControl,
+        InputLabel,
+        Checkbox,
+        FormControlLabel,
+        FormHelperText,
+        Autocomplete,
 } from '@mui/material';
 
 import { DatePicker, DateTimePicker } from '@mui/x-date-pickers';
@@ -111,26 +112,54 @@ export const createFieldRenderer = (field) => {
 				</LocalizationProvider>
 			);
 
-		case FIELD_TYPES.SELECT:
-			return (props) => (
-				<FormControl fullWidth={props.fullWidth} error={!!props.error}>
-					<InputLabel>{field.label}</InputLabel>
-					<Select
-						value={props.value || ''}
-						onChange={(e) => props.onChange(e.target.value)}
-						label={field.label}
-					>
-						{field.options.map((option) => (
-							<MenuItem key={option.value} value={option.value}>
-								{option.label}
-							</MenuItem>
-						))}
-					</Select>
-					{props.error && (
-						<FormHelperText>{props.helperText}</FormHelperText>
-					)}
-				</FormControl>
-			);
+                case FIELD_TYPES.SELECT:
+                        return (props) => {
+                                if (field.options && field.options.length > 100) {
+                                        const valueObj = field.options.find((o) => o.value === props.value) || null;
+                                        return (
+                                                <Autocomplete
+                                                        options={field.options}
+                                                        value={valueObj}
+                                                        onChange={(e, val) => props.onChange(val ? val.value : '')}
+                                                        filterOptions={(opts, state) =>
+                                                                opts
+                                                                        .filter((o) =>
+                                                                                o.label
+                                                                                        .toLowerCase()
+                                                                                        .includes(state.inputValue.toLowerCase())
+                                                                        )
+                                                                        .slice(0, 100)
+                                                        }
+                                                        getOptionLabel={(o) => o.label}
+                                                        renderInput={(params) => (
+                                                                <TextField
+                                                                        {...params}
+                                                                        label={field.label}
+                                                                        error={props.error}
+                                                                        helperText={props.error ? props.helperText : ''}
+                                                                />
+                                                        )}
+                                                />
+                                        );
+                                }
+                                return (
+                                        <FormControl fullWidth={props.fullWidth} error={!!props.error}>
+                                                <InputLabel>{field.label}</InputLabel>
+                                                <Select
+                                                        value={props.value || ''}
+                                                        onChange={(e) => props.onChange(e.target.value)}
+                                                        label={field.label}
+                                                >
+                                                        {field.options.map((option) => (
+                                                                <MenuItem key={option.value} value={option.value}>
+                                                                        {option.label}
+                                                                </MenuItem>
+                                                        ))}
+                                                </Select>
+                                                {props.error && <FormHelperText>{props.helperText}</FormHelperText>}
+                                        </FormControl>
+                                );
+                        };
 
 		case FIELD_TYPES.BOOLEAN:
 			return (props) => (

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -90,16 +90,21 @@ export const UI_LABELS = {
 	ADMIN: {
 		actions: 'Действия',
 		panel: 'Панель администратора',
-		filter: {
-			show: 'Показать фильтры',
-			hide: 'Скрыть фильтры',
-			all: 'Все',
-		},
-		rows: {
-			per_page: 'Записей на странице',
-			from: 'из',
-			more_than: 'более',
-		},
+                filter: {
+                        show: 'Показать фильтры',
+                        hide: 'Скрыть фильтры',
+                        all: 'Все',
+                },
+                upload: {
+                        title: 'Загрузка файла',
+                        drag: 'Перетащите файл сюда или выберите',
+                        select: 'Выбрать файл',
+                },
+                rows: {
+                        per_page: 'Записей на странице',
+                        from: 'из',
+                        more_than: 'более',
+                },
 		modules: {
 			airports: {
 				title: 'Аэропорты',


### PR DESCRIPTION
## Summary
- add drag-and-drop dialog for Excel uploads and show a spinner during upload
- switch long selects to Autocomplete limited to 100 items for performance
- add upload text constants

## Testing
- `npm --prefix client test --silent` *(fails: react-scripts not found)*
- `pytest -q server/tests` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_687a7c1ece00832fbe1ed0f4df2ff66e