### PR TITLE
Improve ORM session usage and 404 helpers

### DIFF
--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -46,10 +46,8 @@ def update_user(current_user, user_id):
 @admin_required
 def delete_user(current_user, user_id):
     try:
-        deleted_user = User.delete(user_id)
-        if deleted_user:
-            return jsonify(deleted_user.to_dict())
-        return jsonify({'message': 'User not found'}), 404
+        deleted_user = User.delete_or_404(user_id)
+        return jsonify(deleted_user.to_dict())
     except ModelValidationError as e:
         return jsonify({'errors': e.errors}), 400
 

--- a/server/app/models/_base_model.py
+++ b/server/app/models/_base_model.py
@@ -108,9 +108,7 @@ class BaseModel(db.Model):
     @classmethod
     def get_or_404(cls, _id, session: Session | None = None) -> Optional['BaseModel']:
         session = session or db.session
-        instance = cls.get_by_id(_id)
-        if not instance:
-            raise NotFoundError(f"{cls.__name__} not found")
+        instance = cls.get_or_404(_id, session)
         return instance
 
     @classmethod
@@ -148,9 +146,7 @@ class BaseModel(db.Model):
         cls, _id, session: Session | None = None, **data
     ) -> Optional['BaseModel']:
         session = session or db.session
-        instance = cls.get_by_id(_id)
-        if not instance:
-            raise NotFoundError(f"{cls.__name__} not found")
+        instance = cls.get_or_404(_id, session)
 
         filtered_data = instance._BaseModel__filter_out_non_existing_fields(data)
         cls._check_foreign_keys_exist(session, filtered_data)
@@ -173,16 +169,7 @@ class BaseModel(db.Model):
         cls, _id, session: Session | None = None
     ) -> Optional['BaseModel']:
         session = session or db.session
-        instance = cls.get_by_id(_id)
-        if not instance:
-            raise NotFoundError(f"{cls.__name__} not found")
-        try:
-            session.delete(instance)
-            session.commit()
-            return instance
-        except IntegrityError as e:
-            session.rollback()
-            raise ModelValidationError({'message': str(e)}) from e
+        return cls.delete_or_404(_id, session)
 
     @classmethod
     def delete_all(cls, session: Session | None = None) -> int:

--- a/server/app/models/airline.py
+++ b/server/app/models/airline.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import Session
+
 from app.database import db
 from app.models._base_model import BaseModel
 from app.utils.xlsx import parse_xlsx, generate_xlsx_template
@@ -36,7 +38,8 @@ class Airline(BaseModel):
         return generate_xlsx_template(cls.upload_fields)
 
     @classmethod
-    def upload_from_file(cls, file):
+    def upload_from_file(cls, file, session: Session | None = None):
+        session = session or db.session
         rows = parse_xlsx(
             file,
             cls.upload_fields,
@@ -55,9 +58,10 @@ class Airline(BaseModel):
                     if not country:
                         raise ValueError('Invalid country code')
 
-                    airline = cls.create(**{
-                        **row,
-                        'country_id': country.id,
+                    airline = cls.create(session,
+                                       **{
+                       **row,
+                       'country_id': country.id,
                     })
                     airlines.append(airline)
                 except Exception as e:

--- a/server/app/models/airport.py
+++ b/server/app/models/airport.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import Session
+
 from app.database import db
 from app.models._base_model import BaseModel
 from app.models.country import Country
@@ -47,7 +49,8 @@ class Airport(BaseModel):
         return generate_xlsx_template(cls.upload_fields)
 
     @classmethod
-    def upload_from_file(cls, file):
+    def upload_from_file(cls, file, session: Session | None = None):
+        session = session or db.session
         rows = parse_xlsx(
             file,
             cls.upload_fields,
@@ -71,7 +74,8 @@ class Airport(BaseModel):
                     if not country:
                         raise ValueError('Invalid country code')
 
-                    airport = cls.create(**{
+                    airport = cls.create(session,
+                                       **{
                         **row,
                         'country_id': country.id,
                     })

--- a/server/app/models/booking.py
+++ b/server/app/models/booking.py
@@ -1,5 +1,6 @@
 import random
 import string
+from sqlalchemy.orm import Session
 
 from app.database import db
 from app.models._base_model import BaseModel
@@ -44,10 +45,10 @@ class Booking(BaseModel):
         return super().get_all(sort_by='booking_number', descending=False)
 
     @classmethod
-    def __generate_booking_number(cls):
+    def __generate_booking_number(cls, session: Session):
         """Generates a unique booking number (PNR - Passenger Name Record)"""
         existing_booking_numbers = {
-            booking.booking_number for booking in cls.query.all()}
+            booking.booking_number for booking in session.query(cls).all()}
 
         while True:
             booking_number = ''.join(
@@ -59,6 +60,7 @@ class Booking(BaseModel):
                 return booking_number
 
     @classmethod
-    def create(cls, **kwargs):
-        kwargs['booking_number'] = cls.__generate_booking_number()
-        return super().create(**kwargs)
+    def create(cls, session: Session | None = None, **kwargs):
+        session = session or db.session
+        kwargs['booking_number'] = cls.__generate_booking_number(session)
+        return super().create(session, **kwargs)

--- a/server/app/models/passenger.py
+++ b/server/app/models/passenger.py
@@ -1,4 +1,5 @@
 import datetime
+from sqlalchemy.orm import Session
 
 from app.database import db
 from app.models._base_model import BaseModel
@@ -54,8 +55,14 @@ class Passenger(BaseModel):
         return 1 <= years < 3
 
     @classmethod
-    def create(cls, **kwargs):
-        if kwargs['document_type'] in (Config.DOCUMENT_TYPE['passport'], Config.DOCUMENT_TYPE['birth_certificate']):
-            kwargs['citizenship_id'] = Country.get_by_code(Config.DEFAULT_CITIZENSHIP_CODE).id
+    def create(cls, session: Session | None = None, **kwargs):
+        session = session or db.session
+        if kwargs['document_type'] in (
+            Config.DOCUMENT_TYPE['passport'],
+            Config.DOCUMENT_TYPE['birth_certificate'],
+        ):
+            kwargs['citizenship_id'] = Country.get_by_code(
+                Config.DEFAULT_CITIZENSHIP_CODE
+            ).id
 
-        return super().create(**kwargs)
+        return super().create(session, **kwargs)

--- a/server/app/models/tariff.py
+++ b/server/app/models/tariff.py
@@ -1,3 +1,5 @@
+from sqlalchemy.orm import Session
+
 from app.database import db
 from app.models._base_model import BaseModel
 from app.config import Config
@@ -25,11 +27,12 @@ class Tariff(BaseModel):
         return super().get_all(sort_by='seat_class', descending=False)
 
     @classmethod
-    def create(cls, session=None, **data):
+    def create(cls, session: Session | None = None, **data):
+        session = session or db.session
         seat_class = data.get('seat_class')
 
         if seat_class is not None:
-            query = cls.query.filter_by(seat_class=seat_class)
+            query = session.query(cls).filter_by(seat_class=seat_class)
             max_order = query.order_by(cls.order_number.desc()).first()
             next_order = (max_order.order_number + 1) if max_order else 1
             data['order_number'] = next_order


### PR DESCRIPTION
## Summary
- refactor BaseModel to rely on get_or_404 and delete_or_404
- ensure custom create methods accept a session argument
- pass sessions through upload helpers
- use delete_or_404 in user controller

## Testing
- `pytest -q tests/unit/test_flight_tariff.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687fc794bf78832fa87854054908401c