### PR TITLE
Implement flight tariff controllers and redux

### DIFF
--- a/client/src/components/admin/FlightManagement.js
+++ b/client/src/components/admin/FlightManagement.js
@@ -19,7 +19,11 @@ import AdminDataTable from '../../components/admin/AdminDataTable';
 import FlightTariffManagement from './FlightTariffManagement';
 
 import { fetchFlights, createFlight, updateFlight, deleteFlight, deleteAllFlights } from '../../redux/actions/flight';
-import { fetchTariffs, deleteTariff } from '../../redux/actions/tariff';
+import { fetchTariffs } from '../../redux/actions/tariff';
+import {
+        fetchFlightTariffs,
+        deleteFlightTariff,
+} from '../../redux/actions/flight_tariff';
 import { fetchRoutes } from '../../redux/actions/route';
 import { fetchAirlines } from '../../redux/actions/airline';
 import { fetchAirports } from '../../redux/actions/airport';
@@ -31,8 +35,9 @@ const FlightManagement = () => {
 	const { flights, isLoading, errors } = useSelector((state) => state.flights);
 	const { routes, isLoading: routesLoading } = useSelector((state) => state.routes);
 	const { airlines, isLoading: airlinesLoading } = useSelector((state) => state.airlines);
-	const { tariffs, isLoading: tariffsLoading } = useSelector((state) => state.tariffs);
-	const { airports, isLoading: airportsLoading } = useSelector((state) => state.airports);
+       const { tariffs, isLoading: tariffsLoading } = useSelector((state) => state.tariffs);
+       const { flightTariffs, isLoading: flightTariffsLoading } = useSelector((state) => state.flightTariffs);
+       const { airports, isLoading: airportsLoading } = useSelector((state) => state.airports);
 
 	const [tariffDialogOpen, setTariffDialogOpen] = useState(false);
 	const [tariffAction, setTariffAction] = useState(null);
@@ -43,9 +48,10 @@ const FlightManagement = () => {
 		dispatch(fetchFlights());
 		dispatch(fetchRoutes());
 		dispatch(fetchAirlines());
-		dispatch(fetchTariffs());
-		dispatch(fetchAirports());
-	}, [dispatch]);
+               dispatch(fetchTariffs());
+               dispatch(fetchFlightTariffs());
+               dispatch(fetchAirports());
+       }, [dispatch]);
 
 	const getRouteById = (id) => {
 		if (routesLoading || !Array.isArray(routes)) {
@@ -61,12 +67,19 @@ const FlightManagement = () => {
 		return airlines.find((airline) => airline.id === id);
 	};
 
-	const getAirportById = (id) => {
-		if (airportsLoading || !Array.isArray(airports)) {
-			return null;
-		}
-		return airports.find((airport) => airport.id === id);
-	};
+        const getAirportById = (id) => {
+                if (airportsLoading || !Array.isArray(airports)) {
+                        return null;
+                }
+                return airports.find((airport) => airport.id === id);
+        };
+
+       const getTariffById = (id) => {
+               if (tariffsLoading || !Array.isArray(tariffs)) {
+                       return null;
+               }
+               return tariffs.find((tariff) => tariff.id === id);
+       };
 
 	const routeOptions = useMemo(() => {
 		if (routesLoading || airportsLoading || !Array.isArray(routes) || !Array.isArray(airports)) {
@@ -122,7 +135,7 @@ const FlightManagement = () => {
 	};
 
 	const confirmDeleteTariff = () => {
-		dispatch(deleteTariff(deleteTariffDialog.tariffId));
+               dispatch(deleteFlightTariff(deleteTariffDialog.tariffId));
 		handleCloseDeleteTariffDialog();
 	};
 
@@ -188,119 +201,107 @@ const FlightManagement = () => {
 			type: FIELD_TYPES.CUSTOM,
 			label: FIELD_LABELS.FLIGHT.tariffs,
 			excludeFromForm: true,
-			renderField: (item) => {
-				const flightTariffs = tariffs.filter((tariff) => tariff.flight_id === item.id);
+                       renderField: (item) => {
+                                const flightTariffsForFlight = flightTariffs.filter((ft) => ft.flight_id === item.id);
 
-				return (
-					<Box
-						sx={{
-							display: 'flex',
-							flexDirection: 'column',
-							alignItems: 'flex-start',
-							minWidth: '200px',
-						}}
-					>
-						{flightTariffs.length === 0 ? (
-							<Tooltip title={UI_LABELS.ADMIN.modules.tariffs.add_button} placement='top'>
-								<IconButton
-									size='small'
-									color='primary'
-									onClick={(e) => {
-										e.stopPropagation();
-										handleAddTariff(item.id);
-									}}
-								>
-									<AddCircleIcon />
-								</IconButton>
-							</Tooltip>
-						) : (
-							<>
-								{flightTariffs.map((tariff) => (
-									<Box
-										key={tariff.id}
-										sx={{
-											display: 'flex',
-											alignItems: 'center',
-											mb: 0.5,
-											backgroundColor: 'rgba(0,0,0,0.04)',
-											borderRadius: 1,
-											p: 0.5,
-											width: '100%',
-										}}
-									>
-										<Typography
-											variant='body2'
-											sx={{
-												mr: 1,
-												flexGrow: 1,
-												whiteSpace: 'nowrap',
-												overflow: 'hidden',
-												textOverflow: 'ellipsis',
-											}}
-										>
-											{`${ENUM_LABELS.SEAT_CLASS[tariff.seat_class] || tariff.seat_class} - ${
-												tariff.price
-											} ${ENUM_LABELS.CURRENCY[tariff.currency] || tariff.currency}`}
-										</Typography>
-										<Box
-											sx={{
-												display: 'flex',
-												flexShrink: 0,
-											}}
-										>
-											<Tooltip
-												title={UI_LABELS.ADMIN.modules.tariffs.edit_button}
-												placement='top'
-											>
-												<IconButton
-													size='small'
-													color='primary'
-													onClick={(e) => {
-														e.stopPropagation();
-														handleEditTariff(item.id, tariff.id);
-													}}
-												>
-													<EditIcon fontSize='small' />
-												</IconButton>
-											</Tooltip>
-											<Tooltip
-												title={UI_LABELS.ADMIN.modules.tariffs.delete_button}
-												placement='top'
-											>
-												<IconButton
-													size='small'
-													color='error'
-													onClick={(e) => {
-														e.stopPropagation();
-														handleOpenDeleteTariffDialog(tariff.id);
-													}}
-												>
-													<DeleteIcon fontSize='small' />
-												</IconButton>
-											</Tooltip>
-										</Box>
-									</Box>
-								))}
-
-								<Tooltip title={UI_LABELS.ADMIN.modules.flights.add_tariff} placement='top'>
-									<IconButton
-										size='small'
-										color='primary'
-										onClick={(e) => {
-											e.stopPropagation();
-											handleAddTariff(item.id);
-										}}
-										sx={{ mt: 0.5 }}
-									>
-										<AddCircleIcon />
-									</IconButton>
-								</Tooltip>
-							</>
-						)}
-					</Box>
-				);
-			},
-		},
+                                return (
+                                        <Box
+                                                sx={{
+                                                        display: 'flex',
+                                                        flexDirection: 'column',
+                                                        alignItems: 'flex-start',
+                                                        minWidth: '200px',
+                                                }}
+                                        >
+                                                {flightTariffsForFlight.length === 0 ? (
+                                                        <Tooltip title={UI_LABELS.ADMIN.modules.tariffs.add_button} placement='top'>
+                                                                <IconButton
+                                                                        size='small'
+                                                                        color='primary'
+                                                                        onClick={(e) => {
+                                                                                e.stopPropagation();
+                                                                                handleAddTariff(item.id);
+                                                                        }}
+                                                                >
+                                                                        <AddCircleIcon />
+                                                                </IconButton>
+                                                        </Tooltip>
+                                                ) : (
+                                                        <>
+                                                                {flightTariffsForFlight.map((ft) => {
+                                                                        const baseTariff = getTariffById(ft.tariff_id) || {};
+                                                                        return (
+                                                                                <Box
+                                                                                        key={ft.id}
+                                                                                        sx={{
+                                                                                                display: 'flex',
+                                                                                                alignItems: 'center',
+                                                                                                mb: 0.5,
+                                                                                                backgroundColor: 'rgba(0,0,0,0.04)',
+                                                                                                borderRadius: 1,
+                                                                                                p: 0.5,
+                                                                                                width: '100%',
+                                                                                        }}
+                                                                                >
+                                                                                        <Typography
+                                                                                                variant='body2'
+                                                                                                sx={{
+                                                                                                        mr: 1,
+                                                                                                        flexGrow: 1,
+                                                                                                        whiteSpace: 'nowrap',
+                                                                                                        overflow: 'hidden',
+                                                                                                        textOverflow: 'ellipsis',
+                                                                                                }}
+                                                                                        >
+                                                                                                {`${ENUM_LABELS.SEAT_CLASS[baseTariff.seat_class] || baseTariff.seat_class} - ${baseTariff.price} ${ENUM_LABELS.CURRENCY[baseTariff.currency] || baseTariff.currency}`}
+                                                                                        </Typography>
+                                                                                        <Box sx={{ display: 'flex', flexShrink: 0 }}>
+                                                                                                <Tooltip title={UI_LABELS.ADMIN.modules.tariffs.edit_button} placement='top'>
+                                                                                                        <IconButton
+                                                                                                                size='small'
+                                                                                                                color='primary'
+                                                                                                                onClick={(e) => {
+                                                                                                                        e.stopPropagation();
+                                                                                                                        handleEditTariff(item.id, ft.id);
+                                                                                                                }}
+                                                                                                        >
+                                                                                                                <EditIcon fontSize='small' />
+                                                                                                        </IconButton>
+                                                                                                </Tooltip>
+                                                                                                <Tooltip title={UI_LABELS.ADMIN.modules.tariffs.delete_button} placement='top'>
+                                                                                                        <IconButton
+                                                                                                                size='small'
+                                                                                                                color='error'
+                                                                                                                onClick={(e) => {
+                                                                                                                        e.stopPropagation();
+                                                                                                                        handleOpenDeleteTariffDialog(ft.id);
+                                                                                                                }}
+                                                                                                        >
+                                                                                                                <DeleteIcon fontSize='small' />
+                                                                                                        </IconButton>
+                                                                                                </Tooltip>
+                                                                                        </Box>
+                                                                                </Box>
+                                                                        );
+                                                                })}
+                                                                <Tooltip title={UI_LABELS.ADMIN.modules.flights.add_tariff} placement='top'>
+                                                                        <IconButton
+                                                                                size='small'
+                                                                                color='primary'
+                                                                                onClick={(e) => {
+                                                                                        e.stopPropagation();
+                                                                                        handleAddTariff(item.id);
+                                                                                }}
+                                                                                sx={{ mt: 0.5 }}
+                                                                        >
+                                                                                <AddCircleIcon />
+                                                                        </IconButton>
+                                                                </Tooltip>
+                                                        </>
+                                                )}
+                                        </Box>
+                                );
+                        },
 	};
 
 	const adminManager = useMemo(
@@ -335,7 +336,7 @@ const FlightManagement = () => {
 				onDeleteAll={handleDeleteAllFlights}
 				renderForm={adminManager.renderForm}
 				addButtonText={UI_LABELS.ADMIN.modules.flights.add_button}
-				isLoading={isLoading || routesLoading || airlinesLoading || tariffsLoading || airportsLoading}
+                               isLoading={isLoading || routesLoading || airlinesLoading || tariffsLoading || flightTariffsLoading || airportsLoading}
 				error={errors}
 			/>
 

--- a/client/src/redux/actions/flight_tariff.js
+++ b/client/src/redux/actions/flight_tariff.js
@@ -1,0 +1,10 @@
+import { createCrudActions } from '../utils';
+
+export const {
+        fetchAll: fetchFlightTariffs,
+        fetchOne: fetchFlightTariff,
+        create: createFlightTariff,
+        update: updateFlightTariff,
+        remove: deleteFlightTariff,
+        removeAll: deleteAllFlightTariffs,
+} = createCrudActions('flight_tariffs');

--- a/client/src/redux/reducers/flight_tariff.js
+++ b/client/src/redux/reducers/flight_tariff.js
@@ -1,0 +1,39 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import {
+        fetchFlightTariffs,
+        fetchFlightTariff,
+        createFlightTariff,
+        updateFlightTariff,
+        deleteFlightTariff,
+} from '../actions/flight_tariff';
+import { addCrudCases } from '../utils';
+
+const initialState = {
+        flightTariffs: [],
+        flightTariff: null,
+        isLoading: false,
+        errors: null,
+};
+
+const flightTariffSlice = createSlice({
+        name: 'flightTariffs',
+        initialState,
+        reducers: {},
+        extraReducers: (builder) => {
+                addCrudCases(
+                        builder,
+                        {
+                                fetchAll: fetchFlightTariffs,
+                                fetchOne: fetchFlightTariff,
+                                create: createFlightTariff,
+                                update: updateFlightTariff,
+                                remove: deleteFlightTariff,
+                        },
+                        'flightTariffs',
+                        'flightTariff'
+                );
+        },
+});
+
+export default flightTariffSlice.reducer;

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -8,6 +8,7 @@ import countryReducer from './reducers/country';
 import routesReducer from './reducers/route';
 import flightReducer from './reducers/flight';
 import tariffsReducer from './reducers/tariff';
+import flightTariffsReducer from './reducers/flight_tariff';
 import ticketsReducer from './reducers/ticket';
 import discountReducer from './reducers/discount';
 import userReducer from './reducers/user';
@@ -21,10 +22,11 @@ const rootReducer = combineReducers({
 	airports: airportReducer,
 	airlines: airlineReducer,
 	countries: countryReducer,
-	routes: routesReducer,
-	flights: flightReducer,
-	tariffs: tariffsReducer,
-	tickets: ticketsReducer,
+        routes: routesReducer,
+        flights: flightReducer,
+        tariffs: tariffsReducer,
+        flightTariffs: flightTariffsReducer,
+        tickets: ticketsReducer,
 	discounts: discountReducer,
 	bookings: bookingReducer,
 	passengers: passengerReducer,

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -15,6 +15,7 @@ from app.controllers.airport_controller import *
 from app.controllers.route_controller import *
 from app.controllers.flight_controller import *
 from app.controllers.tariff_controller import *
+from app.controllers.flight_tariff_controller import *
 from app.controllers.discount_controller import *
 from app.controllers.seat_controller import *
 from app.controllers.passenger_controller import *
@@ -113,6 +114,13 @@ def __create_app(_config_class, _db):
     app.route('/tariffs/<int:tariff_id>', methods=['GET'])(get_tariff)
     app.route('/tariffs/<int:tariff_id>', methods=['PUT'])(update_tariff)
     app.route('/tariffs/<int:tariff_id>', methods=['DELETE'])(delete_tariff)
+
+    # flight tariffs
+    app.route('/flight_tariffs', methods=['GET'])(get_flight_tariffs)
+    app.route('/flight_tariffs', methods=['POST'])(create_flight_tariff)
+    app.route('/flight_tariffs/<int:flight_tariff_id>', methods=['GET'])(get_flight_tariff)
+    app.route('/flight_tariffs/<int:flight_tariff_id>', methods=['PUT'])(update_flight_tariff)
+    app.route('/flight_tariffs/<int:flight_tariff_id>', methods=['DELETE'])(delete_flight_tariff)
 
     # discounts
     app.route('/discounts', methods=['GET'])(get_discounts)

--- a/server/app/controllers/flight_tariff_controller.py
+++ b/server/app/controllers/flight_tariff_controller.py
@@ -1,0 +1,70 @@
+from flask import request, jsonify
+
+from app.models.flight_tariff import FlightTariff
+from app.models.flight import Flight
+from app.models.tariff import Tariff
+from app.middlewares.auth_middleware import admin_required
+from app.models._base_model import ModelValidationError
+
+
+@admin_required
+def get_flight_tariffs(current_user):
+    flight_tariffs = FlightTariff.get_all()
+    return jsonify([ft.to_dict() for ft in flight_tariffs])
+
+
+@admin_required
+def get_flight_tariff(current_user, flight_tariff_id):
+    flight_tariff = FlightTariff.get_by_id(flight_tariff_id)
+    if flight_tariff:
+        return jsonify(flight_tariff.to_dict()), 200
+    return jsonify({'message': 'Flight tariff not found'}), 404
+
+
+@admin_required
+def create_flight_tariff(current_user):
+    body = request.json
+    flight_id = body.get('flight_id')
+    tariff_id = body.get('tariff_id')
+
+    if not Flight.get_by_id(flight_id):
+        return jsonify({'message': 'Flight not found'}), 404
+    if not Tariff.get_by_id(tariff_id):
+        return jsonify({'message': 'Tariff not found'}), 404
+
+    try:
+        flight_tariff = FlightTariff.create(**body)
+        return jsonify(flight_tariff.to_dict()), 201
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400
+
+
+@admin_required
+def update_flight_tariff(current_user, flight_tariff_id):
+    body = request.json
+    flight_id = body.get('flight_id')
+    tariff_id = body.get('tariff_id')
+
+    if flight_id is not None and not Flight.get_by_id(flight_id):
+        return jsonify({'message': 'Flight not found'}), 404
+    if tariff_id is not None and not Tariff.get_by_id(tariff_id):
+        return jsonify({'message': 'Tariff not found'}), 404
+
+    try:
+        updated = FlightTariff.update(flight_tariff_id, **body)
+        if updated:
+            return jsonify(updated.to_dict())
+        return jsonify({'message': 'Flight tariff not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400
+
+
+@admin_required
+def delete_flight_tariff(current_user, flight_tariff_id):
+    try:
+        deleted = FlightTariff.delete(flight_tariff_id)
+        if deleted:
+            return jsonify(deleted.to_dict())
+        return jsonify({'message': 'Flight tariff not found'}), 404
+    except ModelValidationError as e:
+        return jsonify({'errors': e.errors}), 400

--- a/server/app/controllers/tariff_controller.py
+++ b/server/app/controllers/tariff_controller.py
@@ -1,7 +1,6 @@
 from flask import request, jsonify
 
 from app.models.tariff import Tariff
-from app.models.flight import Flight
 from app.middlewares.auth_middleware import admin_required
 from app.models._base_model import ModelValidationError
 
@@ -23,10 +22,6 @@ def get_tariff(current_user, tariff_id):
 @admin_required
 def create_tariff(current_user):
     body = request.json
-    flight_id = body.get('flight_id')
-
-    if not Flight.get_by_id(flight_id):
-        return jsonify({'message': 'Flight not found'}), 404
 
     try:
         tariff = Tariff.create(**body)


### PR DESCRIPTION
## Summary
- add FlightTariff controller with CRUD endpoints
- clean up Tariff controller to remove old flight checks
- register flight tariff routes
- add redux slice/actions for flight tariffs and connect to store
- update flight management UI to use flight tariff data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687cf1453238832f9039af290837b835