### PR TITLE
Add flexible date search and flight schedule

### DIFF
--- a/client/src/components/search/Schedule.js
+++ b/client/src/components/search/Schedule.js
@@ -1,0 +1,61 @@
+import React, { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { Box, Typography } from '@mui/material';
+import Base from '../Base';
+import SearchForm from './SearchForm';
+import SearchResultCard from './SearchResultCard';
+import { UI_LABELS } from '../../constants';
+import { fetchSearchFlights } from '../../redux/actions/search';
+import { formatDate } from '../utils';
+
+const Schedule = () => {
+    const dispatch = useDispatch();
+    const { flights } = useSelector((state) => state.search);
+    const [params] = useSearchParams();
+    const paramObj = Object.fromEntries(params.entries());
+    const paramStr = params.toString();
+    const from = params.get('from');
+    const to = params.get('to');
+
+    useEffect(() => {
+        if (from && to) {
+            const p = { ...paramObj };
+            if (!p.when_from) {
+                const today = new Date();
+                const end = new Date();
+                end.setDate(today.getDate() + 30);
+                p.when_from = formatDate(today, 'yyyy-MM-dd');
+                p.when_to = formatDate(end, 'yyyy-MM-dd');
+            }
+            dispatch(fetchSearchFlights(p));
+        }
+    }, [dispatch, paramStr, from, to]);
+
+    useEffect(() => {
+        document.title = UI_LABELS.HOME.schedule.title;
+        return () => { document.title = UI_LABELS.APP_TITLE; };
+    }, []);
+
+    return (
+        <Base maxWidth="xl">
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                <SearchForm initialParams={paramObj} />
+            </Box>
+            <Box sx={{ p: 3 }}>
+                <Typography variant="h4" component="h1" gutterBottom sx={{ mt: 3 }}>
+                    {UI_LABELS.HOME.schedule.title}
+                </Typography>
+                {flights && flights.length ? (
+                    flights.map((f) => (
+                        <SearchResultCard key={f.id} outbound={f} />
+                    ))
+                ) : (
+                    <Typography>{UI_LABELS.SEARCH.no_results}</Typography>
+                )}
+            </Box>
+        </Base>
+    );
+};
+
+export default Schedule;

--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -16,29 +16,46 @@ const Search = () => {
 	const paramStr = params.toString();
 	const from = params.get('from');
 	const to = params.get('to');
-	const depart = params.get('when');
-	const returnDate = params.get('return');
-	const hasReturn = returnDate;
+        const depart = params.get('when');
+        const returnDate = params.get('return');
+        const departFrom = params.get('when_from');
+        const departTo = params.get('when_to');
+        const returnFrom = params.get('return_from');
+        const returnTo = params.get('return_to');
+        const isFlexible = departFrom || departTo || returnFrom || returnTo;
+        const hasReturn = returnDate || returnFrom || returnTo;
 
 	useEffect(() => {
 		dispatch(fetchSearchFlights(paramObj));
 	}, [dispatch, paramStr]);
 
-	useEffect(() => {
-		document.title = UI_LABELS.SEARCH.from_to(from || '', to || '', depart, returnDate || '');
-		return () => {
-			document.title = UI_LABELS.APP_TITLE;
-		};
-	}, [from, to, depart, returnDate]);
+        useEffect(() => {
+                const titleFrom = departFrom || depart || '';
+                const titleTo = returnTo || returnDate || '';
+                document.title = UI_LABELS.SEARCH.from_to(from || '', to || '', titleFrom, titleTo);
+                return () => {
+                        document.title = UI_LABELS.APP_TITLE;
+                };
+        }, [from, to, depart, returnDate, departFrom, returnTo]);
 
-	const grouped = [];
-	if (hasReturn) {
-		for (let i = 0; i < flights.length; i += 2) {
-			grouped.push({ outbound: flights[i], returnFlight: flights[i + 1] });
-		}
-	} else {
-		for (const f of flights) grouped.push({ outbound: f });
-	}
+        const grouped = [];
+        if (isFlexible) {
+                const outbounds = flights.filter((f) => f.direction !== 'return');
+                const returns = flights.filter((f) => f.direction === 'return');
+                for (const out of outbounds) {
+                        if (returns.length) {
+                                for (const r of returns) grouped.push({ outbound: out, returnFlight: r });
+                        } else {
+                                grouped.push({ outbound: out });
+                        }
+                }
+        } else if (hasReturn) {
+                for (let i = 0; i < flights.length; i += 2) {
+                        grouped.push({ outbound: flights[i], returnFlight: flights[i + 1] });
+                }
+        } else {
+                for (const f of flights) grouped.push({ outbound: f });
+        }
 
 	return (
 		<Base maxWidth='xl'>

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -229,7 +229,12 @@ export const UI_LABELS = {
 			return: 'Обратно',
 			passengers: 'Пассажиры',
 			class: 'Эконом',
-			seat_class_title: 'Класс обслуживания',
+                        seat_class_title: 'Класс обслуживания',
+                        date_modes: {
+                                exact: 'Точные даты',
+                                flexible: 'Гибкие даты',
+                        },
+                        schedule_button: 'Расписание',
 			button: 'Найти билеты',
 			passenger_word: (count) =>
 				count % 10 === 1 && count % 100 !== 11

--- a/client/src/routes/PublicRoutes.js
+++ b/client/src/routes/PublicRoutes.js
@@ -4,14 +4,16 @@ import Home from '../components/Home';
 import About from '../components/About';
 import ResetPassword from '../components/auth/ResetPassword';
 import Search from '../components/search/Search';
+import Schedule from '../components/search/Schedule';
 import Cart from '../components/cart/Cart';
 
 const PublicRoutes = () => [
 	{ path: '/', element: <Home /> },
 	{ path: '/about', element: <About /> },
 	{ path: '/reset_password', element: <ResetPassword /> },
-	{ path: '/search', element: <Search /> },
-	{ path: '/cart', element: <Cart />}
+        { path: '/search', element: <Search /> },
+        { path: '/schedule', element: <Schedule /> },
+        { path: '/cart', element: <Cart />}
 ];
 
 export default PublicRoutes;

--- a/server/tests/integration/test_search.py
+++ b/server/tests/integration/test_search.py
@@ -13,3 +13,17 @@ def test_search_flights(client, future_flight, economy_flight_tariff, economy_ta
     assert any(f['id'] == future_flight.id for f in data)
     found = next(f for f in data if f['id'] == future_flight.id)
     assert found['price'] == economy_tariff.price
+
+
+def test_search_flights_range(client, future_flight, economy_flight_tariff):
+    start = (future_flight.scheduled_departure - datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+    end = (future_flight.scheduled_departure + datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+    resp = client.get('/search/flights', query_string={
+        'from': 'SVO',
+        'to': 'PWE',
+        'when_from': start,
+        'when_to': end,
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert any(f['id'] == future_flight.id for f in data)


### PR DESCRIPTION
## Summary
- support flexible date ranges in search API
- add flexible date mode and schedule button on search form
- show combinations of flights for flexible date searches
- implement schedule page
- extend search tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6885b048fec0832fa5edebd2008dee76