### PR TITLE
Implement timezone upload loader and update airport upload

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -105,6 +105,8 @@ def __create_app(_config_class, _db):
     app.route('/timezones/<int:timezone_id>', methods=['GET'])(get_timezone)
     app.route('/timezones/<int:timezone_id>', methods=['PUT'])(update_timezone)
     app.route('/timezones/<int:timezone_id>', methods=['DELETE'])(delete_timezone)
+    app.route('/timezones/upload', methods=['POST'])(upload_timezone)
+    app.route('/timezones/template', methods=['GET'])(get_timezone_template)
 
     # routes
     app.route('/routes', methods=['GET'])(get_routes)

--- a/server/app/models/timezone.py
+++ b/server/app/models/timezone.py
@@ -1,5 +1,8 @@
+from sqlalchemy.orm import Session
+
 from app.database import db
 from app.models._base_model import BaseModel
+from app.utils.xlsx import parse_xlsx, generate_xlsx_template
 
 
 class Timezone(BaseModel):
@@ -12,3 +15,40 @@ class Timezone(BaseModel):
             'id': self.id,
             'name': self.name,
         }
+
+    upload_fields = {
+        'name': 'Часовой пояс',
+    }
+
+    @classmethod
+    def get_all(cls):
+        return super().get_all(sort_by='name', descending=False)
+
+    @classmethod
+    def get_xlsx_template(cls):
+        return generate_xlsx_template(cls.upload_fields)
+
+    @classmethod
+    def upload_from_file(cls, file, session: Session | None = None):
+        session = session or db.session
+        rows = parse_xlsx(
+            file,
+            cls.upload_fields,
+            required_fields=['name'],
+        )
+
+        timezones = []
+        error_rows = []
+
+        for row in rows:
+            if not row.get('error'):
+                try:
+                    tz = cls.create(session, **row)
+                    timezones.append(tz)
+                except Exception as e:
+                    row['error'] = str(e)
+
+            if row.get('error'):
+                error_rows.append(row)
+
+        return timezones, error_rows

--- a/server/tests/integration/test_upload.py
+++ b/server/tests/integration/test_upload.py
@@ -13,6 +13,17 @@ def create_country_file():
     return bio
 
 
+def create_timezone_file():
+    wb = Workbook()
+    ws = wb.active
+    ws.append(['Часовой пояс'])
+    ws.append(['Europe/Moscow'])
+    bio = BytesIO()
+    wb.save(bio)
+    bio.seek(0)
+    return bio
+
+
 def test_country_template(client, admin_headers):
     resp = client.get('/countries/template', headers=admin_headers)
     assert resp.status_code == 200
@@ -26,3 +37,18 @@ def test_country_upload(client, admin_headers):
     assert resp.status_code == 201
     assert resp.is_json
     assert resp.get_json()['message'] == 'Countries created successfully'
+
+
+def test_timezone_template(client, admin_headers):
+    resp = client.get('/timezones/template', headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.mimetype == 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+
+def test_timezone_upload(client, admin_headers):
+    file_obj = create_timezone_file()
+    data = {'file': (file_obj, 'timezones.xlsx')}
+    resp = client.post('/timezones/upload', headers=admin_headers, content_type='multipart/form-data', data=data)
+    assert resp.status_code == 201
+    assert resp.is_json
+    assert resp.get_json()['message'] == 'Timezones created successfully'


### PR DESCRIPTION
## Summary
- add XLSX loader support for `Timezone`
- enable timezone template and upload endpoints
- expose timezone upload routes in the Flask app
- include timezone upload tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_688b943b7530832f922f4b8f343421bc