### PR TITLE
Add search params and results cards

### DIFF
--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -1,50 +1,57 @@
 import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { Box, Typography, Paper } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import Base from '../Base';
+import SearchForm from './SearchForm';
+import SearchResultCard from './SearchResultCard';
 import { UI_LABELS } from '../../constants';
 import { fetchSearchFlights } from '../../redux/actions/search';
 
 const Search = () => {
-	const dispatch = useDispatch();
-	const { flights } = useSelector((state) => state.search);
-	const [params] = useSearchParams();
-	const from = params.get('from');
-	const to = params.get('to');
+        const dispatch = useDispatch();
+        const { flights } = useSelector((state) => state.search);
+        const [params] = useSearchParams();
+        const paramObj = Object.fromEntries(params.entries());
+        const paramStr = params.toString();
+        const from = params.get('from');
+        const to = params.get('to');
+        const hasReturn = params.get('return');
 
-	useEffect(() => {
-		dispatch(fetchSearchFlights());
-	}, [dispatch]);
+        useEffect(() => {
+                dispatch(fetchSearchFlights(paramObj));
+        }, [dispatch, paramStr]);
 
-	return (
-		<Base>
-			<Box sx={{ p: 3 }}>
-				<Typography variant='h5' gutterBottom>
-					{UI_LABELS.SEARCH.results}
-				</Typography>
-				<Typography variant='subtitle1' gutterBottom>
-					{from && to ? UI_LABELS.SEARCH.from_to(from, to) : ''}
-				</Typography>
-				{flights && flights.length ? (
-					flights.map((f) => (
-						<Paper key={f.id} sx={{ p: 2, mb: 2 }}>
-							<Typography variant='h6'>{f.airline || f.airline_id}</Typography>
-							<Typography>{`${f.from || f.origin} - ${f.to || f.destination}`}</Typography>
-							<Typography>{`${f.departure || f.scheduled_departure} - ${
-								f.arrival || f.scheduled_arrival
-							}`}</Typography>
-							<Typography>
-								{UI_LABELS.SEARCH.flight_details.price}: {f.price}
-							</Typography>
-						</Paper>
-					))
-				) : (
-					<Typography>{UI_LABELS.SEARCH.no_results}</Typography>
-				)}
-			</Box>
-		</Base>
-	);
+        const grouped = [];
+        if (hasReturn) {
+                for (let i = 0; i < flights.length; i += 2) {
+                        grouped.push({ outbound: flights[i], returnFlight: flights[i + 1] });
+                }
+        } else {
+                for (const f of flights) grouped.push({ outbound: f });
+        }
+
+        return (
+                <Base>
+                        <Box sx={{ p: 3 }}>
+                                <SearchForm initialParams={paramObj} />
+
+                                <Typography variant='h5' gutterBottom sx={{ mt: 3 }}>
+                                        {UI_LABELS.SEARCH.results}
+                                </Typography>
+                                <Typography variant='subtitle1' gutterBottom>
+                                        {from && to ? UI_LABELS.SEARCH.from_to(from, to) : ''}
+                                </Typography>
+                                {grouped && grouped.length ? (
+                                        grouped.map((g, idx) => (
+                                                <SearchResultCard key={idx} outbound={g.outbound} returnFlight={g.returnFlight} />
+                                        ))
+                                ) : (
+                                        <Typography>{UI_LABELS.SEARCH.no_results}</Typography>
+                                )}
+                        </Box>
+                </Base>
+        );
 };
 
 export default Search;

