### PR TITLE
Add global exception handler middleware

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -7,6 +7,7 @@ from flask_cors import CORS
 from app.config import Config
 from app.database import db
 from app.utils.email import init_mail
+from app.middlewares.error_handler import register_error_handlers
 
 from app.controllers._dev_controller import *
 from app.controllers.auth_controller import *
@@ -50,6 +51,7 @@ def __create_app(_config_class, _db):
 
     _db.init_app(app)
     init_mail(app)
+    register_error_handlers(app)
 
     # auth
     app.route('/register', methods=['POST'])(register)

--- a/server/app/controllers/_dev_controller.py
+++ b/server/app/controllers/_dev_controller.py
@@ -15,7 +15,7 @@ from app.models.booking import Booking
 from app.models.payment import Payment
 from app.models.user import User
 from app.models.ticket import Ticket
-from app.models._base_model import ModelValidationError
+
 
 MODEL_MAP = {
     'airports': Airport,
@@ -41,9 +41,6 @@ def clear_table(current_user, table_name: str):
     if not model:
         return jsonify({'message': 'Invalid table name'}), 404
 
-    try:
-        deleted = model.delete_all()
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
+    deleted = model.delete_all()
 
     return jsonify({'deleted': deleted})

--- a/server/app/controllers/airport_controller.py
+++ b/server/app/controllers/airport_controller.py
@@ -2,7 +2,6 @@ from flask import request, jsonify, send_file
 
 from app.models.airport import Airport
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 from app.utils.xlsx import is_xlsx_file, create_xlsx
 
 
@@ -14,46 +13,28 @@ def get_airports(current_user):
 
 @admin_required
 def get_airport(current_user, airport_id):
-    try:
-        airport = Airport.get_or_404(airport_id)
-        return jsonify(airport.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    airport = Airport.get_or_404(airport_id)
+    return jsonify(airport.to_dict()), 200
 
 
 @admin_required
 def create_airport(current_user):
     body = request.json
-    try:
-        airport = Airport.create(**body)
-        return jsonify(airport.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    airport = Airport.create(**body)
+    return jsonify(airport.to_dict()), 201
 
 
 @admin_required
 def update_airport(current_user, airport_id):
     body = request.json
-    try:
-        updated = Airport.update(airport_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Airport.update(airport_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_airport(current_user, airport_id):
-    try:
-        deleted = Airport.delete_or_404(airport_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Airport.delete_or_404(airport_id)
+    return jsonify(deleted.to_dict())
 
 
 @admin_required
@@ -75,18 +56,15 @@ def upload_airport(current_user):
         return jsonify({'message': 'No file provided'}), 400
     if not is_xlsx_file(file):
         return jsonify({'message': 'Invalid file type'}), 400
-    try:
-        airports, error_rows = Airport.upload_from_file(file)
-        if error_rows:
-            error_xlsx = create_xlsx(Airport.upload_fields, error_rows)
-            error_xlsx.seek(0)
-            return send_file(
-                error_xlsx,
-                as_attachment=True,
-                download_name='upload_errors.xlsx',
-                mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-            ), 201
+    airports, error_rows = Airport.upload_from_file(file)
+    if error_rows:
+        error_xlsx = create_xlsx(Airport.upload_fields, error_rows)
+        error_xlsx.seek(0)
+        return send_file(
+            error_xlsx,
+            as_attachment=True,
+            download_name='upload_errors.xlsx',
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        ), 201
 
-        return jsonify({'message': 'Airports created successfully'}), 201
-    except Exception as e:
-        return jsonify({'message': str(e)}), 500
+    return jsonify({'message': 'Airports created successfully'}), 201

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -2,7 +2,6 @@ from flask import request, jsonify
 
 from app.models.booking import Booking
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -13,43 +12,25 @@ def get_bookings(current_user):
 
 @admin_required
 def get_booking(current_user, booking_id):
-    try:
-        booking = Booking.get_or_404(booking_id)
-        return jsonify(booking.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    booking = Booking.get_or_404(booking_id)
+    return jsonify(booking.to_dict()), 200
 
 
 @admin_required
 def create_booking(current_user):
     body = request.json
-    try:
-        booking = Booking.create(**body)
-        return jsonify(booking.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    booking = Booking.create(**body)
+    return jsonify(booking.to_dict()), 201
 
 
 @admin_required
 def update_booking(current_user, booking_id):
     body = request.json
-    try:
-        updated = Booking.update(booking_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Booking.update(booking_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_booking(current_user, booking_id):
-    try:
-        deleted = Booking.delete_or_404(booking_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Booking.delete_or_404(booking_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/booking_passenger_controller.py
+++ b/server/app/controllers/booking_passenger_controller.py
@@ -2,7 +2,6 @@ from flask import request, jsonify
 
 from app.models.booking_passenger import BookingPassenger
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -13,43 +12,25 @@ def get_booking_passengers(current_user):
 
 @admin_required
 def get_booking_passenger(current_user, booking_passenger_id):
-    try:
-        booking_passenger = BookingPassenger.get_or_404(booking_passenger_id)
-        return jsonify(booking_passenger.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    booking_passenger = BookingPassenger.get_or_404(booking_passenger_id)
+    return jsonify(booking_passenger.to_dict()), 200
 
 
 @admin_required
 def create_booking_passenger(current_user):
     body = request.json
-    try:
-        booking_passenger = BookingPassenger.create(**body)
-        return jsonify(booking_passenger.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    booking_passenger = BookingPassenger.create(**body)
+    return jsonify(booking_passenger.to_dict()), 201
 
 
 @admin_required
 def update_booking_passenger(current_user, booking_passenger_id):
     body = request.json
-    try:
-        updated = BookingPassenger.update(booking_passenger_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = BookingPassenger.update(booking_passenger_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_booking_passenger(current_user, booking_passenger_id):
-    try:
-        deleted = BookingPassenger.delete_or_404(booking_passenger_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = BookingPassenger.delete_or_404(booking_passenger_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/country_controller.py
+++ b/server/app/controllers/country_controller.py
@@ -2,7 +2,6 @@ from flask import request, jsonify, send_file
 
 from app.models.country import Country
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 from app.utils.xlsx import create_xlsx, is_xlsx_file
 
 
@@ -14,46 +13,28 @@ def get_countries(current_user):
 
 @admin_required
 def get_country(current_user, country_id):
-    try:
-        country = Country.get_or_404(country_id)
-        return jsonify(country.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    country = Country.get_or_404(country_id)
+    return jsonify(country.to_dict()), 200
 
 
 @admin_required
 def create_country(current_user):
     body = request.json
-    try:
-        country = Country.create(**body)
-        return jsonify(country.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    country = Country.create(**body)
+    return jsonify(country.to_dict()), 201
 
 
 @admin_required
 def update_country(current_user, country_id):
     body = request.json
-    try:
-        updated = Country.update(country_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Country.update(country_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_country(current_user, country_id):
-    try:
-        deleted = Country.delete_or_404(country_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Country.delete_or_404(country_id)
+    return jsonify(deleted.to_dict())
 
 
 @admin_required
@@ -75,19 +56,16 @@ def upload_country(current_user):
         return jsonify({'message': 'No file provided'}), 400
     if not is_xlsx_file(file):
         return jsonify({'message': 'Invalid file type'}), 400
-    try:
-        countries, error_rows = Country.upload_from_file(file)
+    countries, error_rows = Country.upload_from_file(file)
 
-        if error_rows:
-            error_xlsx = create_xlsx(Country.upload_fields, error_rows)
-            error_xlsx.seek(0)
-            return send_file(
-                error_xlsx,
-                as_attachment=True,
-                download_name='upload_errors.xlsx',
-                mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-            ), 201
+    if error_rows:
+        error_xlsx = create_xlsx(Country.upload_fields, error_rows)
+        error_xlsx.seek(0)
+        return send_file(
+            error_xlsx,
+            as_attachment=True,
+            download_name='upload_errors.xlsx',
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        ), 201
 
-        return jsonify({'message': 'Countries created successfully'}), 201
-    except Exception as e:
-        return jsonify({'message': str(e)}), 500
+    return jsonify({'message': 'Countries created successfully'}), 201

--- a/server/app/controllers/discount_controller.py
+++ b/server/app/controllers/discount_controller.py
@@ -2,7 +2,6 @@ from flask import request, jsonify
 
 from app.models.discount import Discount
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -13,43 +12,25 @@ def get_discounts(current_user):
 
 @admin_required
 def get_discount(current_user, discount_id):
-    try:
-        discount = Discount.get_or_404(discount_id)
-        return jsonify(discount.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    discount = Discount.get_or_404(discount_id)
+    return jsonify(discount.to_dict()), 200
 
 
 @admin_required
 def create_discount(current_user):
     body = request.json
-    try:
-        discount = Discount.create(**body)
-        return jsonify(discount.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    discount = Discount.create(**body)
+    return jsonify(discount.to_dict()), 201
 
 
 @admin_required
 def update_discount(current_user, discount_id):
     body = request.json
-    try:
-        updated = Discount.update(discount_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Discount.update(discount_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_discount(current_user, discount_id):
-    try:
-        deleted = Discount.delete_or_404(discount_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Discount.delete_or_404(discount_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/flight_controller.py
+++ b/server/app/controllers/flight_controller.py
@@ -4,7 +4,6 @@ from app.models.flight import Flight
 from app.models.route import Route
 from app.models.airline import Airline
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -15,43 +14,25 @@ def get_flights(current_user):
 
 @admin_required
 def get_flight(current_user, flight_id):
-    try:
-        flight = Flight.get_or_404(flight_id)
-        return jsonify(flight.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    flight = Flight.get_or_404(flight_id)
+    return jsonify(flight.to_dict()), 200
 
 
 @admin_required
 def create_flight(current_user):
     body = request.json
-    try:
-        flight = Flight.create(**body)
-        return jsonify(flight.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    flight = Flight.create(**body)
+    return jsonify(flight.to_dict()), 201
 
 
 @admin_required
 def update_flight(current_user, flight_id):
     body = request.json
-    try:
-        updated = Flight.update(flight_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Flight.update(flight_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_flight(current_user, flight_id):
-    try:
-        deleted = Flight.delete_or_404(flight_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Flight.delete_or_404(flight_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/flight_tariff_controller.py
+++ b/server/app/controllers/flight_tariff_controller.py
@@ -4,7 +4,6 @@ from app.models.flight_tariff import FlightTariff
 from app.models.flight import Flight
 from app.models.tariff import Tariff
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -15,43 +14,25 @@ def get_flight_tariffs(current_user):
 
 @admin_required
 def get_flight_tariff(current_user, flight_tariff_id):
-    try:
-        flight_tariff = FlightTariff.get_or_404(flight_tariff_id)
-        return jsonify(flight_tariff.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    flight_tariff = FlightTariff.get_or_404(flight_tariff_id)
+    return jsonify(flight_tariff.to_dict()), 200
 
 
 @admin_required
 def create_flight_tariff(current_user):
     body = request.json
-    try:
-        flight_tariff = FlightTariff.create(**body)
-        return jsonify(flight_tariff.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    flight_tariff = FlightTariff.create(**body)
+    return jsonify(flight_tariff.to_dict()), 201
 
 
 @admin_required
 def update_flight_tariff(current_user, flight_tariff_id):
     body = request.json
-    try:
-        updated = FlightTariff.update(flight_tariff_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = FlightTariff.update(flight_tariff_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_flight_tariff(current_user, flight_tariff_id):
-    try:
-        deleted = FlightTariff.delete_or_404(flight_tariff_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = FlightTariff.delete_or_404(flight_tariff_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/passenger_controller.py
+++ b/server/app/controllers/passenger_controller.py
@@ -2,7 +2,6 @@ from flask import request, jsonify
 
 from app.models.passenger import Passenger
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -13,43 +12,25 @@ def get_passengers(current_user):
 
 @admin_required
 def get_passenger(current_user, passenger_id):
-    try:
-        passenger = Passenger.get_or_404(passenger_id)
-        return jsonify(passenger.to_dict())
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    passenger = Passenger.get_or_404(passenger_id)
+    return jsonify(passenger.to_dict())
 
 
 @admin_required
 def create_passenger(current_user):
     body = request.json
-    try:
-        passenger = Passenger.create(**body)
-        return jsonify(passenger.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    passenger = Passenger.create(**body)
+    return jsonify(passenger.to_dict()), 201
 
 
 @admin_required
 def update_passenger(current_user, passenger_id):
     body = request.json
-    try:
-        updated = Passenger.update(passenger_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Passenger.update(passenger_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_passenger(current_user, passenger_id):
-    try:
-        deleted = Passenger.delete_or_404(passenger_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Passenger.delete_or_404(passenger_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/payment_controller.py
+++ b/server/app/controllers/payment_controller.py
@@ -3,7 +3,6 @@ from flask import request, jsonify
 from app.models.payment import Payment
 from app.models.booking import Booking
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -14,43 +13,25 @@ def get_payments(current_user):
 
 @admin_required
 def get_payment(current_user, payment_id):
-    try:
-        payment = Payment.get_or_404(payment_id)
-        return jsonify(payment.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    payment = Payment.get_or_404(payment_id)
+    return jsonify(payment.to_dict()), 200
 
 
 @admin_required
 def create_payment(current_user):
     body = request.json
-    try:
-        payment = Payment.create(**body)
-        return jsonify(payment.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    payment = Payment.create(**body)
+    return jsonify(payment.to_dict()), 201
 
 
 @admin_required
 def update_payment(current_user, payment_id):
     body = request.json
-    try:
-        updated = Payment.update(payment_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Payment.update(payment_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_payment(current_user, payment_id):
-    try:
-        deleted = Payment.delete_or_404(payment_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Payment.delete_or_404(payment_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/route_controller.py
+++ b/server/app/controllers/route_controller.py
@@ -3,7 +3,6 @@ from flask import request, jsonify
 from app.models.route import Route
 from app.models.airport import Airport
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -14,43 +13,25 @@ def get_routes(current_user):
 
 @admin_required
 def get_route(current_user, route_id):
-    try:
-        route = Route.get_or_404(route_id)
-        return jsonify(route.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    route = Route.get_or_404(route_id)
+    return jsonify(route.to_dict()), 200
 
 
 @admin_required
 def create_route(current_user):
     body = request.json
-    try:
-        route = Route.create(**body)
-        return jsonify(route.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    route = Route.create(**body)
+    return jsonify(route.to_dict()), 201
 
 
 @admin_required
 def update_route(current_user, route_id):
     body = request.json
-    try:
-        updated = Route.update(route_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Route.update(route_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_route(current_user, route_id):
-    try:
-        deleted = Route.delete_or_404(route_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Route.delete_or_404(route_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/seat_controller.py
+++ b/server/app/controllers/seat_controller.py
@@ -3,7 +3,6 @@ from flask import request, jsonify
 from app.models.seat import Seat
 from app.models.tariff import Tariff
 from app.models.booking import Booking
-from app.models._base_model import ModelValidationError, NotFoundError
 from app.middlewares.auth_middleware import admin_required
 
 
@@ -15,43 +14,25 @@ def get_seats(current_user):
 
 @admin_required
 def get_seat(current_user, seat_id):
-    try:
-        seat = Seat.get_or_404(seat_id)
-        return jsonify(seat.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    seat = Seat.get_or_404(seat_id)
+    return jsonify(seat.to_dict()), 200
 
 
 @admin_required
 def create_seat(current_user):
     body = request.json
-    try:
-        seat = Seat.create(**body)
-        return jsonify(seat.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    seat = Seat.create(**body)
+    return jsonify(seat.to_dict()), 201
 
 
 @admin_required
 def update_seat(current_user, seat_id):
     body = request.json
-    try:
-        updated = Seat.update(seat_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Seat.update(seat_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_seat(current_user, seat_id):
-    try:
-        deleted = Seat.delete_or_404(seat_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Seat.delete_or_404(seat_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/tariff_controller.py
+++ b/server/app/controllers/tariff_controller.py
@@ -2,7 +2,7 @@ from flask import request, jsonify
 
 from app.models.tariff import Tariff
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
+
 
 
 @admin_required
@@ -13,44 +13,25 @@ def get_tariffs(current_user):
 
 @admin_required
 def get_tariff(current_user, tariff_id):
-    try:
-        tariff = Tariff.get_or_404(tariff_id)
-        return jsonify(tariff.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    tariff = Tariff.get_or_404(tariff_id)
+    return jsonify(tariff.to_dict()), 200
 
 
 @admin_required
 def create_tariff(current_user):
     body = request.json
-
-    try:
-        tariff = Tariff.create(**body)
-        return jsonify(tariff.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    tariff = Tariff.create(**body)
+    return jsonify(tariff.to_dict()), 201
 
 
 @admin_required
 def update_tariff(current_user, tariff_id):
     body = request.json
-    try:
-        updated = Tariff.update(tariff_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Tariff.update(tariff_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_tariff(current_user, tariff_id):
-    try:
-        deleted = Tariff.delete_or_404(tariff_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Tariff.delete_or_404(tariff_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/ticket_controller.py
+++ b/server/app/controllers/ticket_controller.py
@@ -2,7 +2,6 @@ from flask import request, jsonify
 
 from app.models.ticket import Ticket
 from app.middlewares.auth_middleware import admin_required
-from app.models._base_model import ModelValidationError, NotFoundError
 
 
 @admin_required
@@ -13,43 +12,25 @@ def get_tickets(current_user):
 
 @admin_required
 def get_ticket(current_user, ticket_id):
-    try:
-        ticket = Ticket.get_or_404(ticket_id)
-        return jsonify(ticket.to_dict()), 200
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    ticket = Ticket.get_or_404(ticket_id)
+    return jsonify(ticket.to_dict()), 200
 
 
 @admin_required
 def create_ticket(current_user):
     body = request.json
-    try:
-        ticket = Ticket.create(**body)
-        return jsonify(ticket.to_dict()), 201
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    ticket = Ticket.create(**body)
+    return jsonify(ticket.to_dict()), 201
 
 
 @admin_required
 def update_ticket(current_user, ticket_id):
     body = request.json
-    try:
-        updated = Ticket.update(ticket_id, **body)
-        return jsonify(updated.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    updated = Ticket.update(ticket_id, **body)
+    return jsonify(updated.to_dict())
 
 
 @admin_required
 def delete_ticket(current_user, ticket_id):
-    try:
-        deleted = Ticket.delete_or_404(ticket_id)
-        return jsonify(deleted.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
-    except NotFoundError as e:
-        return jsonify({'message': str(e)}), 404
+    deleted = Ticket.delete_or_404(ticket_id)
+    return jsonify(deleted.to_dict())

--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -2,7 +2,7 @@ from flask import request, jsonify
 
 from app.models.user import User
 from app.middlewares.auth_middleware import admin_required, login_required
-from app.models._base_model import ModelValidationError
+
 
 
 @admin_required
@@ -10,13 +10,10 @@ def create_user(current_user):
     body = request.json
     if 'email' in body and isinstance(body['email'], str):
         body['email'] = body['email'].lower()
-    try:
-        new_user = User.create(**body)
-        if new_user:
-            return jsonify(new_user.to_dict()), 201
-        return jsonify({'message': 'User not created'}), 400
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
+    new_user = User.create(**body)
+    if new_user:
+        return jsonify(new_user.to_dict()), 201
+    return jsonify({'message': 'User not created'}), 400
 
 
 @admin_required
@@ -34,32 +31,23 @@ def get_user(current_user, user_id):
 @admin_required
 def update_user(current_user, user_id):
     body = request.json
-    try:
-        updated_user = User.update(user_id, **body)
-        if updated_user:
-            return jsonify(updated_user.to_dict())
-        return jsonify({'message': 'User not found'}), 404
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
+    updated_user = User.update(user_id, **body)
+    if updated_user:
+        return jsonify(updated_user.to_dict())
+    return jsonify({'message': 'User not found'}), 404
 
 
 @admin_required
 def delete_user(current_user, user_id):
-    try:
-        deleted_user = User.delete_or_404(user_id)
-        return jsonify(deleted_user.to_dict())
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
+    deleted_user = User.delete_or_404(user_id)
+    return jsonify(deleted_user.to_dict())
 
 
 def __set_user_activity(user_id, is_active):
-    try:
-        updated_user = User.update(user_id, is_active=is_active)
-        if updated_user:
-            return jsonify(updated_user.to_dict())
-        return jsonify({'message': 'User not found'}), 404
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
+    updated_user = User.update(user_id, is_active=is_active)
+    if updated_user:
+        return jsonify(updated_user.to_dict())
+    return jsonify({'message': 'User not found'}), 404
 
 
 @admin_required
@@ -79,10 +67,7 @@ def change_password(current_user):
 
     if not password:
         return jsonify({'message': 'Invalid password'}), 404
-    try:
-        updated_user = User.change_password(current_user.id, password)
-        if updated_user:
-            return jsonify(updated_user.to_dict())
-        return jsonify({'message': 'User not found'}), 404
-    except ModelValidationError as e:
-        return jsonify({'errors': e.errors}), 400
+    updated_user = User.change_password(current_user.id, password)
+    if updated_user:
+        return jsonify(updated_user.to_dict())
+    return jsonify({'message': 'User not found'}), 404

--- a/server/app/middlewares/error_handler.py
+++ b/server/app/middlewares/error_handler.py
@@ -1,0 +1,49 @@
+from functools import wraps
+from typing import Callable, Any
+
+from flask import jsonify, current_app
+from werkzeug.exceptions import HTTPException
+
+from app.models._base_model import ModelValidationError, NotFoundError
+
+
+def handle_exceptions(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator to handle common exceptions and return JSON responses."""
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except ModelValidationError as e:
+            return jsonify({'errors': e.errors}), 400
+        except NotFoundError as e:
+            return jsonify({'message': str(e)}), 404
+        except Exception as e:  # unexpected errors
+            if isinstance(e, HTTPException):
+                # Let Flask handle built-in HTTP exceptions
+                raise e
+            if current_app:
+                current_app.logger.exception("Unhandled exception", exc_info=e)
+            return jsonify({'message': 'Internal server error'}), 500
+
+    return wrapper
+
+
+def register_error_handlers(app):
+    """Register global error handlers on the given Flask app."""
+
+    @app.errorhandler(ModelValidationError)
+    def _handle_model_validation_error(e):
+        return jsonify({'errors': e.errors}), 400
+
+    @app.errorhandler(NotFoundError)
+    def _handle_not_found_error(e):
+        return jsonify({'message': str(e)}), 404
+
+    @app.errorhandler(Exception)
+    def _handle_unexpected_error(e):
+        if isinstance(e, HTTPException):
+            return e
+        app.logger.exception("Unhandled exception", exc_info=e)
+        return jsonify({'message': 'Internal server error'}), 500
+


### PR DESCRIPTION
## Summary
- add middleware to globally handle ModelValidationError and NotFoundError
- register error handlers in Flask app
- simplify tariff controller to rely on new middleware
- remove local try/except blocks from all controllers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687fcd083708832fa3aeeeab544c4be5