### PR TITLE
Implement search form and results

### DIFF
--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -1,83 +1,16 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
 import Base from './Base';
-import UI_LABELS from '../constants/uiLabels';
+import SearchForm from './search/SearchForm';
 
 const Home = () => {
-	const dispatch = useDispatch();
-
-	return (
-		<Base>
-			<Box sx={{ p: 3, display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '200px' }}>
-				<Box
-					sx={{
-						display: 'flex',
-						background: '#fff',
-						borderRadius: 3,
-						boxShadow: 1,
-						p: 1,
-						gap: 0,
-					}}
-				>
-					{/* Откуда */}
-					<Box sx={{ px: 3, py: 2, minWidth: 150 }}>
-						<Typography variant='h6' sx={{ color: '#b0b0b0', fontSize: 18 }}>
-							{UI_LABELS.HOME.search.from}
-						</Typography>
-					</Box>
-					{/* Куда */}
-					<Box sx={{ px: 3, py: 2, minWidth: 150, borderLeft: '1px solid #e0e0e0' }}>
-						<Typography variant='h6' sx={{ color: '#b0b0b0', fontSize: 18 }}>
-							{UI_LABELS.HOME.search.to}
-						</Typography>
-					</Box>
-					{/* Когда */}
-					<Box sx={{ px: 3, py: 2, minWidth: 150, borderLeft: '1px solid #e0e0e0' }}>
-						<Typography variant='h6' sx={{ color: '#b0b0b0', fontSize: 18 }}>
-							{UI_LABELS.HOME.search.when}
-						</Typography>
-					</Box>
-					{/* Обратно */}
-					<Box sx={{ px: 3, py: 2, minWidth: 150, borderLeft: '1px solid #e0e0e0' }}>
-						<Typography variant='h6' sx={{ color: '#b0b0b0', fontSize: 18 }}>
-							{UI_LABELS.HOME.search.return}
-						</Typography>
-					</Box>
-					{/* Кто летит */}
-					<Box sx={{ px: 3, py: 2, minWidth: 180, borderLeft: '1px solid #e0e0e0' }}>
-						<Typography variant='h6' sx={{ fontSize: 18 }}>
-							{UI_LABELS.HOME.search.passengers}
-						</Typography>
-						<Typography variant='body2' sx={{ color: '#b0b0b0', fontSize: 14 }}>
-							{UI_LABELS.HOME.search.class}
-						</Typography>
-					</Box>
-					{/* Найти билеты */}
-					<Box sx={{ px: 0, py: 1, ml: 2, display: 'flex', alignItems: 'center' }}>
-						<Button
-							variant='contained'
-							sx={{
-								background: '#ff7f2a',
-								color: '#fff',
-								borderRadius: 2,
-								px: 4,
-								py: 2,
-								fontSize: 20,
-								fontWeight: 600,
-								boxShadow: 'none',
-								'&:hover': { background: '#ff6600' },
-							}}
-						>
-							{UI_LABELS.HOME.search.button}
-						</Button>
-					</Box>
-				</Box>
-			</Box>
-		</Base>
-	);
+        return (
+                <Base>
+                        <Box sx={{ p: 3, display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '200px' }}>
+                                <SearchForm />
+                        </Box>
+                </Base>
+        );
 };
 
 export default Home;

--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Box, Typography, Paper } from '@mui/material';
+import Base from '../Base';
+
+const fakeFlights = [
+  {
+    id: 1,
+    airline: 'Avex Air',
+    from: 'SVO',
+    to: 'PKC',
+    departure: '2025-07-24 09:00',
+    arrival: '2025-07-24 16:00',
+    price: 12000,
+  },
+  {
+    id: 2,
+    airline: 'Avex Air',
+    from: 'SVO',
+    to: 'PKC',
+    departure: '2025-07-24 13:00',
+    arrival: '2025-07-24 20:00',
+    price: 13500,
+  },
+];
+
+const Search = () => {
+  const [params] = useSearchParams();
+  const from = params.get('from');
+  const to = params.get('to');
+
+  return (
+    <Base>
+      <Box sx={{ p: 3 }}>
+        <Typography variant="h5" gutterBottom>
+          Результаты поиска
+        </Typography>
+        <Typography variant="subtitle1" gutterBottom>
+          {from && to ? `${from} → ${to}` : ''}
+        </Typography>
+        {fakeFlights.map((f) => (
+          <Paper key={f.id} sx={{ p: 2, mb: 2 }}>
+            <Typography variant="h6">{f.airline}</Typography>
+            <Typography>{`${f.from} - ${f.to}`}</Typography>
+            <Typography>{`${f.departure} - ${f.arrival}`}</Typography>
+            <Typography>Цена: {f.price} ₽</Typography>
+          </Paper>
+        ))}
+      </Box>
+    </Base>
+  );
+};
+
+export default Search;

