### PR TITLE
Implement search features and endpoints

### DIFF
--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -1,34 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 import { Box, Typography, Paper } from '@mui/material';
 import Base from '../Base';
 import { UI_LABELS } from '../../constants';
-
-const fakeFlights = [
-	{
-		id: 1,
-		airline: 'Avex Air',
-		from: 'SVO',
-		to: 'PKC',
-		departure: '2025-07-24 09:00',
-		arrival: '2025-07-24 16:00',
-		price: 12000,
-	},
-	{
-		id: 2,
-		airline: 'Avex Air',
-		from: 'SVO',
-		to: 'PKC',
-		departure: '2025-07-24 13:00',
-		arrival: '2025-07-24 20:00',
-		price: 13500,
-	},
-];
+import { fetchSearchFlights } from '../../redux/actions/search';
 
 const Search = () => {
-	const [params] = useSearchParams();
-	const from = params.get('from');
-	const to = params.get('to');
+        const dispatch = useDispatch();
+        const { flights } = useSelector((state) => state.search);
+        const [params] = useSearchParams();
+        const from = params.get('from');
+        const to = params.get('to');
+
+        useEffect(() => {
+                dispatch(fetchSearchFlights());
+        }, [dispatch]);
 
 	return (
 		<Base>
@@ -39,14 +26,20 @@ const Search = () => {
 				<Typography variant='subtitle1' gutterBottom>
 					{from && to ? UI_LABELS.SEARCH.from_to(from, to) : ''}
 				</Typography>
-				{fakeFlights.map((f) => (
-					<Paper key={f.id} sx={{ p: 2, mb: 2 }}>
-						<Typography variant='h6'>{f.airline}</Typography>
-						<Typography>{`${f.from} - ${f.to}`}</Typography>
-						<Typography>{`${f.departure} - ${f.arrival}`}</Typography>
-						<Typography>{UI_LABELS.SEARCH.flight_details.price}: {f.price}</Typography>
-					</Paper>
-				))}
+                                {flights && flights.length ? (
+                                        flights.map((f) => (
+                                                <Paper key={f.id} sx={{ p: 2, mb: 2 }}>
+                                                        <Typography variant='h6'>{f.airline || f.airline_id}</Typography>
+                                                        <Typography>{`${f.from || f.origin} - ${f.to || f.destination}`}</Typography>
+                                                        <Typography>{`${f.departure || f.scheduled_departure} - ${f.arrival || f.scheduled_arrival}`}</Typography>
+                                                        <Typography>
+                                                                {UI_LABELS.SEARCH.flight_details.price}: {f.price}
+                                                        </Typography>
+                                                </Paper>
+                                        ))
+                                ) : (
+                                        <Typography>{UI_LABELS.SEARCH.no_results}</Typography>
+                                )}
 			</Box>
 		</Base>
 	);

--- a/client/src/components/search/SearchForm.js
+++ b/client/src/components/search/SearchForm.js
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
 import {
 	Box,
 	Button,
@@ -7,10 +8,13 @@ import {
 	Typography,
 	Collapse,
 	Paper,
-	Select,
-	FormControl,
-	InputLabel,
-	MenuItem,
+        Select,
+        FormControl,
+        InputLabel,
+        MenuItem,
+        FormHelperText,
+        Autocomplete,
+        TextField,
 	RadioGroup,
 	FormControlLabel,
 	Radio,
@@ -20,44 +24,59 @@ import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 
 import { getEnumOptions, UI_LABELS, dateLocale } from '../../constants';
-import AIRPORTS from '../../constants/airports';
+import { fetchSearchAirports } from '../../redux/actions/search';
 
 const seatClassOptions = getEnumOptions('SEAT_CLASS');
 
 const SearchForm = () => {
-	const navigate = useNavigate();
-	const [from, setFrom] = useState(AIRPORTS[0]);
-	const [to, setTo] = useState(AIRPORTS[1]);
-	const [departDate, setDepartDate] = useState(null);
-	const [returnDate, setReturnDate] = useState(null);
-	const [passengers, setPassengers] = useState({ adults: 1, children: 0, infants: 0 });
-	const [seatClass, setSeatClass] = useState(seatClassOptions[0].value);
-	const [showPassengers, setShowPassengers] = useState(false);
-	const [error, setError] = useState('');
+        const navigate = useNavigate();
+        const dispatch = useDispatch();
+        const { airports } = useSelector((state) => state.search);
 
-	const passengerCategories = UI_LABELS.HOME.search.passenger_categories.length
-		? UI_LABELS.HOME.search.passenger_categories
-		: [
-				{ key: 'adults', label: 'Взрослые', desc: '12 лет и старше' },
-				{ key: 'children', label: 'Дети', desc: '2–11 лет' },
-				{ key: 'infants', label: 'Младенцы', desc: 'до 2 лет' },
-		  ];
+        const [from, setFrom] = useState(null);
+        const [to, setTo] = useState(null);
+        const [departDate, setDepartDate] = useState(null);
+        const [returnDate, setReturnDate] = useState(null);
+        const [passengers, setPassengers] = useState({ adults: 1, children: 0, infants: 0 });
+        const [seatClass, setSeatClass] = useState(seatClassOptions[0].value);
+        const [showPassengers, setShowPassengers] = useState(false);
+        const [validationErrors, setValidationErrors] = useState({});
+
+        const passengersRef = useRef(null);
+
+        useEffect(() => {
+                dispatch(fetchSearchAirports());
+        }, [dispatch]);
+
+        useEffect(() => {
+                if (airports.length && !from) {
+                        const opts = airports.map((a) => ({ code: a.iata_code, label: `${a.city_name} (${a.name})` }));
+                        setFrom(opts[0] || null);
+                        setTo(opts[1] || null);
+                }
+        }, [airports]);
+
+        useEffect(() => {
+                const handleClick = (e) => {
+                        if (passengersRef.current && !passengersRef.current.contains(e.target)) {
+                                setShowPassengers(false);
+                        }
+                };
+                document.addEventListener('mousedown', handleClick);
+                return () => document.removeEventListener('mousedown', handleClick);
+        }, []);
+
+        const passengerCategories = UI_LABELS.HOME.search.passenger_categories;
 
 	const swapAirports = () => {
 		setFrom(to);
 		setTo(from);
 	};
 
-	const totalPassengers = passengers.adults + passengers.children + passengers.infants;
-	const passengerWord =
-		totalPassengers % 10 === 1 && totalPassengers % 100 !== 11
-			? 'пассажир'
-			: totalPassengers % 10 >= 2 &&
-			  totalPassengers % 10 <= 4 &&
-			  (totalPassengers % 100 < 10 || totalPassengers % 100 >= 20)
-			? 'пассажира'
-			: 'пассажиров';
-	const seatClassLabel = seatClassOptions.find((o) => o.value === seatClass)?.label;
+        const totalPassengers = passengers.adults + passengers.children + passengers.infants;
+        const passengerWord = UI_LABELS.HOME.search.passenger_word(totalPassengers);
+        const seatClassLabel = seatClassOptions.find((o) => o.value === seatClass)?.label;
+        const airportOptions = airports.map((a) => ({ code: a.iata_code, label: `${a.city_name} (${a.name})` }));
 
 	const handlePassengerChange = (key, delta) => {
 		setPassengers((prev) => {
@@ -66,15 +85,25 @@ const SearchForm = () => {
 		});
 	};
 
-	const handleSubmit = (e) => {
-		e.preventDefault();
-		if (!from || !to) return;
-		if (from.code === to.code) {
-			setError('Пункты отправления и назначения не могут совпадать');
-			return;
-		}
-		setError('');
-		const params = new URLSearchParams();
+        const validateForm = () => {
+                const errors = {};
+                if (!from) errors.from = UI_LABELS.MESSAGES.required_field;
+                if (!to) errors.to = UI_LABELS.MESSAGES.required_field;
+                if (from && to && from.code === to.code) {
+                        errors.to = UI_LABELS.HOME.search.errors.same_airport;
+                }
+                if (!departDate) errors.departDate = UI_LABELS.MESSAGES.required_field;
+                if (returnDate && departDate && returnDate < departDate) {
+                        errors.returnDate = UI_LABELS.HOME.search.errors.invalid_return;
+                }
+                setValidationErrors(errors);
+                return Object.keys(errors).length === 0;
+        };
+
+        const handleSubmit = (e) => {
+                e.preventDefault();
+                if (!validateForm()) return;
+                const params = new URLSearchParams();
 		params.set('from', from.code);
 		params.set('to', to.code);
 		if (departDate) params.set('when', departDate.toISOString().split('T')[0]);
@@ -93,62 +122,122 @@ const SearchForm = () => {
 				onSubmit={handleSubmit}
 				sx={{ display: 'flex', background: '#fff', borderRadius: 3, boxShadow: 1, p: 1 }}
 			>
-				<Box sx={{ px: 2, py: 1 }}>
-					<FormControl sx={{ minWidth: 160 }}>
-						<InputLabel id='from-label'>{UI_LABELS.HOME.search.from}</InputLabel>
-						<Select
-							labelId='from-label'
-							value={from.code}
-							label={UI_LABELS.HOME.search.from}
-							onChange={(e) => setFrom(AIRPORTS.find((a) => a.code === e.target.value))}
-						>
-							{AIRPORTS.map((a) => (
-								<MenuItem key={a.code} value={a.code}>
-									{a.label}
-								</MenuItem>
-							))}
-						</Select>
-					</FormControl>
-				</Box>
+                                <Box sx={{ px: 2, py: 1 }}>
+                                        {airportOptions.length > 100 ? (
+                                                <Autocomplete
+                                                        options={airportOptions}
+                                                        value={from}
+                                                        onChange={(e, val) => setFrom(val)}
+                                                        getOptionLabel={(o) => o.label}
+                                                        sx={{ width: 160 }}
+                                                        renderInput={(params) => (
+                                                                <TextField
+                                                                        {...params}
+                                                                        label={UI_LABELS.HOME.search.from}
+                                                                        error={!!validationErrors.from}
+                                                                        helperText={validationErrors.from}
+                                                                />
+                                                        )}
+                                                />
+                                        ) : (
+                                                <FormControl sx={{ width: 160 }} error={!!validationErrors.from}>
+                                                        <InputLabel id='from-label'>{UI_LABELS.HOME.search.from}</InputLabel>
+                                                        <Select
+                                                                labelId='from-label'
+                                                                value={from ? from.code : ''}
+                                                                label={UI_LABELS.HOME.search.from}
+                                                                onChange={(e) =>
+                                                                        setFrom(
+                                                                                airportOptions.find((a) => a.code === e.target.value) || null
+                                                                        )
+                                                                }
+                                                                sx={{ '& .MuiSelect-select': { overflow: 'hidden', textOverflow: 'ellipsis' }, width: 160 }}
+                                                        >
+                                                                {airportOptions.map((a) => (
+                                                                        <MenuItem key={a.code} value={a.code}>
+                                                                                {a.label}
+                                                                        </MenuItem>
+                                                                ))}
+                                                        </Select>
+                                                        {validationErrors.from && <FormHelperText>{validationErrors.from}</FormHelperText>}
+                                                </FormControl>
+                                        )}
+                                </Box>
 				<Box sx={{ display: 'flex', alignItems: 'center' }}>
 					<IconButton aria-label='swap' onClick={swapAirports}>
 						<SwapHorizIcon />
 					</IconButton>
 				</Box>
-				<Box sx={{ px: 2, py: 1 }}>
-					<FormControl sx={{ minWidth: 160 }}>
-						<InputLabel id='to-label'>{UI_LABELS.HOME.search.to}</InputLabel>
-						<Select
-							labelId='to-label'
-							value={to.code}
-							label={UI_LABELS.HOME.search.to}
-							onChange={(e) => setTo(AIRPORTS.find((a) => a.code === e.target.value))}
-						>
-							{AIRPORTS.map((a) => (
-								<MenuItem key={a.code} value={a.code}>
-									{a.label}
-								</MenuItem>
-							))}
-						</Select>
-					</FormControl>
-				</Box>
-				<Box sx={{ px: 2, py: 1 }}>
-					<DatePicker
-						label={UI_LABELS.HOME.search.when}
-						value={departDate}
-						onChange={(newDate) => setDepartDate(newDate)}
-						slotProps={{ textField: { sx: { minWidth: 150 } } }}
-					/>
-				</Box>
-				<Box sx={{ px: 2, py: 1 }}>
-					<DatePicker
-						label={UI_LABELS.HOME.search.return}
-						value={returnDate}
-						onChange={(newDate) => setReturnDate(newDate)}
-						slotProps={{ textField: { sx: { minWidth: 150 } } }}
-					/>
-				</Box>
-				<Box sx={{ px: 2, py: 1, position: 'relative' }}>
+                                <Box sx={{ px: 2, py: 1 }}>
+                                        {airportOptions.length > 100 ? (
+                                                <Autocomplete
+                                                        options={airportOptions}
+                                                        value={to}
+                                                        onChange={(e, val) => setTo(val)}
+                                                        getOptionLabel={(o) => o.label}
+                                                        sx={{ width: 160 }}
+                                                        renderInput={(params) => (
+                                                                <TextField
+                                                                        {...params}
+                                                                        label={UI_LABELS.HOME.search.to}
+                                                                        error={!!validationErrors.to}
+                                                                        helperText={validationErrors.to}
+                                                                />
+                                                        )}
+                                                />
+                                        ) : (
+                                                <FormControl sx={{ width: 160 }} error={!!validationErrors.to}>
+                                                        <InputLabel id='to-label'>{UI_LABELS.HOME.search.to}</InputLabel>
+                                                        <Select
+                                                                labelId='to-label'
+                                                                value={to ? to.code : ''}
+                                                                label={UI_LABELS.HOME.search.to}
+                                                                onChange={(e) =>
+                                                                        setTo(
+                                                                                airportOptions.find((a) => a.code === e.target.value) || null
+                                                                        )
+                                                                }
+                                                                sx={{ '& .MuiSelect-select': { overflow: 'hidden', textOverflow: 'ellipsis' }, width: 160 }}
+                                                        >
+                                                                {airportOptions.map((a) => (
+                                                                        <MenuItem key={a.code} value={a.code}>
+                                                                                {a.label}
+                                                                        </MenuItem>
+                                                                ))}
+                                                        </Select>
+                                                        {validationErrors.to && <FormHelperText>{validationErrors.to}</FormHelperText>}
+                                                </FormControl>
+                                        )}
+                                </Box>
+                                <Box sx={{ px: 2, py: 1 }}>
+                                        <DatePicker
+                                                label={UI_LABELS.HOME.search.when}
+                                                value={departDate}
+                                                onChange={(newDate) => setDepartDate(newDate)}
+                                                slotProps={{
+                                                        textField: {
+                                                                sx: { minWidth: 150 },
+                                                                error: !!validationErrors.departDate,
+                                                                helperText: validationErrors.departDate,
+                                                        },
+                                                }}
+                                        />
+                                </Box>
+                                <Box sx={{ px: 2, py: 1 }}>
+                                        <DatePicker
+                                                label={UI_LABELS.HOME.search.return}
+                                                value={returnDate}
+                                                onChange={(newDate) => setReturnDate(newDate)}
+                                                slotProps={{
+                                                        textField: {
+                                                                sx: { minWidth: 150 },
+                                                                error: !!validationErrors.returnDate,
+                                                                helperText: validationErrors.returnDate,
+                                                        },
+                                                }}
+                                        />
+                                </Box>
+                                <Box sx={{ px: 2, py: 1, position: 'relative' }} ref={passengersRef}>
 					<Button variant='text' onClick={() => setShowPassengers((p) => !p)}>
 						{`${totalPassengers} ${passengerWord}, ${seatClassLabel}`}
 					</Button>
@@ -187,8 +276,10 @@ const SearchForm = () => {
 									</Box>
 								</Box>
 							))}
-							<Box sx={{ mt: 2 }}>
-								<Typography gutterBottom>Класс обслуживания</Typography>
+                                                        <Box sx={{ mt: 2 }}>
+                                                                <Typography gutterBottom>
+                                                                        {UI_LABELS.HOME.search.seat_class_title}
+                                                                </Typography>
 								<RadioGroup value={seatClass} onChange={(e) => setSeatClass(e.target.value)}>
 									{seatClassOptions.map((o) => (
 										<FormControlLabel
@@ -203,21 +294,14 @@ const SearchForm = () => {
 						</Paper>
 					</Collapse>
 				</Box>
-				<Box sx={{ px: 2, py: 1, display: 'flex', alignItems: 'center' }}>
-					<Button type='submit' variant='contained' sx={{ textTransform: 'none' }}>
-						{UI_LABELS.HOME.search.button}
-					</Button>
-				</Box>
-				{error && (
-					<Box sx={{ px: 2, py: 1, width: '100%' }}>
-						<Typography color='error' variant='body2'>
-							{error}
-						</Typography>
-					</Box>
-				)}
-			</Box>
-		</LocalizationProvider>
-	);
+                                <Box sx={{ px: 2, py: 1, display: 'flex', alignItems: 'center' }}>
+                                        <Button type='submit' variant='contained' sx={{ textTransform: 'none' }}>
+                                                {UI_LABELS.HOME.search.button}
+                                        </Button>
+                                </Box>
+                        </Box>
+                </LocalizationProvider>
+        );
 };
 
 export default SearchForm;

--- a/client/src/constants/airports.js
+++ b/client/src/constants/airports.js
@@ -1,9 +1,0 @@
-export const AIRPORTS = [
-	{ code: 'VKO', label: 'Москва (Внуково)' },
-	{ code: 'SVO', label: 'Москва (Шереметьево)' },
-	{ code: 'LED', label: 'Санкт-Петербург (Пулково)' },
-	{ code: 'YKS', label: 'Якутск' },
-	{ code: 'PKC', label: 'Петропавловск-Камчатский (Елизово)' },
-];
-
-export default AIRPORTS;

--- a/client/src/constants/index.js
+++ b/client/src/constants/index.js
@@ -3,4 +3,3 @@ export { default as ENUM_LABELS, getEnumOptions } from './enumLabels';
 export { default as UI_LABELS } from './uiLabels';
 export { default as VALIDATION_MESSAGES } from './validationMessages';
 export { dateLocale } from './formats';
-export { default as AIRPORTS } from './airports';

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -218,22 +218,35 @@ export const UI_LABELS = {
 		password_changed: 'Пароль успешно изменен',
 		passwords_dont_match: 'Пароли не совпадают',
 	},
-	HOME: {
-		search: {
-			from: 'Откуда',
-			to: 'Куда',
-			when: 'Когда',
-			return: 'Обратно',
-			passengers: '1 пассажир',
-			class: 'Эконом',
-			button: 'Найти билеты',
-			passenger_categories: [
-				{ key: 'adults', label: 'Взрослые', desc: '12 лет и старше' },
-				{ key: 'children', label: 'Дети', desc: '2–11 лет' },
-				{ key: 'infants', label: 'Младенцы', desc: 'до 2 лет' },
-			],
-		},
-	},
+        HOME: {
+                search: {
+                        from: 'Откуда',
+                        to: 'Куда',
+                        when: 'Когда',
+                        return: 'Обратно',
+                        passengers: '1 пассажир',
+                        class: 'Эконом',
+                        seat_class_title: 'Класс обслуживания',
+                        button: 'Найти билеты',
+                        passenger_word: (count) =>
+                                count % 10 === 1 && count % 100 !== 11
+                                        ? 'пассажир'
+                                        : count % 10 >= 2 &&
+                                          count % 10 <= 4 &&
+                                          (count % 100 < 10 || count % 100 >= 20)
+                                        ? 'пассажира'
+                                        : 'пассажиров',
+                        passenger_categories: [
+                                { key: 'adults', label: 'Взрослые', desc: '12 лет и старше' },
+                                { key: 'children', label: 'Дети', desc: '2–11 лет' },
+                                { key: 'infants', label: 'Младенцы', desc: 'до 2 лет' },
+                        ],
+                        errors: {
+                                same_airport: 'Пункты отправления и назначения не могут совпадать',
+                                invalid_return: 'Дата возвращения не может быть раньше даты отправления',
+                        },
+                },
+        },
 	SEARCH: {
 		results: 'Результаты поиска',
 		no_results: 'Нет результатов',

--- a/client/src/redux/actions/search.js
+++ b/client/src/redux/actions/search.js
@@ -1,0 +1,21 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { serverApi } from '../../api';
+import { getErrorData } from '../utils';
+
+export const fetchSearchAirports = createAsyncThunk('search/fetchAirports', async (_, { rejectWithValue }) => {
+    try {
+        const res = await serverApi.get('/search/airports');
+        return res.data;
+    } catch (err) {
+        return rejectWithValue(getErrorData(err));
+    }
+});
+
+export const fetchSearchFlights = createAsyncThunk('search/fetchFlights', async (params, { rejectWithValue }) => {
+    try {
+        const res = await serverApi.get('/search/flights', { params });
+        return res.data;
+    } catch (err) {
+        return rejectWithValue(getErrorData(err));
+    }
+});

--- a/client/src/redux/reducers/search.js
+++ b/client/src/redux/reducers/search.js
@@ -1,0 +1,33 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { fetchSearchAirports, fetchSearchFlights } from '../actions/search';
+import { handlePending, handleRejected } from '../utils';
+
+const initialState = {
+    airports: [],
+    flights: [],
+    isLoading: false,
+    errors: null,
+};
+
+const searchSlice = createSlice({
+    name: 'search',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchSearchAirports.pending, handlePending)
+            .addCase(fetchSearchAirports.fulfilled, (state, action) => {
+                state.airports = action.payload;
+                state.isLoading = false;
+            })
+            .addCase(fetchSearchAirports.rejected, handleRejected)
+            .addCase(fetchSearchFlights.pending, handlePending)
+            .addCase(fetchSearchFlights.fulfilled, (state, action) => {
+                state.flights = action.payload;
+                state.isLoading = false;
+            })
+            .addCase(fetchSearchFlights.rejected, handleRejected);
+    },
+});
+
+export default searchSlice.reducer;

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -15,6 +15,7 @@ import userReducer from './reducers/user';
 import bookingReducer from './reducers/booking';
 import passengerReducer from './reducers/passenger';
 import bookingPassengerReducer from './reducers/bookingPassenger';
+import searchReducer from './reducers/search';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const middleware = [thunk];
@@ -31,8 +32,9 @@ const rootReducer = combineReducers({
 	discounts: discountReducer,
 	bookings: bookingReducer,
 	passengers: passengerReducer,
-	bookingPassengers: bookingPassengerReducer,
-	users: userReducer,
+        bookingPassengers: bookingPassengerReducer,
+        users: userReducer,
+        search: searchReducer,
 });
 
 const store = createStore(rootReducer, composeEnhancers(applyMiddleware(...middleware)));

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -26,6 +26,7 @@ from app.controllers.ticket_controller import *
 from app.controllers.payment_controller import *
 from app.controllers.airline_controller import *
 from app.controllers.country_controller import *
+from app.controllers.search_controller import *
 
 
 def __import_models():
@@ -173,6 +174,10 @@ def __create_app(_config_class, _db):
     app.route('/payments/<int:payment_id>', methods=['GET'])(get_payment)
     app.route('/payments/<int:payment_id>', methods=['PUT'])(update_payment)
     app.route('/payments/<int:payment_id>', methods=['DELETE'])(delete_payment)
+
+    # search
+    app.route('/search/airports', methods=['GET'])(search_airports)
+    app.route('/search/flights', methods=['GET'])(search_flights)
 
     # dev
     app.route('/dev/clear/<string:table_name>', methods=['DELETE'])(clear_table)

--- a/server/app/controllers/search_controller.py
+++ b/server/app/controllers/search_controller.py
@@ -1,0 +1,14 @@
+from flask import jsonify
+
+from app.models.airport import Airport
+from app.models.flight import Flight
+
+
+def search_airports():
+    airports = Airport.get_all()
+    return jsonify([airport.to_dict() for airport in airports])
+
+
+def search_flights():
+    flights = Flight.get_all()
+    return jsonify([flight.to_dict() for flight in flights])


### PR DESCRIPTION
## Summary
- add `/search/airports` and `/search/flights` server endpoints
- remove fake airports and flights on client
- fetch airports and flights via Redux
- make search form inputs fixed width and handle long text
- improve search form validation and passenger dropdown
- close passenger selector on outside click
- support many airports with Autocomplete
- update UI labels for search

## Testing
- `pytest -sv server/tests` *(fails: ModuleNotFoundError for `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_e_688230d1a9b0832f8a8562e4d37da7bb