### PR TITLE
Fix FlightTariff edit mode

### DIFF
--- a/client/src/components/admin/FlightManagement.js
+++ b/client/src/components/admin/FlightManagement.js
@@ -399,13 +399,13 @@ const FlightManagement = () => {
 				error={errors}
 			/>
 
-			<FlightTariffManagement
-				flightId={selectedFlightId}
-				tariffDialogOpen={tariffDialogOpen}
-				onClose={handleTariffDialogClose}
-				action={tariffAction}
-				tariffId={selectedTariffId}
-			/>
+                       <FlightTariffManagement
+                               flightId={selectedFlightId}
+                               tariffDialogOpen={tariffDialogOpen}
+                               onClose={handleTariffDialogClose}
+                               action={tariffAction}
+                               flightTariffId={selectedTariffId}
+                       />
 
 			{/* Delete tariff dialog */}
 			<Dialog open={deleteTariffDialog.open} onClose={handleCloseDeleteTariffDialog}>

--- a/client/src/components/admin/FlightTariffManagement.js
+++ b/client/src/components/admin/FlightTariffManagement.js
@@ -12,7 +12,7 @@ export const FlightTariffManagement = ({ flightId, tariffDialogOpen, onClose, ac
 	const { tariffs } = useSelector((state) => state.tariffs);
 	const { flightTariff, isLoading } = useSelector((state) => state.flightTariffs);
 
-	const [seatClass, setSeatClass] = useState('');
+        const [seatClass, setSeatClass] = useState('');
 
 	const isEditing = action === 'edit';
 
@@ -22,11 +22,19 @@ export const FlightTariffManagement = ({ flightId, tariffDialogOpen, onClose, ac
 		}
 	}, [dispatch, tariffs]);
 
-	useEffect(() => {
-		if (isEditing && flightTariffId) {
-			dispatch(fetchFlightTariff(flightTariffId));
-		}
-	}, [dispatch, isEditing, flightTariffId]);
+        useEffect(() => {
+                if (isEditing && flightTariffId) {
+                        dispatch(fetchFlightTariff(flightTariffId));
+                }
+        }, [dispatch, isEditing, flightTariffId]);
+
+        useEffect(() => {
+                if (isEditing && flightTariff) {
+                        setSeatClass(flightTariff.seat_class);
+                } else if (!isEditing) {
+                        setSeatClass('');
+                }
+        }, [isEditing, flightTariff]);
 
 	const seatClassOptions = useMemo(() => getEnumOptions('SEAT_CLASS'), []);
 


### PR DESCRIPTION
## Summary
- pass the correct `flightTariffId` prop to FlightTariffManagement
- sync seat class state when loading an existing flight tariff

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687e1fa16af8832f93fed76c19a3fdde