### PR TITLE
Enforce unique flight tariff by seat class

### DIFF
--- a/server/app/models/flight_tariff.py
+++ b/server/app/models/flight_tariff.py
@@ -1,5 +1,6 @@
 from app.database import db
-from app.models._base_model import BaseModel
+from app.models._base_model import BaseModel, ModelValidationError
+from app.models.tariff import Tariff
 
 
 class FlightTariff(BaseModel):
@@ -9,6 +10,20 @@ class FlightTariff(BaseModel):
     tariff_id = db.Column(db.Integer, db.ForeignKey('tariffs.id', ondelete='CASCADE'), nullable=False)
     seats_number = db.Column(db.Integer, nullable=False)
 
+    @classmethod
+    def __check_seat_class_unique(cls, session, flight_id, tariff_id, instance_id=None):
+        """Ensure only one tariff per flight for the same seat class."""
+        tariff = Tariff.get_by_id(tariff_id)
+        if not tariff:
+            return
+
+        query = session.query(cls).join(Tariff, cls.tariff_id == Tariff.id)
+        query = query.filter(cls.flight_id == flight_id, Tariff.seat_class == tariff.seat_class)
+        if instance_id is not None:
+            query = query.filter(cls.id != instance_id)
+        if query.first() is not None:
+            raise ModelValidationError({'seat_class': 'flight tariff for this class already exists'})
+
     def to_dict(self):
         return {
             'id': self.id,
@@ -16,3 +31,27 @@ class FlightTariff(BaseModel):
             'tariff_id': self.tariff_id,
             'seats_number': self.seats_number
         }
+
+    @classmethod
+    def create(cls, session=None, **data):
+        session = session or db.session
+        flight_id = data.get('flight_id')
+        tariff_id = data.get('tariff_id')
+        if flight_id is not None and tariff_id is not None:
+            cls.__check_seat_class_unique(session, flight_id, tariff_id)
+        return super().create(session, **data)
+
+    @classmethod
+    def update(cls, _id, session=None, **data):
+        session = session or db.session
+        instance = cls.get_by_id(_id)
+        if not instance:
+            return None
+
+        flight_id = data.get('flight_id', instance.flight_id)
+        tariff_id = data.get('tariff_id', instance.tariff_id)
+        if flight_id is not None and tariff_id is not None:
+            cls.__check_seat_class_unique(session, flight_id, tariff_id, instance_id=_id)
+
+        return super().update(_id, session, **data)
+

--- a/server/tests/fixtures/__init__.py
+++ b/server/tests/fixtures/__init__.py
@@ -8,4 +8,5 @@ from tests.fixtures.tariff import *
 from tests.fixtures.discount import *
 from tests.fixtures.booking import *
 from tests.fixtures.seat import *
+from tests.fixtures.flight_tariff import *
 from tests.fixtures.user import *

--- a/server/tests/fixtures/flight_tariff.py
+++ b/server/tests/fixtures/flight_tariff.py
@@ -1,0 +1,19 @@
+import pytest
+from app.models.flight_tariff import FlightTariff
+
+
+@pytest.fixture
+def economy_flight_tariff(future_flight, economy_tariff):
+    return FlightTariff.create(
+        flight_id=future_flight.id,
+        tariff_id=economy_tariff.id,
+        seats_number=100
+    )
+
+@pytest.fixture
+def business_flight_tariff(future_flight, business_tariff):
+    return FlightTariff.create(
+        flight_id=future_flight.id,
+        tariff_id=business_tariff.id,
+        seats_number=10
+    )

--- a/server/tests/fixtures/tariff.py
+++ b/server/tests/fixtures/tariff.py
@@ -4,24 +4,20 @@ from app.config import Config
 
 
 @pytest.fixture
-def economy_tariff(future_flight):
+def economy_tariff():
     """Create and return an economy tariff"""
     return Tariff.create(
-        flight_id=future_flight.id,
         seat_class=Config.SEAT_CLASS.economy,
         price=15000.0,
-        seats_number=180,
         currency=Config.CURRENCY.rub
     )
 
 
 @pytest.fixture
-def business_tariff(future_flight):
+def business_tariff():
     """Create and return a business tariff"""
     return Tariff.create(
-        flight_id=future_flight.id,
         seat_class=Config.SEAT_CLASS.business,
         price=45000.0,
-        seats_number=20,
         currency=Config.CURRENCY.rub
     )

--- a/server/tests/unit/test_flight_tariff.py
+++ b/server/tests/unit/test_flight_tariff.py
@@ -1,0 +1,55 @@
+import pytest
+
+from app.models.flight_tariff import FlightTariff
+from app.models.tariff import Tariff
+from app.models._base_model import ModelValidationError
+from app.config import Config
+
+
+def test_unique_class_on_create(future_flight, economy_tariff):
+    ft1 = FlightTariff.create(
+        flight_id=future_flight.id,
+        tariff_id=economy_tariff.id,
+        seats_number=100
+    )
+    assert ft1 is not None
+
+    with pytest.raises(ModelValidationError):
+        FlightTariff.create(
+            flight_id=future_flight.id,
+            tariff_id=economy_tariff.id,
+            seats_number=50
+        )
+
+    another_tariff = Tariff.create(
+        seat_class=Config.SEAT_CLASS.economy,
+        price=16000.0,
+        currency=Config.CURRENCY.rub
+    )
+    with pytest.raises(ModelValidationError):
+        FlightTariff.create(
+            flight_id=future_flight.id,
+            tariff_id=another_tariff.id,
+            seats_number=30
+        )
+
+
+def test_unique_class_on_update(future_flight, economy_tariff, business_tariff):
+    ft1 = FlightTariff.create(
+        flight_id=future_flight.id,
+        tariff_id=economy_tariff.id,
+        seats_number=100
+    )
+    ft2 = FlightTariff.create(
+        flight_id=future_flight.id,
+        tariff_id=business_tariff.id,
+        seats_number=10
+    )
+
+    # updating same record without changing seat_class should pass
+    updated = FlightTariff.update(ft1.id, seats_number=120)
+    assert updated.seats_number == 120
+
+    with pytest.raises(ModelValidationError):
+        FlightTariff.update(ft2.id, tariff_id=economy_tariff.id)
+


### PR DESCRIPTION
## Summary
- validate seat class uniqueness when creating/updating `FlightTariff`
- fix tariff fixtures for new model structure
- add `FlightTariff` fixtures
- add unit tests for flight tariff validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687e8a5538a8832f801fed2e9af7d9fc