### PR TITLE
Add date/time validation utils

### DIFF
--- a/client/src/components/admin/FlightManagement.js
+++ b/client/src/components/admin/FlightManagement.js
@@ -25,7 +25,14 @@ import { fetchRoutes } from '../../redux/actions/route';
 import { fetchAirlines } from '../../redux/actions/airline';
 import { fetchAirports } from '../../redux/actions/airport';
 import { FIELD_TYPES, createAdminManager } from './utils';
-import { formatDate, formatTime, formatTimeToAPI, formatTimeToUI } from '../utils';
+import {
+        formatDate,
+        formatTime,
+        formatTimeToAPI,
+        formatTimeToUI,
+        validateDate,
+        validateTime,
+} from '../utils';
 import { ENUM_LABELS, FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES } from '../../constants';
 
 const FlightManagement = () => {
@@ -183,43 +190,59 @@ const FlightManagement = () => {
 			label: FIELD_LABELS.FLIGHT.aircraft,
 			type: FIELD_TYPES.TEXT,
 		},
-		scheduledDeparture: {
-			key: 'scheduledDeparture',
-			apiKey: 'scheduled_departure',
-			label: FIELD_LABELS.FLIGHT.scheduled_departure,
-			type: FIELD_TYPES.DATE,
-			formatter: (value) => formatDate(value),
-			validate: (value) => (!value ? VALIDATION_MESSAGES.FLIGHT.scheduled_departure.REQUIRED : null),
-		},
-		scheduledDepartureTime: {
-			key: 'scheduledDepartureTime',
-			apiKey: 'scheduled_departure_time',
-			label: FIELD_LABELS.FLIGHT.scheduled_departure_time,
-			type: FIELD_TYPES.TIME,
-			excludeFromTable: true,
-			toApi: (value) => formatTimeToAPI(value),
-			toUi: (value) => formatTimeToUI(value),
-			formatter: (value) => formatTime(value),
-		},
-		scheduledArrival: {
-			key: 'scheduledArrival',
-			apiKey: 'scheduled_arrival',
-			label: FIELD_LABELS.FLIGHT.scheduled_arrival,
-			type: FIELD_TYPES.DATE,
-			excludeFromTable: true,
-			formatter: (value) => formatDate(value),
-			validate: (value) => (!value ? VALIDATION_MESSAGES.FLIGHT.scheduled_arrival.REQUIRED : null),
-		},
-		scheduledArrivalTime: {
-			key: 'scheduledArrivalTime',
-			apiKey: 'scheduled_arrival_time',
-			label: FIELD_LABELS.FLIGHT.scheduled_arrival_time,
-			type: FIELD_TYPES.TIME,
-			excludeFromTable: true,
-			toApi: (value) => formatTimeToAPI(value),
-			toUi: (value) => formatTimeToUI(value),
-			formatter: (value) => formatTime(value),
-		},
+                scheduledDeparture: {
+                        key: 'scheduledDeparture',
+                        apiKey: 'scheduled_departure',
+                        label: FIELD_LABELS.FLIGHT.scheduled_departure,
+                        type: FIELD_TYPES.DATE,
+                        formatter: (value) => formatDate(value),
+                        validate: (value) => {
+                                if (!value) return VALIDATION_MESSAGES.FLIGHT.scheduled_departure.REQUIRED;
+                                if (!validateDate(value)) return VALIDATION_MESSAGES.GENERAL.INVALID_DATE;
+                                return null;
+                        },
+                },
+                scheduledDepartureTime: {
+                        key: 'scheduledDepartureTime',
+                        apiKey: 'scheduled_departure_time',
+                        label: FIELD_LABELS.FLIGHT.scheduled_departure_time,
+                        type: FIELD_TYPES.TIME,
+                        excludeFromTable: true,
+                        toApi: (value) => formatTimeToAPI(value),
+                        toUi: (value) => formatTimeToUI(value),
+                        formatter: (value) => formatTime(value),
+                        validate: (value) => {
+                                if (value && !validateTime(value)) return VALIDATION_MESSAGES.GENERAL.INVALID_TIME;
+                                return null;
+                        },
+                },
+                scheduledArrival: {
+                        key: 'scheduledArrival',
+                        apiKey: 'scheduled_arrival',
+                        label: FIELD_LABELS.FLIGHT.scheduled_arrival,
+                        type: FIELD_TYPES.DATE,
+                        excludeFromTable: true,
+                        formatter: (value) => formatDate(value),
+                        validate: (value) => {
+                                if (!value) return VALIDATION_MESSAGES.FLIGHT.scheduled_arrival.REQUIRED;
+                                if (!validateDate(value)) return VALIDATION_MESSAGES.GENERAL.INVALID_DATE;
+                                return null;
+                        },
+                },
+                scheduledArrivalTime: {
+                        key: 'scheduledArrivalTime',
+                        apiKey: 'scheduled_arrival_time',
+                        label: FIELD_LABELS.FLIGHT.scheduled_arrival_time,
+                        type: FIELD_TYPES.TIME,
+                        excludeFromTable: true,
+                        toApi: (value) => formatTimeToAPI(value),
+                        toUi: (value) => formatTimeToUI(value),
+                        formatter: (value) => formatTime(value),
+                        validate: (value) => {
+                                if (value && !validateTime(value)) return VALIDATION_MESSAGES.GENERAL.INVALID_TIME;
+                                return null;
+                        },
+                },
 		tariffs: {
 			key: 'tariffs',
 			type: FIELD_TYPES.CUSTOM,

--- a/client/src/components/admin/PassengerManagement.js
+++ b/client/src/components/admin/PassengerManagement.js
@@ -11,7 +11,7 @@ import {
 	deleteAllPassengers,
 } from '../../redux/actions/passenger';
 import { FIELD_TYPES, createAdminManager } from './utils';
-import { formatDate } from '../utils';
+import { formatDate, validateDate } from '../utils';
 import { ENUM_LABELS, FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES, getEnumOptions } from '../../constants';
 
 const PassengerManagement = () => {
@@ -55,13 +55,17 @@ const PassengerManagement = () => {
 			options: getEnumOptions('GENDER'),
 			formatter: (value) => ENUM_LABELS.GENDER[value] || value,
 		},
-		birthDate: {
-			key: 'birthDate',
-			apiKey: 'birth_date',
-			label: FIELD_LABELS.PASSENGER.birth_date,
-			type: FIELD_TYPES.DATE,
-			formatter: (value) => formatDate(value),
-		},
+                birthDate: {
+                        key: 'birthDate',
+                        apiKey: 'birth_date',
+                        label: FIELD_LABELS.PASSENGER.birth_date,
+                        type: FIELD_TYPES.DATE,
+                        formatter: (value) => formatDate(value),
+                        validate: (value) => {
+                                if (value && !validateDate(value)) return VALIDATION_MESSAGES.GENERAL.INVALID_DATE;
+                                return null;
+                        },
+                },
 		documentType: {
 			key: 'documentType',
 			apiKey: 'document_type',

--- a/client/src/components/utils.js
+++ b/client/src/components/utils.js
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, parse, isValid } from 'date-fns';
 import { DATE_FORMAT, TIME_FORMAT, DATETIME_FORMAT } from '../constants/formats';
 
 export const formatDate = (value, dateFormat = DATE_FORMAT) => {
@@ -42,11 +42,53 @@ export const formatTimeToAPI = (value) => {
 };
 
 export const formatTimeToUI = (value) => {
-	if (!value) return '';
-	try {
-		return new Date(`1970-01-01T${value}`);
-	} catch (error) {
-		console.error('Invalid time value (UI):', value);
-		return value;
-	}
+        if (!value) return '';
+        try {
+                return new Date(`1970-01-01T${value}`);
+        } catch (error) {
+                console.error('Invalid time value (UI):', value);
+                return value;
+        }
+};
+
+export const validateDate = (value, dateFormat = DATE_FORMAT) => {
+        if (!value) return false;
+        try {
+                const date =
+                        value instanceof Date
+                                ? value
+                                : parse(value, dateFormat, new Date());
+                return isValid(date);
+        } catch (error) {
+                console.error('Invalid date value:', value);
+                return false;
+        }
+};
+
+export const validateTime = (value, timeFormat = TIME_FORMAT) => {
+        if (!value) return false;
+        try {
+                const date =
+                        value instanceof Date
+                                ? value
+                                : parse(value, timeFormat, new Date());
+                return isValid(date);
+        } catch (error) {
+                console.error('Invalid time value:', value);
+                return false;
+        }
+};
+
+export const validateDateTime = (value, dateTimeFormat = DATETIME_FORMAT) => {
+        if (!value) return false;
+        try {
+                const date =
+                        value instanceof Date
+                                ? value
+                                : parse(value, dateTimeFormat, new Date());
+                return isValid(date);
+        } catch (error) {
+                console.error('Invalid datetime value:', value);
+                return false;
+        }
 };

--- a/client/src/constants/validationMessages.js
+++ b/client/src/constants/validationMessages.js
@@ -1,7 +1,12 @@
 export const VALIDATION_MESSAGES = {
-	DISCOUNT: {
-		discount_name: {
-			REQUIRED: 'Название скидки обязательно',
+        GENERAL: {
+                INVALID_DATE: 'Неверный формат даты',
+                INVALID_TIME: 'Неверный формат времени',
+                INVALID_DATETIME: 'Неверный формат даты и времени',
+        },
+        DISCOUNT: {
+                discount_name: {
+                        REQUIRED: 'Название скидки обязательно',
 		},
 		discount_type: {
 			REQUIRED: 'Тип скидки обязателен',


### PR DESCRIPTION
## Summary
- add validation helpers for date and time formats
- update validation messages with generic format errors
- use new validators in flight and passenger management forms

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687dfde10c9c832f97dacf29e1e44287