--- a/client/src/components/search/SearchForm.js
+++ b/client/src/components/search/SearchForm.js
@@ -65,14 +65,29 @@ const dateProps = {
 
 const seatClassOptions = getEnumOptions('SEAT_CLASS');
 
-const SearchForm = () => {
-	const navigate = useNavigate();
-	const dispatch = useDispatch();
-	const { airports } = useSelector((state) => state.search);
+const parseDate = (value) => {
+        if (!value) return null;
+        const d = new Date(value);
+        return isNaN(d) ? null : d;
+};
 
-	const [formValues, setFormValues] = useState({ from: '', to: '', departDate: null, returnDate: null });
-	const [passengers, setPassengers] = useState({ adults: 1, children: 0, infants: 0 });
-	const [seatClass, setSeatClass] = useState(seatClassOptions[0].value);
+const SearchForm = ({ initialParams = {} }) => {
+        const navigate = useNavigate();
+        const dispatch = useDispatch();
+        const { airports } = useSelector((state) => state.search);
+
+        const [formValues, setFormValues] = useState({
+                from: initialParams.from || '',
+                to: initialParams.to || '',
+                departDate: parseDate(initialParams.when),
+                returnDate: parseDate(initialParams.return),
+        });
+        const [passengers, setPassengers] = useState({
+                adults: parseInt(initialParams.adults, 10) || 1,
+                children: parseInt(initialParams.children, 10) || 0,
+                infants: parseInt(initialParams.infants, 10) || 0,
+        });
+        const [seatClass, setSeatClass] = useState(initialParams.class || seatClassOptions[0].value);
 	const [showPassengers, setShowPassengers] = useState(false);
 	const [validationErrors, setValidationErrors] = useState({});
 

--- a/client/src/components/search/SearchResultCard.js
+++ b/client/src/components/search/SearchResultCard.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Card, Box, Typography, Button, Divider } from '@mui/material';
+import FlightIcon from '@mui/icons-material/Flight';
+import NightlightRoundIcon from '@mui/icons-material/NightlightRound';
+import HourglassBottomIcon from '@mui/icons-material/HourglassBottom';
+import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
+import ShareIcon from '@mui/icons-material/Share';
+
+const Segment = ({ flight }) => {
+    if (!flight) return null;
+    return (
+        <Box sx={{ mb: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                <Typography variant='subtitle2' sx={{ fontWeight: 600, mr: 1 }}>
+                    {flight.airline || flight.airline_id}
+                </Typography>
+                <NightlightRoundIcon fontSize='small' sx={{ ml: 0.5 }} />
+                <HourglassBottomIcon fontSize='small' sx={{ ml: 0.5 }} />
+                <FavoriteBorderIcon fontSize='small' sx={{ ml: 0.5 }} />
+                <ShareIcon fontSize='small' sx={{ ml: 0.5 }} />
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <Box>
+                    <Typography variant='h6' className='mono-nums'>
+                        {flight.departure_time || flight.scheduled_departure_time || flight.departure || flight.scheduled_departure}
+                    </Typography>
+                    <Typography variant='body2' color='text.secondary'>
+                        {flight.from || flight.origin}
+                    </Typography>
+                </Box>
+                <FlightIcon sx={{ mx: 1 }} />
+                <Box>
+                    <Typography variant='h6' className='mono-nums'>
+                        {flight.arrival_time || flight.scheduled_arrival_time || flight.arrival || flight.scheduled_arrival}
+                    </Typography>
+                    <Typography variant='body2' color='text.secondary'>
+                        {flight.to || flight.destination}
+                    </Typography>
+                </Box>
+            </Box>
+        </Box>
+    );
+};
+
+const SearchResultCard = ({ outbound, returnFlight }) => {
+    const price = outbound.price || outbound.min_price || '--';
+    return (
+        <Card sx={{ display: 'flex', p: 2, mb: 2 }}>
+            <Box sx={{ width: 160, textAlign: 'center', pr: 2, borderRight: '1px solid #eee', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
+                <Typography variant='h5' sx={{ fontWeight: 'bold', mb: 1 }}>
+                    {price}
+                </Typography>
+                <Button
+                    variant='contained'
+                    sx={{
+                        background: '#ff7f2a',
+                        color: '#fff',
+                        borderRadius: 2,
+                        boxShadow: 'none',
+                        textTransform: 'none',
+                        '&:hover': { background: '#ff6600' },
+                    }}
+                >
+                    Обновить
+                </Button>
+            </Box>
+            <Box sx={{ flexGrow: 1, pl: 2 }}>
+                <Segment flight={outbound} />
+                {returnFlight && <Divider sx={{ my: 1 }} />}
+                {returnFlight && <Segment flight={returnFlight} />}
+            </Box>
+        </Card>
+    );
+};
+
+export default SearchResultCard;


### PR DESCRIPTION
## Summary
- show a SearchForm on the search page using params from URL
- fetch flights using URL parameters and display them with SearchResultCard
- add SearchResultCard component
- support initial params in SearchForm

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6882735eb14c832f819bffa3bcb077e5