### PR TITLE
Ensure default values populate admin forms

### DIFF
--- a/client/src/components/admin/AdminEntityForm.js
+++ b/client/src/components/admin/AdminEntityForm.js
@@ -14,16 +14,25 @@ const AdminEntityForm = ({
 	editButtonText,
 	externalUpdates = {},
 }) => {
-	const [formData, setFormData] = useState(initialData || {});
+        const initializeFormData = (data) => {
+                const result = { ...(data || {}) };
+                fields.forEach((field) => {
+                        if (result[field.name] === undefined && field.defaultValue !== undefined) {
+                                result[field.name] = field.defaultValue;
+                        }
+                });
+                return result;
+        };
+
+        const [formData, setFormData] = useState(() => initializeFormData(initialData));
 	const [successMessage, setSuccessMessage] = useState('');
 	const [errorMessage, setErrorMessage] = useState('');
 	const [validationErrors, setValidationErrors] = useState({});
 
-	useEffect(() => {
-		if (isEditing && initialData?.id) {
-			setFormData(initialData);
-		}
-	}, [isEditing, initialData?.id]);
+        useEffect(() => {
+                const data = isEditing && initialData?.id ? initialData : initialData;
+                setFormData(initializeFormData(data));
+        }, [isEditing, initialData, fields]);
 
 	useEffect(() => {
 		if (Object.keys(externalUpdates).length > 0) {

--- a/client/src/components/admin/utils.js
+++ b/client/src/components/admin/utils.js
@@ -269,14 +269,15 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
  * Create field configurations for AdminEntityForm
  */
 export const createFormFields = (fields) => {
-	return Object.values(fields)
-		.filter((field) => field.key !== 'id' && !field.excludeFromForm)
-		.map((field) => ({
-			name: field.key,
-			fullWidth: field.fullWidth || false,
-			renderField: createFieldRenderer(field),
-			validate: field.validate,
-		}));
+        return Object.values(fields)
+                .filter((field) => field.key !== 'id' && !field.excludeFromForm)
+                .map((field) => ({
+                        name: field.key,
+                        fullWidth: field.fullWidth || false,
+                        defaultValue: field.defaultValue,
+                        renderField: createFieldRenderer(field),
+                        validate: field.validate,
+                }));
 };
 
 /**


### PR DESCRIPTION
## Summary
- keep default values when creating form fields
- apply defaults when initialising AdminEntityForm state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: dotenv)*
- `npm test --silent` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7c7795b8832f892126ded1baf8a6