### PR TITLE
Refactor admin filter fields

### DIFF
--- a/client/src/components/admin/AdminDataTable.js
+++ b/client/src/components/admin/AdminDataTable.js
@@ -2,30 +2,28 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import {
-	Box,
-	Typography,
-	Button,
-	Table,
-	TableBody,
-	TableCell,
-	TableContainer,
-	TableHead,
-	TableRow,
-	Paper,
-	TableSortLabel,
-	TablePagination,
-	TextField,
-	Select,
-	MenuItem,
-	IconButton,
-	Dialog,
-	DialogTitle,
-	DialogContent,
-	DialogActions,
-	Snackbar,
-	Alert,
-	Backdrop,
-	CircularProgress,
+        Box,
+        Typography,
+        Button,
+        Table,
+        TableBody,
+        TableCell,
+        TableContainer,
+        TableHead,
+        TableRow,
+        Paper,
+        TableSortLabel,
+        TablePagination,
+        MenuItem,
+        IconButton,
+        Dialog,
+        DialogTitle,
+        DialogContent,
+        DialogActions,
+        Snackbar,
+        Alert,
+        Backdrop,
+        CircularProgress,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DownloadIcon from '@mui/icons-material/Download';
@@ -38,7 +36,7 @@ import FilterListOffIcon from '@mui/icons-material/FilterListOff';
 
 import Base from '../Base';
 import { UI_LABELS, ENUM_LABELS } from '../../constants';
-import { FIELD_TYPES } from './utils';
+import { FIELD_TYPES, createFieldRenderer } from './utils';
 import { isDev } from '../../redux/reducers/auth';
 
 const AdminDataTable = ({
@@ -408,119 +406,40 @@ const AdminDataTable = ({
 								</TableCell>
 							</TableRow>
 							{showFilters && (
-								<TableRow>
-									{columns.map((column, index) =>
-										column.type === FIELD_TYPES.CUSTOM ? null : (
-											<TableCell key={index} align={column.align || 'left'}>
-												{column.type === FIELD_TYPES.SELECT ||
-												column.type === FIELD_TYPES.BOOLEAN ? (
-													<Select
-														value={filters[column.field] || ''}
-														onChange={(e) =>
-															handleFilterChange(
-																column.field,
-																e.target.value,
-																column.type
-															)
-														}
-														displayEmpty
-														size='small'
-														fullWidth
-														sx={{
-															fontSize: '0.75rem',
-															minHeight: 28,
-															height: 28,
-															py: 0,
-														}}
-														MenuProps={{
-															PaperProps: {
-																sx: {
-																	fontSize: '0.75rem',
-																},
-															},
-														}}
-													>
-														<MenuItem
-															value=''
-															sx={{
-																fontSize: '0.75rem',
-																minHeight: 28,
-																height: 28,
-															}}
-														>
-															{UI_LABELS.ADMIN.filter.all}
-														</MenuItem>
-														{(() => {
-															const opts = [
-																...(column.options ||
-																	(column.type === FIELD_TYPES.BOOLEAN
-																		? [
-																				{
-																					value: true,
-																					label: ENUM_LABELS.BOOLEAN.true,
-																				},
-																				{
-																					value: false,
-																					label: ENUM_LABELS.BOOLEAN.false,
-																				},
-																		  ]
-																		: [])),
-															];
-															opts.sort((a, b) => a.label.localeCompare(b.label));
-															return opts.map((opt) => (
-																<MenuItem
-																	key={opt.value}
-																	value={opt.value}
-																	sx={{
-																		fontSize: '0.75rem',
-																		minHeight: 28,
-																		height: 28,
-																	}}
-																>
-																	{opt.label}
-																</MenuItem>
-															));
-														})()}
-													</Select>
-												) : (
-													<TextField
-														value={filters[column.field] || ''}
-														onChange={(e) =>
-															handleFilterChange(column.field, e.target.value)
-														}
-														size='small'
-														fullWidth
-														inputProps={{
-															style: {
-																fontSize: '0.75rem',
-																padding: '4px 8px',
-																height: 20,
-																boxSizing: 'border-box',
-															},
-														}}
-														sx={{
-															minWidth: 0,
-															maxWidth: 150,
-															'& .MuiInputBase-root': {
-																fontSize: '0.75rem',
-																height: 28,
-																minHeight: 28,
-																padding: '0 8px',
-															},
-															'& .MuiInputBase-input': {
-																fontSize: '0.75rem',
-																height: 20,
-																padding: '4px 0',
-															},
-														}}
-													/>
-												)}
-											</TableCell>
-										)
-									)}
-									<TableCell align='right' />
-								</TableRow>
-							)}
+        <TableRow>
+                {columns.map((column, index) => {
+                        if (column.type === FIELD_TYPES.CUSTOM) return null;
+                        const baseField = { ...column };
+                        if (column.type === FIELD_TYPES.SELECT || column.type === FIELD_TYPES.BOOLEAN) {
+                                const opts = [
+                                        ...(column.options ||
+                                                (column.type === FIELD_TYPES.BOOLEAN
+                                                        ? [
+                                                                { value: true, label: ENUM_LABELS.BOOLEAN.true },
+                                                                { value: false, label: ENUM_LABELS.BOOLEAN.false },
+                                                        ]
+                                                        : [])),
+                                ];
+                                opts.sort((a, b) => a.label.localeCompare(b.label));
+                                baseField.options = [{ value: '', label: UI_LABELS.ADMIN.filter.all }, ...opts];
+                        }
+                        const render = createFieldRenderer(baseField, {
+                                size: 'small',
+                                sx: { fontSize: '0.75rem', minWidth: 0, maxWidth: 150 },
+                        });
+                        return (
+                                <TableCell key={index} align={column.align || 'left'}>
+                                        {render({
+                                                value: filters[column.field] ?? '',
+                                                onChange: (val) => handleFilterChange(column.field, val, column.type),
+                                                fullWidth: true,
+                                        })}
+                                </TableCell>
+                        );
+                })}
+                <TableCell align='right' />
+        </TableRow>
+                                                        )}
 						</TableHead>
 						<TableBody>
 							{paginatedData.map((item) => (

--- a/client/src/components/admin/utils.js
+++ b/client/src/components/admin/utils.js
@@ -34,115 +34,121 @@ export const FIELD_TYPES = {
 /**
  * Generate field renderers based on field type
  */
-export const createFieldRenderer = (field) => {
-	const type = field.type || FIELD_TYPES.TEXT;
+export const createFieldRenderer = (field, extraProps = {}) => {
+        const type = field.type || FIELD_TYPES.TEXT;
 
 	switch (type) {
-		case FIELD_TYPES.TEXT:
-			return (props) => (
-				<TextField
-					label={field.label}
-					value={props.value || ''}
-					onChange={(e) => props.onChange(e.target.value)}
-					fullWidth={props.fullWidth}
-					error={props.error}
-					helperText={props.error ? props.helperText : ''}
-					inputProps={field.inputProps}
-				/>
-			);
+                case FIELD_TYPES.TEXT:
+                        return (props) => (
+                                <TextField
+                                        label={field.label}
+                                        value={props.value || ''}
+                                        onChange={(e) => props.onChange(e.target.value)}
+                                        fullWidth={props.fullWidth}
+                                        error={props.error}
+                                        helperText={props.error ? props.helperText : ''}
+                                        inputProps={field.inputProps}
+                                        {...extraProps}
+                                />
+                        );
 
-		case FIELD_TYPES.NUMBER:
-			return (props) => (
-				<TextField
-					label={field.label}
-					value={props.value ?? ''}
-					onChange={(e) => {
-						const value = e.target.value;
-						const numValue = field.float ? parseFloat(value) : parseInt(value, 10);
-						props.onChange(value === '' ? '' : numValue);
-					}}
-					type='number'
-					fullWidth={props.fullWidth}
-					error={props.error}
-					helperText={props.error ? props.helperText : ''}
-					inputProps={{
-						step: field.float ? 0.01 : 1,
-						...field.inputProps,
-					}}
-				/>
-			);
+                case FIELD_TYPES.NUMBER:
+                        return (props) => (
+                                <TextField
+                                        label={field.label}
+                                        value={props.value ?? ''}
+                                        onChange={(e) => {
+                                                const value = e.target.value;
+                                                const numValue = field.float ? parseFloat(value) : parseInt(value, 10);
+                                                props.onChange(value === '' ? '' : numValue);
+                                        }}
+                                        type='number'
+                                        fullWidth={props.fullWidth}
+                                        error={props.error}
+                                        helperText={props.error ? props.helperText : ''}
+                                        inputProps={{
+                                                step: field.float ? 0.01 : 1,
+                                                ...field.inputProps,
+                                        }}
+                                        {...extraProps}
+                                />
+                        );
 
-		case FIELD_TYPES.DATE:
-			return (props) => (
-				<LocalizationProvider dateAdapter={AdapterDateFns}>
-					<DatePicker
-						label={field.label}
-						value={props.value ? new Date(props.value) : null}
-						onChange={(date) => props.onChange(date)}
-						slotProps={{
-							textField: {
-								fullWidth: props.fullWidth,
-								error: props.error,
-								helperText: props.error ? props.helperText : '',
-							},
-						}}
-						format={field.dateFormat || 'dd.MM.yyyy'}
-					/>
-				</LocalizationProvider>
-			);
+                case FIELD_TYPES.DATE:
+                        return (props) => (
+                                <LocalizationProvider dateAdapter={AdapterDateFns}>
+                                        <DatePicker
+                                                label={field.label}
+                                                value={props.value ? new Date(props.value) : null}
+                                                onChange={(date) => props.onChange(date)}
+                                                slotProps={{
+                                                        textField: {
+                                                                fullWidth: props.fullWidth,
+                                                                error: props.error,
+                                                                helperText: props.error ? props.helperText : '',
+                                                                ...extraProps,
+                                                        },
+                                                }}
+                                                format={field.dateFormat || 'dd.MM.yyyy'}
+                                        />
+                                </LocalizationProvider>
+                        );
 
-		case FIELD_TYPES.DATETIME:
-			return (props) => (
-				<LocalizationProvider dateAdapter={AdapterDateFns}>
-					<DateTimePicker
-						label={field.label}
-						value={props.value ? new Date(props.value) : null}
-						onChange={(dateTime) => props.onChange(dateTime)}
-						slotProps={{
-							textField: {
-								fullWidth: props.fullWidth,
-								error: props.error,
-								helperText: props.error ? props.helperText : '',
-							},
-						}}
-						format={field.dateTimeFormat || 'dd.MM.yyyy HH:mm'}
-					/>
-				</LocalizationProvider>
-			);
+                case FIELD_TYPES.DATETIME:
+                        return (props) => (
+                                <LocalizationProvider dateAdapter={AdapterDateFns}>
+                                        <DateTimePicker
+                                                label={field.label}
+                                                value={props.value ? new Date(props.value) : null}
+                                                onChange={(dateTime) => props.onChange(dateTime)}
+                                                slotProps={{
+                                                        textField: {
+                                                                fullWidth: props.fullWidth,
+                                                                error: props.error,
+                                                                helperText: props.error ? props.helperText : '',
+                                                                ...extraProps,
+                                                        },
+                                                }}
+                                                format={field.dateTimeFormat || 'dd.MM.yyyy HH:mm'}
+                                        />
+                                </LocalizationProvider>
+                        );
 
 		case FIELD_TYPES.SELECT:
 			return (props) => {
-				if (field.options && field.options.length > 100) {
-					const valueObj = field.options.find((o) => o.value === props.value) || null;
-					return (
-						<Autocomplete
-							options={field.options}
-							value={valueObj}
-							onChange={(e, val) => props.onChange(val ? val.value : '')}
-							filterOptions={(opts, state) =>
-								opts
-									.filter((o) => o.label.toLowerCase().includes(state.inputValue.toLowerCase()))
-									.slice(0, 100)
-							}
-							getOptionLabel={(o) => o.label}
-							renderInput={(params) => (
-								<TextField
-									{...params}
-									label={field.label}
-									error={props.error}
-									helperText={props.error ? props.helperText : ''}
-								/>
-							)}
-						/>
-					);
-				}
-				return (
-					<FormControl fullWidth={props.fullWidth} error={!!props.error}>
-						<InputLabel>{field.label}</InputLabel>
-						<Select
-							value={props.value || ''}
-							onChange={(e) => props.onChange(e.target.value)}
-							label={field.label}
+                                if (field.options && field.options.length > 100) {
+                                        const valueObj = field.options.find((o) => o.value === props.value) || null;
+                                        return (
+                                                <Autocomplete
+                                                        options={field.options}
+                                                        value={valueObj}
+                                                        onChange={(e, val) => props.onChange(val ? val.value : '')}
+                                                        filterOptions={(opts, state) =>
+                                                                opts
+                                                                        .filter((o) => o.label.toLowerCase().includes(state.inputValue.toLowerCase()))
+                                                                        .slice(0, 100)
+                                                        }
+                                                        getOptionLabel={(o) => o.label}
+                                                        renderInput={(params) => (
+                                                                <TextField
+                                                                        {...params}
+                                                                        label={field.label}
+                                                                        error={props.error}
+                                                                        helperText={props.error ? props.helperText : ''}
+                                                                        {...extraProps}
+                                                                />
+                                                        )}
+                                                        {...extraProps}
+                                                />
+                                        );
+                                }
+                                return (
+                                        <FormControl fullWidth={props.fullWidth} error={!!props.error} {...extraProps}>
+                                                <InputLabel>{field.label}</InputLabel>
+                                                <Select
+                                                        value={props.value || ''}
+                                                        onChange={(e) => props.onChange(e.target.value)}
+                                                        label={field.label}
 						>
 							{field.options.map((option) => (
 								<MenuItem key={option.value} value={option.value}>
@@ -155,35 +161,37 @@ export const createFieldRenderer = (field) => {
 				);
 			};
 
-		case FIELD_TYPES.BOOLEAN:
-			return (props) => (
-				<FormControlLabel
-					control={
-						<Checkbox
-							checked={!!props.value}
-							onChange={(e) => props.onChange(e.target.checked)}
-							color='primary'
-						/>
-					}
-					label={field.label}
-				/>
-			);
+                case FIELD_TYPES.BOOLEAN:
+                        return (props) => (
+                                <FormControlLabel
+                                        control={
+                                                <Checkbox
+                                                        checked={!!props.value}
+                                                        onChange={(e) => props.onChange(e.target.checked)}
+                                                        color='primary'
+                                                />
+                                        }
+                                        label={field.label}
+                                        {...extraProps}
+                                />
+                        );
 
 		case FIELD_TYPES.CUSTOM:
 			return (props) => {
 				return field.renderField(props);
 			};
 
-		default:
-			return (props) => (
-				<TextField
-					label={field.label}
-					value={props.value || ''}
-					onChange={(e) => props.onChange(e.target.value)}
-					fullWidth={props.fullWidth}
-				/>
-			);
-	}
+                default:
+                        return (props) => (
+                                <TextField
+                                        label={field.label}
+                                        value={props.value || ''}
+                                        onChange={(e) => props.onChange(e.target.value)}
+                                        fullWidth={props.fullWidth}
+                                        {...extraProps}
+                                />
+                        );
+        }
 };
 
 /**


### PR DESCRIPTION
## Summary
- allow passing extra props to `createFieldRenderer`
- reuse field renderer for AdminDataTable filters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687b5683ce2c832fb8109d1048cf47e2