--- a/client/src/components/search/SearchForm.js
+++ b/client/src/components/search/SearchForm.js
@@ -1,0 +1,186 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  IconButton,
+  Typography,
+  Collapse,
+  Paper,
+  TextField,
+  MenuItem,
+  RadioGroup,
+  FormControlLabel,
+  Radio,
+} from '@mui/material';
+import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
+import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+
+import { getEnumOptions, UI_LABELS, dateLocale } from '../../constants';
+import AIRPORTS from '../../constants/airports';
+
+const seatClassOptions = getEnumOptions('SEAT_CLASS');
+
+const SearchForm = () => {
+  const navigate = useNavigate();
+  const [from, setFrom] = useState(AIRPORTS[0]);
+  const [to, setTo] = useState(AIRPORTS[1]);
+  const [departDate, setDepartDate] = useState(null);
+  const [returnDate, setReturnDate] = useState(null);
+  const [passengers, setPassengers] = useState({ adults: 1, children: 0, infants: 0 });
+  const [seatClass, setSeatClass] = useState(seatClassOptions[0].value);
+  const [showPassengers, setShowPassengers] = useState(false);
+
+  const swapAirports = () => {
+    setFrom(to);
+    setTo(from);
+  };
+
+  const totalPassengers = passengers.adults + passengers.children + passengers.infants;
+  const passengerWord =
+    totalPassengers % 10 === 1 && totalPassengers % 100 !== 11
+      ? 'пассажир'
+      : totalPassengers % 10 >= 2 && totalPassengers % 10 <= 4 &&
+        (totalPassengers % 100 < 10 || totalPassengers % 100 >= 20)
+      ? 'пассажира'
+      : 'пассажиров';
+  const seatClassLabel = seatClassOptions.find((o) => o.value === seatClass)?.label;
+
+  const handlePassengerChange = (key, delta) => {
+    setPassengers((prev) => {
+      const value = Math.min(9, Math.max(key === 'adults' ? 1 : 0, prev[key] + delta));
+      return { ...prev, [key]: value };
+    });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!from || !to || from.code === to.code) return;
+    const params = new URLSearchParams();
+    params.set('from', from.code);
+    params.set('to', to.code);
+    if (departDate) params.set('when', departDate.toISOString().split('T')[0]);
+    if (returnDate) params.set('return', returnDate.toISOString().split('T')[0]);
+    params.set('adults', passengers.adults);
+    params.set('children', passengers.children);
+    params.set('infants', passengers.infants);
+    params.set('class', seatClass);
+    navigate(`/search?${params.toString()}`);
+  };
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        sx={{ display: 'flex', background: '#fff', borderRadius: 3, boxShadow: 1, p: 1 }}
+      >
+        <Box sx={{ px: 2, py: 1 }}>
+          <TextField
+            select
+            label={UI_LABELS.HOME.search.from}
+            value={from.code}
+            onChange={(e) => setFrom(AIRPORTS.find((a) => a.code === e.target.value))}
+            sx={{ minWidth: 160 }}
+          >
+            {AIRPORTS.map((a) => (
+              <MenuItem key={a.code} value={a.code}>
+                {a.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <IconButton aria-label="swap" onClick={swapAirports}>
+            <SwapHorizIcon />
+          </IconButton>
+        </Box>
+        <Box sx={{ px: 2, py: 1 }}>
+          <TextField
+            select
+            label={UI_LABELS.HOME.search.to}
+            value={to.code}
+            onChange={(e) => setTo(AIRPORTS.find((a) => a.code === e.target.value))}
+            sx={{ minWidth: 160 }}
+          >
+            {AIRPORTS.map((a) => (
+              <MenuItem key={a.code} value={a.code}>
+                {a.label}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Box>
+        <Box sx={{ px: 2, py: 1 }}>
+          <DatePicker
+            label={UI_LABELS.HOME.search.when}
+            value={departDate}
+            onChange={(newDate) => setDepartDate(newDate)}
+            slotProps={{ textField: { sx: { minWidth: 150 } } }}
+          />
+        </Box>
+        <Box sx={{ px: 2, py: 1 }}>
+          <DatePicker
+            label={UI_LABELS.HOME.search.return}
+            value={returnDate}
+            onChange={(newDate) => setReturnDate(newDate)}
+            slotProps={{ textField: { sx: { minWidth: 150 } } }}
+          />
+        </Box>
+        <Box sx={{ px: 2, py: 1, position: 'relative' }}>
+          <Button variant="text" onClick={() => setShowPassengers((p) => !p)}>
+            {`${totalPassengers} ${passengerWord}, ${seatClassLabel}`}
+          </Button>
+          <Collapse in={showPassengers} sx={{ position: 'absolute', zIndex: 10, top: '100%', left: 0 }}>
+            <Paper sx={{ p: 2, minWidth: 220 }}>
+              {[
+                { key: 'adults', label: 'Взрослые', desc: '12 лет и старше' },
+                { key: 'children', label: 'Дети', desc: '2–11 лет' },
+                { key: 'infants', label: 'Младенцы', desc: 'до 2 лет' },
+              ].map((row) => (
+                <Box key={row.key} sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+                  <Box>
+                    <Typography>{row.label}</Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {row.desc}
+                    </Typography>
+                  </Box>
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <IconButton
+                      onClick={() => handlePassengerChange(row.key, -1)}
+                      disabled={passengers[row.key] <= (row.key === 'adults' ? 1 : 0)}
+                    >
+                      –
+                    </IconButton>
+                    <Typography>{passengers[row.key]}</Typography>
+                    <IconButton
+                      onClick={() => handlePassengerChange(row.key, 1)}
+                      disabled={passengers[row.key] >= 9}
+                    >
+                      +
+                    </IconButton>
+                  </Box>
+                </Box>
+              ))}
+              <Box sx={{ mt: 2 }}>
+                <Typography gutterBottom>Класс обслуживания</Typography>
+                <RadioGroup value={seatClass} onChange={(e) => setSeatClass(e.target.value)}>
+                  {seatClassOptions.map((o) => (
+                    <FormControlLabel key={o.value} value={o.value} control={<Radio />} label={o.label} />
+                  ))}
+                </RadioGroup>
+              </Box>
+            </Paper>
+          </Collapse>
+        </Box>
+        <Box sx={{ px: 2, py: 1, display: 'flex', alignItems: 'center' }}>
+          <Button type="submit" variant="contained" sx={{ textTransform: 'none' }}>
+            {UI_LABELS.HOME.search.button}
+          </Button>
+        </Box>
+      </Box>
+    </LocalizationProvider>
+  );
+};
+
+export default SearchForm;

--- a/client/src/constants/airports.js
+++ b/client/src/constants/airports.js
@@ -1,0 +1,9 @@
+export const AIRPORTS = [
+  { code: 'VKO', label: 'Москва (Внуково)' },
+  { code: 'SVO', label: 'Москва (Шереметьево)' },
+  { code: 'LED', label: 'Санкт-Петербург (Пулково)' },
+  { code: 'YKS', label: 'Якутск' },
+  { code: 'PKC', label: 'Петропавловск-Камчатский (Елизово)' },
+];
+
+export default AIRPORTS;

--- a/client/src/constants/index.js
+++ b/client/src/constants/index.js
@@ -3,3 +3,4 @@ export { default as ENUM_LABELS, getEnumOptions } from './enumLabels';
 export { default as UI_LABELS } from './uiLabels';
 export { default as VALIDATION_MESSAGES } from './validationMessages';
 export { dateLocale } from './formats';
+export { default as AIRPORTS } from './airports';


### PR DESCRIPTION
## Summary
- add mock airports list
- create search form with inputs for airports, dates, passengers and class
- show fake flights on search results page
- integrate SearchForm into Home
- export airports from constants

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6881f1af81e4832fa446d5c08476840d