### PR TITLE
Restore filters styling with createFieldRenderer

### DIFF
--- a/client/src/components/admin/AdminDataTable.js
+++ b/client/src/components/admin/AdminDataTable.js
@@ -12,9 +12,8 @@ import {
 	TableHead,
 	TableRow,
 	Paper,
-	TableSortLabel,
-	TablePagination,
-	MenuItem,
+        TableSortLabel,
+        TablePagination,
 	IconButton,
 	Dialog,
 	DialogTitle,
@@ -405,77 +404,79 @@ const AdminDataTable = ({
 									{UI_LABELS.ADMIN.actions}
 								</TableCell>
 							</TableRow>
-							{showFilters && (
-								<TableRow>
-									{columns.map((col, idx) => {
-										if (col.type === FIELD_TYPES.CUSTOM) return null;
+{showFilters && (
+                                <TableRow>
+                                    {columns.map((col, idx) => {
+                                        if (col.type === FIELD_TYPES.CUSTOM) return null;
 
-										let options = [];
-										if (col.type === FIELD_TYPES.SELECT || col.type === FIELD_TYPES.BOOLEAN) {
-											options = col.options
-												? [...col.options]
-												: [
-														{ value: true, label: ENUM_LABELS.BOOLEAN.true },
-														{ value: false, label: ENUM_LABELS.BOOLEAN.false },
-												  ];
-											options.sort((a, b) => a.label.localeCompare(b.label));
-											col = {
-												...col,
-												options: [{ value: '', label: UI_LABELS.ADMIN.filter.all }, ...options],
-											};
-										}
+                                        let options = [];
+                                        if (col.type === FIELD_TYPES.SELECT || col.type === FIELD_TYPES.BOOLEAN) {
+                                            options = col.options
+                                                ? [...col.options]
+                                                : [
+                                                      { value: true, label: ENUM_LABELS.BOOLEAN.true },
+                                                      { value: false, label: ENUM_LABELS.BOOLEAN.false },
+                                                  ];
+                                            options.sort((a, b) => a.label.localeCompare(b.label));
+                                            col = {
+                                                ...col,
+                                                options: [{ value: '', label: UI_LABELS.ADMIN.filter.all }, ...options],
+                                            };
+                                        }
 
-										const renderField = createFieldRenderer(col);
+                                        const renderField = createFieldRenderer(col);
 
-										return (
-											<TableCell key={idx} align={col.align || 'left'}>
-												{renderField({
-													value: filters[col.field] ?? '',
-													onChange: (val) => handleFilterChange(col.field, val, col.type),
-													size: 'small',
-													fullWidth: true,
-													sx: {
-														minWidth: 0,
-														maxWidth: 150,
-														'& .MuiInputBase-root': {
-															fontSize: '0.75rem',
-															height: 28,
-															minHeight: 28,
-															padding: '0 8px',
-														},
-														'& .MuiInputBase-input': {
-															fontSize: '0.75rem',
-															height: 20,
-															padding: '4px 0',
-														},
-													},
-													inputProps: {
-														style: {
-															fontSize: '0.75rem',
-															padding: '4px 8px',
-															height: 20,
-															boxSizing: 'border-box',
-														},
-													},
-													displayEmpty: true,
-													MenuProps: {
-														PaperProps: {
-															sx: { fontSize: '0.75rem' },
-														},
-													},
-													MenuItemProps: {
-														sx: {
-															fontSize: '0.75rem',
-															minHeight: 28,
-															height: 28,
-														},
-													},
-												})}
-											</TableCell>
-										);
-									})}
-									<TableCell align='right' />
-								</TableRow>
+                                        return (
+                                            <TableCell key={idx} align={col.align || 'left'}>
+                                                {renderField({
+                                                    value: filters[col.field] ?? '',
+                                                    onChange: (val) => handleFilterChange(col.field, val, col.type),
+                                                    size: 'small',
+                                                    fullWidth: true,
+                                                    sx: {
+                                                        minWidth: 0,
+                                                        maxWidth: 150,
+                                                        '& .MuiInputBase-root': {
+                                                            fontSize: '0.75rem',
+                                                            height: 28,
+                                                            minHeight: 28,
+                                                            padding: '0 8px',
+                                                        },
+                                                        '& .MuiInputBase-input': {
+                                                            fontSize: '0.75rem',
+                                                            height: 20,
+                                                            padding: '4px 0',
+                                                        },
+                                                    },
+                                                    inputProps: {
+                                                        style: {
+                                                            fontSize: '0.75rem',
+                                                            padding: '4px 8px',
+                                                            height: 20,
+                                                            boxSizing: 'border-box',
+                                                        },
+                                                    },
+                                                    displayEmpty: true,
+                                                    simpleSelect: true,
+                                                    MenuProps: {
+                                                        PaperProps: {
+                                                            sx: { fontSize: '0.75rem' },
+                                                        },
+                                                    },
+                                                    MenuItemProps: {
+                                                        sx: {
+                                                            fontSize: '0.75rem',
+                                                            minHeight: 28,
+                                                            height: 28,
+                                                        },
+                                                    },
+                                                })}
+                                            </TableCell>
+                                        );
+                                    })}
+                                    <TableCell align='right' />
+                                </TableRow>
+                            )}
 							)}
 						</TableHead>
 						<TableBody>

--- a/client/src/components/admin/utils.js
+++ b/client/src/components/admin/utils.js
@@ -34,164 +34,224 @@ export const FIELD_TYPES = {
 /**
  * Generate field renderers based on field type
  */
-export const createFieldRenderer = (field, extraProps = {}) => {
-	const type = field.type || FIELD_TYPES.TEXT;
+export const createFieldRenderer = (field, defaultProps = {}) => {
+        const type = field.type || FIELD_TYPES.TEXT;
 
-	switch (type) {
-		case FIELD_TYPES.TEXT:
-			return (props) => (
-				<TextField
-					label={field.label}
-					value={props.value || ''}
-					onChange={(e) => props.onChange(e.target.value)}
-					fullWidth={props.fullWidth}
-					error={props.error}
-					helperText={props.error ? props.helperText : ''}
-					inputProps={field.inputProps}
-					{...extraProps}
-				/>
-			);
+        return (props = {}) => {
+                const allProps = { ...defaultProps, ...props };
 
-		case FIELD_TYPES.NUMBER:
-			return (props) => (
-				<TextField
-					label={field.label}
-					value={props.value ?? ''}
-					onChange={(e) => {
-						const value = e.target.value;
-						const numValue = field.float ? parseFloat(value) : parseInt(value, 10);
-						props.onChange(value === '' ? '' : numValue);
-					}}
-					type='number'
-					fullWidth={props.fullWidth}
-					error={props.error}
-					helperText={props.error ? props.helperText : ''}
-					inputProps={{
-						step: field.float ? 0.01 : 1,
-						...field.inputProps,
-					}}
-					{...extraProps}
-				/>
-			);
+                switch (type) {
+                        case FIELD_TYPES.TEXT: {
+                                const {
+                                        value = '',
+                                        onChange,
+                                        fullWidth,
+                                        error,
+                                        helperText,
+                                        inputProps,
+                                        ...rest
+                                } = allProps;
+                                return (
+                                        <TextField
+                                                label={field.label}
+                                                value={value}
+                                                onChange={(e) => onChange(e.target.value)}
+                                                fullWidth={fullWidth}
+                                                error={error}
+                                                helperText={error ? helperText : ''}
+                                                inputProps={{ ...field.inputProps, ...inputProps }}
+                                                {...rest}
+                                        />
+                                );
+                        }
 
-		case FIELD_TYPES.DATE:
-			return (props) => (
-				<LocalizationProvider dateAdapter={AdapterDateFns}>
-					<DatePicker
-						label={field.label}
-						value={props.value ? new Date(props.value) : null}
-						onChange={(date) => props.onChange(date)}
-						slotProps={{
-							textField: {
-								fullWidth: props.fullWidth,
-								error: props.error,
-								helperText: props.error ? props.helperText : '',
-								...extraProps,
-							},
-						}}
-						format={field.dateFormat || 'dd.MM.yyyy'}
-					/>
-				</LocalizationProvider>
-			);
+                case FIELD_TYPES.NUMBER: {
+                        const {
+                                value = '',
+                                onChange,
+                                fullWidth,
+                                error,
+                                helperText,
+                                inputProps,
+                                ...rest
+                        } = allProps;
+                        return (
+                                <TextField
+                                        label={field.label}
+                                        value={value}
+                                        onChange={(e) => {
+                                                const val = e.target.value;
+                                                const numValue = field.float ? parseFloat(val) : parseInt(val, 10);
+                                                onChange(val === '' ? '' : numValue);
+                                        }}
+                                        type='number'
+                                        fullWidth={fullWidth}
+                                        error={error}
+                                        helperText={error ? helperText : ''}
+                                        inputProps={{ step: field.float ? 0.01 : 1, ...field.inputProps, ...inputProps }}
+                                        {...rest}
+                                />
+                        );
+                }
 
-		case FIELD_TYPES.DATETIME:
-			return (props) => (
-				<LocalizationProvider dateAdapter={AdapterDateFns}>
-					<DateTimePicker
-						label={field.label}
-						value={props.value ? new Date(props.value) : null}
-						onChange={(dateTime) => props.onChange(dateTime)}
-						slotProps={{
-							textField: {
-								fullWidth: props.fullWidth,
-								error: props.error,
-								helperText: props.error ? props.helperText : '',
-								...extraProps,
-							},
-						}}
-						format={field.dateTimeFormat || 'dd.MM.yyyy HH:mm'}
-					/>
-				</LocalizationProvider>
-			);
+                case FIELD_TYPES.DATE: {
+                        const { value, onChange, fullWidth, error, helperText, ...rest } = allProps;
+                        return (
+                                <LocalizationProvider dateAdapter={AdapterDateFns}>
+                                        <DatePicker
+                                                label={field.label}
+                                                value={value ? new Date(value) : null}
+                                                onChange={(date) => onChange(date)}
+                                                slotProps={{
+                                                        textField: {
+                                                                fullWidth,
+                                                                error,
+                                                                helperText: error ? helperText : '',
+                                                                ...rest,
+                                                        },
+                                                }}
+                                                format={field.dateFormat || 'dd.MM.yyyy'}
+                                        />
+                                </LocalizationProvider>
+                        );
+                }
 
-		case FIELD_TYPES.SELECT:
-			return (props) => {
-				if (field.options && field.options.length > 100) {
-					const valueObj = field.options.find((o) => o.value === props.value) || null;
-					return (
-						<Autocomplete
-							options={field.options}
-							value={valueObj}
-							onChange={(e, val) => props.onChange(val ? val.value : '')}
-							filterOptions={(opts, state) =>
-								opts
-									.filter((o) => o.label.toLowerCase().includes(state.inputValue.toLowerCase()))
-									.slice(0, 100)
-							}
-							getOptionLabel={(o) => o.label}
-							renderInput={(params) => (
-								<TextField
-									{...params}
-									label={field.label}
-									error={props.error}
-									helperText={props.error ? props.helperText : ''}
-									{...extraProps}
-								/>
-							)}
-							{...extraProps}
-						/>
-					);
-				}
-				return (
-					<FormControl fullWidth={props.fullWidth} error={!!props.error} {...extraProps}>
-						<InputLabel>{field.label}</InputLabel>
-						<Select
-							value={props.value || ''}
-							onChange={(e) => props.onChange(e.target.value)}
-							label={field.label}
-						>
-							{field.options.map((option) => (
-								<MenuItem key={option.value} value={option.value}>
-									{option.label}
-								</MenuItem>
-							))}
-						</Select>
-						{props.error && <FormHelperText>{props.helperText}</FormHelperText>}
-					</FormControl>
-				);
-			};
+                case FIELD_TYPES.DATETIME: {
+                        const { value, onChange, fullWidth, error, helperText, ...rest } = allProps;
+                        return (
+                                <LocalizationProvider dateAdapter={AdapterDateFns}>
+                                        <DateTimePicker
+                                                label={field.label}
+                                                value={value ? new Date(value) : null}
+                                                onChange={(dateTime) => onChange(dateTime)}
+                                                slotProps={{
+                                                        textField: {
+                                                                fullWidth,
+                                                                error,
+                                                                helperText: error ? helperText : '',
+                                                                ...rest,
+                                                        },
+                                                }}
+                                                format={field.dateTimeFormat || 'dd.MM.yyyy HH:mm'}
+                                        />
+                                </LocalizationProvider>
+                        );
+                }
 
-		case FIELD_TYPES.BOOLEAN:
-			return (props) => (
-				<FormControlLabel
-					control={
-						<Checkbox
-							checked={!!props.value}
-							onChange={(e) => props.onChange(e.target.checked)}
-							color='primary'
-						/>
-					}
-					label={field.label}
-					{...extraProps}
-				/>
-			);
+                case FIELD_TYPES.SELECT: {
+                        const {
+                                value = '',
+                                onChange,
+                                fullWidth,
+                                error,
+                                helperText,
+                                options = field.options || [],
+                                MenuItemProps,
+                                simpleSelect,
+                                ...rest
+                        } = allProps;
 
-		case FIELD_TYPES.CUSTOM:
-			return (props) => {
-				return field.renderField(props);
-			};
+                        if (!simpleSelect && options.length > 100) {
+                                const valueObj = options.find((o) => o.value === value) || null;
+                                return (
+                                        <Autocomplete
+                                                options={options}
+                                                value={valueObj}
+                                                onChange={(e, val) => onChange(val ? val.value : '')}
+                                                filterOptions={(opts, state) =>
+                                                        opts
+                                                                .filter((o) =>
+                                                                        o.label.toLowerCase().includes(state.inputValue.toLowerCase())
+                                                                )
+                                                                .slice(0, 100)
+                                                }
+                                                getOptionLabel={(o) => o.label}
+                                                renderInput={(params) => (
+                                                        <TextField
+                                                                {...params}
+                                                                label={field.label}
+                                                                error={error}
+                                                                helperText={error ? helperText : ''}
+                                                                {...rest}
+                                                        />
+                                                )}
+                                                {...rest}
+                                        />
+                                );
+                        }
 
-		default:
-			return (props) => (
-				<TextField
-					label={field.label}
-					value={props.value || ''}
-					onChange={(e) => props.onChange(e.target.value)}
-					fullWidth={props.fullWidth}
-					{...extraProps}
-				/>
-			);
-	}
+                        if (simpleSelect) {
+                                return (
+                                        <Select
+                                                value={value}
+                                                onChange={(e) => onChange(e.target.value)}
+                                                fullWidth={fullWidth}
+                                                {...rest}
+                                        >
+                                                {options.map((option) => (
+                                                        <MenuItem key={option.value} value={option.value} {...MenuItemProps}>
+                                                                {option.label}
+                                                        </MenuItem>
+                                                ))}
+                                        </Select>
+                                );
+                        }
+
+                        return (
+                                <FormControl fullWidth={fullWidth} error={!!error} {...rest}>
+                                        <InputLabel>{field.label}</InputLabel>
+                                        <Select
+                                                value={value}
+                                                onChange={(e) => onChange(e.target.value)}
+                                                label={field.label}
+                                                {...rest}
+                                        >
+                                                {options.map((option) => (
+                                                        <MenuItem key={option.value} value={option.value} {...MenuItemProps}>
+                                                                {option.label}
+                                                        </MenuItem>
+                                                ))}
+                                        </Select>
+                                        {error && <FormHelperText>{helperText}</FormHelperText>}
+                                </FormControl>
+                        );
+                }
+
+                case FIELD_TYPES.BOOLEAN: {
+                        const { value = false, onChange, ...rest } = allProps;
+                        return (
+                                <FormControlLabel
+                                        control={
+                                                <Checkbox
+                                                        checked={!!value}
+                                                        onChange={(e) => onChange(e.target.checked)}
+                                                        color='primary'
+                                                />
+                                        }
+                                        label={field.label}
+                                        {...rest}
+                                />
+                        );
+                }
+
+                case FIELD_TYPES.CUSTOM:
+                        return (customProps) => field.renderField({ ...allProps, ...customProps });
+
+                default: {
+                        const { value = '', onChange, fullWidth, inputProps, ...rest } = allProps;
+                        return (
+                                <TextField
+                                        label={field.label}
+                                        value={value}
+                                        onChange={(e) => onChange(e.target.value)}
+                                        fullWidth={fullWidth}
+                                        inputProps={{ ...field.inputProps, ...inputProps }}
+                                        {...rest}
+                                />
+                        );
+                }
+               }
+        };
 };
 
 /**


### PR DESCRIPTION
## Summary
- adjust `createFieldRenderer` to forward props and support a `simpleSelect` mode
- reinstate filters row in `AdminDataTable` using `createFieldRenderer`

## Testing
- `npm test --prefix client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6ae307b8832fb08cd01bf89ea335