### PR TITLE
Enhance flexible dates selection

### DIFF
--- a/client/src/components/utils.js
+++ b/client/src/components/utils.js
@@ -11,6 +11,7 @@ import {
 	Autocomplete,
 } from '@mui/material';
 import { DatePicker, DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { DateRangePicker } from '@mui/x-date-pickers-pro';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 
@@ -26,17 +27,18 @@ import {
 import { dateLocale } from '../constants';
 
 export const FIELD_TYPES = {
-	TEXT: 'text',
-	TEXT_AREA: 'text_area',
-	NUMBER: 'number',
-	EMAIL: 'email',
-	PHONE: 'phone',
-	DATE: 'date',
-	TIME: 'time',
-	DATETIME: 'dateTime',
-	SELECT: 'select',
-	BOOLEAN: 'boolean',
-	CUSTOM: 'custom',
+        TEXT: 'text',
+        TEXT_AREA: 'text_area',
+        NUMBER: 'number',
+        EMAIL: 'email',
+        PHONE: 'phone',
+        DATE: 'date',
+        TIME: 'time',
+        DATETIME: 'dateTime',
+        DATERANGE: 'dateRange',
+        SELECT: 'select',
+        BOOLEAN: 'boolean',
+        CUSTOM: 'custom',
 };
 
 export const createFieldRenderer = (field, defaultProps = {}) => {
@@ -193,11 +195,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				);
 			}
 
-			case FIELD_TYPES.DATETIME: {
-				const { value, onChange, fullWidth, error, helperText, sx } = allProps;
-				return (
-					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
-						<DateTimePicker
+                        case FIELD_TYPES.DATETIME: {
+                                const { value, onChange, fullWidth, error, helperText, sx } = allProps;
+                                return (
+                                        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
+                                                <DateTimePicker
 							label={field.label}
 							value={value ? new Date(value) : null}
 							onChange={(dateTime) => onChange(dateTime)}
@@ -210,10 +212,32 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 									sx,
 								},
 							}}
-						/>
-					</LocalizationProvider>
-				);
-			}
+                                                />
+                                        </LocalizationProvider>
+                                );
+                        }
+
+                        case FIELD_TYPES.DATERANGE: {
+                                const { value = [null, null], onChange, fullWidth, error, helperText, sx, minDate } = allProps;
+                                return (
+                                        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
+                                                <DateRangePicker
+                                                        value={value}
+                                                        onChange={(range) => onChange(range)}
+                                                        minDate={minDate}
+                                                        format={field.dateFormat || DATE_FORMAT}
+                                                        slotProps={{
+                                                                textField: {
+                                                                        fullWidth,
+                                                                        error,
+                                                                        helperText: error ? helperText : '',
+                                                                        sx,
+                                                                },
+                                                        }}
+                                                />
+                                        </LocalizationProvider>
+                                );
+                        }
 
 			case FIELD_TYPES.SELECT: {
 				const {


### PR DESCRIPTION
## Summary
- add new `DATERANGE` field type and support `DateRangePicker`
- refactor search form to use date range pickers when flexible dates are selected
- toggle date mode with a switch and move schedule button under direction fields
- validate flexible date ranges

## Testing
- `docker-compose run --rm server-app pytest -sv tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885df8c9d94832fa7cbee1dbdba8321