### PR TITLE
Persist search params and filter airports

### DIFF
--- a/server/app/controllers/search_controller.py
+++ b/server/app/controllers/search_controller.py
@@ -6,12 +6,25 @@ from app.models.route import Route
 from app.models.flight_tariff import FlightTariff
 from app.models.tariff import Tariff
 
+from sqlalchemy import or_
 from app.models.airport import Airport
 from app.models.flight import Flight
 
 
 def search_airports():
-    airports = Airport.get_all()
+    airports = (
+        db.session.query(Airport)
+        .join(
+            Route,
+            or_(
+                Airport.id == Route.origin_airport_id,
+                Airport.id == Route.destination_airport_id,
+            ),
+        )
+        .distinct()
+        .order_by(Airport.name.asc())
+        .all()
+    )
     return jsonify([airport.to_dict() for airport in airports])
 
 

--- a/server/tests/integration/test_search.py
+++ b/server/tests/integration/test_search.py
@@ -13,3 +13,13 @@ def test_search_flights(client, future_flight, economy_flight_tariff, economy_ta
     assert any(f['id'] == future_flight.id for f in data)
     found = next(f for f in data if f['id'] == future_flight.id)
     assert found['price'] == economy_tariff.price
+
+
+def test_search_airports(client, airport_moscow, airport_saint_petersburg, airport_pevek, route_moscow_pevek):
+    resp = client.get('/search/airports')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    codes = {a['iata_code'] for a in data}
+    assert 'SVO' in codes
+    assert 'PWE' in codes
+    assert 'LED' not in codes


### PR DESCRIPTION
## Summary
- save submitted search parameters in local storage
- restore last search on home page using saved data
- filter /search/airports to only return airports with existing routes
- test airport filtering logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6885b4c8cadc832fae2068360a5a3a7b