### PR TITLE
Fix flight tariff form warnings

### DIFF
--- a/client/src/components/admin/AdminEntityForm.js
+++ b/client/src/components/admin/AdminEntityForm.js
@@ -4,25 +4,32 @@ import { DialogTitle, DialogContent, DialogActions, Button, Grid, Alert, Fade, B
 import { UI_LABELS } from '../../constants';
 
 const AdminEntityForm = ({
-	fields,
-	initialData,
-	onSave,
-	onChange,
-	onClose,
-	isEditing,
-	addButtonText,
-	editButtonText,
+        fields,
+        initialData,
+        onSave,
+        onChange,
+        onClose,
+        isEditing,
+        addButtonText,
+        editButtonText,
+        externalUpdates = {},
 }) => {
 	const [formData, setFormData] = useState(initialData || {});
 	const [successMessage, setSuccessMessage] = useState('');
 	const [errorMessage, setErrorMessage] = useState('');
 	const [validationErrors, setValidationErrors] = useState({});
 
-	useEffect(() => {
-		if (isEditing && initialData?.id) {
-			setFormData(initialData);
-		}
-	}, [isEditing, initialData?.id]);
+        useEffect(() => {
+                if (isEditing && initialData?.id) {
+                        setFormData(initialData);
+                }
+        }, [isEditing, initialData?.id]);
+
+        useEffect(() => {
+                if (Object.keys(externalUpdates).length > 0) {
+                        setFormData((prev) => ({ ...prev, ...externalUpdates }));
+                }
+        }, [externalUpdates]);
 
 	const handleChange = (field, value) => {
 		setFormData((prev) => ({ ...prev, [field]: value }));

--- a/client/src/components/admin/FlightTariffManagement.js
+++ b/client/src/components/admin/FlightTariffManagement.js
@@ -12,7 +12,8 @@ export const FlightTariffManagement = ({ flightId, tariffDialogOpen, onClose, ac
 	const { tariffs, isLoading: isLoadingTariffs } = useSelector((state) => state.tariffs);
 	const { flightTariff, isLoading: isLoadingFlightTariff } = useSelector((state) => state.flightTariffs);
 
-	const [seatClass, setSeatClass] = useState('');
+        const [seatClass, setSeatClass] = useState('');
+        const [formUpdates, setFormUpdates] = useState({});
 
 	const isEditing = action === 'edit';
 
@@ -28,14 +29,22 @@ export const FlightTariffManagement = ({ flightId, tariffDialogOpen, onClose, ac
 		}
 	}, [dispatch, isEditing, flightTariffId]);
 
-	useEffect(() => {
-		if (isEditing && flightTariff && tariffs) {
-			const tariff = tariffs.find((t) => t.id === flightTariff.tariff_id);
-			setSeatClass(tariff.seat_class);
-		} else if (!isEditing) {
-			setSeatClass('');
-		}
-	}, [isEditing, flightTariff, tariffs]);
+        useEffect(() => {
+                if (isEditing && flightTariff && Array.isArray(tariffs) && tariffs.length > 0) {
+                        const tariff = tariffs.find((t) => t.id === flightTariff.tariff_id);
+                        if (tariff) {
+                                setSeatClass(tariff.seat_class);
+                        }
+                } else if (!isEditing) {
+                        setSeatClass('');
+                }
+        }, [isEditing, flightTariff, tariffs]);
+
+        useEffect(() => {
+                if (Object.keys(formUpdates).length > 0) {
+                        setFormUpdates({});
+                }
+        }, [formUpdates]);
 
 	const seatClassOptions = useMemo(() => getEnumOptions('SEAT_CLASS'), []);
 
@@ -92,42 +101,49 @@ export const FlightTariffManagement = ({ flightId, tariffDialogOpen, onClose, ac
 		[FIELDS]
 	);
 
-	const currentItem = useMemo(() => {
-		if (isEditing) {
-			if (flightTariff && tariffs) {
-				const tariff = tariffs.find((t) => t.id === flightTariff.tariff_id);
-				return {
-					id: flightTariffId,
-					flightId: flightId,
-					seatClass: tariff.seat_class,
-					seatsNumber: flightTariff.seats_number,
-					flightTariffId: flightTariff.tariff_id,
-				};
-			}
-		}
-		return { flightId, seatClass: '', seatsNumber: 0, flightTariffId: '' };
-	}, [isEditing, flightTariff, tariffs, flightId]);
+        const currentItem = useMemo(() => {
+                if (isEditing) {
+                        if (flightTariff && Array.isArray(tariffs) && tariffs.length > 0) {
+                                const tariff = tariffs.find((t) => t.id === flightTariff.tariff_id);
+                                const originalSeatClass = tariff ? tariff.seat_class : '';
+                                return {
+                                        id: flightTariffId,
+                                        flightId: flightId,
+                                        seatClass: seatClass || originalSeatClass,
+                                        seatsNumber: flightTariff.seats_number,
+                                        flightTariffId:
+                                                seatClass && seatClass !== originalSeatClass
+                                                        ? ''
+                                                        : flightTariff.tariff_id,
+                                };
+                        }
+                }
+                return { flightId, seatClass, seatsNumber: 0, flightTariffId: '' };
+        }, [isEditing, flightTariff, tariffs, flightId, seatClass]);
 
-	const handleSaveTariff = async (tariffData) => {
-		const formattedData = tariffManager.toApiFormat({
-			...tariffData,
-			flightId,
-		});
+        const handleSaveTariff = async (tariffData) => {
+                const formattedData = tariffManager.toApiFormat({
+                        ...tariffData,
+                        flightId,
+                });
 
-		try {
-			await dispatch(isEditing ? updateFlightTariff(formattedData) : createFlightTariff(formattedData)).unwrap();
-		} catch (error) {
-			throw error;
-		}
-	};
+                try {
+                        return await dispatch(
+                                isEditing ? updateFlightTariff(formattedData) : createFlightTariff(formattedData)
+                        ).unwrap();
+                } catch (error) {
+                        throw error;
+                }
+        };
 
-	const handleChange = (field, value) => {
-		if (field === FIELDS.seatClass.key) {
-			setSeatClass(value);
-		}
-	};
+        const handleChange = (field, value) => {
+                if (field === FIELDS.seatClass.key) {
+                        setSeatClass(value);
+                        setFormUpdates({ flightTariffId: '' });
+                }
+        };
 
-	if (isEditing && (isLoadingFlightTariff || isLoadingTariffs)) {
+        if (isEditing && (isLoadingFlightTariff || isLoadingTariffs || !seatClass)) {
 		return (
 			<Dialog open={tariffDialogOpen} onClose={onClose} maxWidth='sm' fullWidth>
 				<DialogContent>
@@ -140,13 +156,14 @@ export const FlightTariffManagement = ({ flightId, tariffDialogOpen, onClose, ac
 	return (
 		<Dialog open={tariffDialogOpen} onClose={onClose} maxWidth='md' fullWidth>
 			<DialogContent>
-				{tariffManager.renderForm({
-					isEditing,
-					currentItem,
-					onSave: handleSaveTariff,
-					onChange: handleChange,
-					onClose,
-				})}
+                                {tariffManager.renderForm({
+                                        isEditing,
+                                        currentItem,
+                                        onSave: handleSaveTariff,
+                                        onChange: handleChange,
+                                        onClose,
+                                        externalUpdates: formUpdates,
+                                })}
 			</DialogContent>
 		</Dialog>
 	);

--- a/client/src/components/admin/utils.js
+++ b/client/src/components/admin/utils.js
@@ -362,17 +362,18 @@ export const createAdminManager = (fields, options = {}) => {
 		columns,
 		toApiFormat,
 		toUiFormat,
-		renderForm: ({ isEditing, currentItem, onSave, onChange, onClose }) => (
-			<AdminEntityForm
-				fields={formFields}
-				initialData={currentItem}
-				onSave={onSave}
-				onChange={onChange}
-				onClose={onClose}
-				isEditing={isEditing}
-				addButtonText={options.addButtonText(currentItem)}
-				editButtonText={options.editButtonText(currentItem)}
-			/>
-		),
+                renderForm: ({ isEditing, currentItem, onSave, onChange, onClose, ...rest }) => (
+                        <AdminEntityForm
+                                fields={formFields}
+                                initialData={currentItem}
+                                onSave={onSave}
+                                onChange={onChange}
+                                onClose={onClose}
+                                isEditing={isEditing}
+                                addButtonText={options.addButtonText(currentItem)}
+                                editButtonText={options.editButtonText(currentItem)}
+                                {...rest}
+                        />
+                ),
 	};
 };


### PR DESCRIPTION
## Summary
- fix warnings when editing tariffs
- reset tariff after changing seat class
- allow admin forms to accept external updates
- pass externalUpdates to AdminEntityForm

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687e701c2dbc832fbfd45a84b79c7b6a