### PR TITLE
Implement booking passenger logic

### DIFF
--- a/client/src/components/utils.js
+++ b/client/src/components/utils.js
@@ -83,3 +83,24 @@ export const validateDateTime = (value) => {
 		return false;
 	}
 };
+
+export const isDuplicateInBooking = (
+        bookingPassengers,
+        passengers,
+        bookingId,
+        firstName,
+        lastName,
+        birthDate,
+        ignoreId = null
+) => {
+        return bookingPassengers.some((bp) => {
+                if (bp.booking_id !== bookingId || bp.id === ignoreId) return false;
+                const p = passengers.find((pass) => pass.id === bp.passenger_id);
+                return (
+                        p &&
+                        p.first_name === firstName &&
+                        p.last_name === lastName &&
+                        p.birth_date === birthDate
+                );
+        });
+};


### PR DESCRIPTION
## Summary
- enhance PassengerManagement to include booking passenger data
- add booking/country options and join data from booking_passengers
- manage booking passenger and passenger records together
- move duplicate booking check to shared utils

## Testing
- `npm test --prefix client --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd8aeef4c832f8ec2b9015f83aea8