### PR TITLE
Refactor schedule display into sortable tables by direction

### DIFF
--- a/client/src/components/search/Schedule.js
+++ b/client/src/components/search/Schedule.js
@@ -1,22 +1,24 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Box, Typography } from '@mui/material';
 import Base from '../Base';
 import SearchForm from './SearchForm';
-import SearchResultCard from './SearchResultCard';
+import ScheduleTable from './ScheduleTable';
 import { UI_LABELS } from '../../constants';
 import { fetchScheduleFlights } from '../../redux/actions/search';
+import { fetchAirlines } from '../../redux/actions/airline';
 import { formatDate } from '../utils';
 
 const Schedule = () => {
-	const dispatch = useDispatch();
-	const { flights } = useSelector((state) => state.search);
-	const [params] = useSearchParams();
-	const paramObj = Object.fromEntries(params.entries());
-	const paramStr = params.toString();
-	const from = params.get('from');
-	const to = params.get('to');
+        const dispatch = useDispatch();
+        const { flights } = useSelector((state) => state.search);
+        const { airlines } = useSelector((state) => state.airlines);
+        const [params] = useSearchParams();
+        const paramObj = Object.fromEntries(params.entries());
+        const paramStr = params.toString();
+        const from = params.get('from');
+        const to = params.get('to');
 
 	useEffect(() => {
 		if (from && to) {
@@ -27,30 +29,58 @@ const Schedule = () => {
 		}
 	}, [dispatch, paramStr, from, to]);
 
-	useEffect(() => {
-		document.title = UI_LABELS.SCHEDULE.from_to(from || '', to || '');
-		return () => {
-			document.title = UI_LABELS.APP_TITLE;
-		};
-	}, [from, to]);
+        useEffect(() => {
+                document.title = UI_LABELS.SCHEDULE.from_to(from || '', to || '');
+                return () => {
+                        document.title = UI_LABELS.APP_TITLE;
+                };
+        }, [from, to]);
+
+        useEffect(() => {
+                dispatch(fetchAirlines());
+        }, [dispatch]);
+
+        const outboundFlights = useMemo(
+                () => flights.filter((f) => f.direction === 'outbound'),
+                [flights],
+        );
+
+        const returnFlights = useMemo(
+                () => flights.filter((f) => f.direction === 'return'),
+                [flights],
+        );
 
 	return (
 		<Base maxWidth='xl'>
 			<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
 				<SearchForm initialParams={paramObj} />
 			</Box>
-			<Box sx={{ p: 3 }}>
-				<Typography variant='h4' component='h1' gutterBottom sx={{ mt: 3 }}>
-					{UI_LABELS.SCHEDULE.title}
-				</Typography>
-				{flights && flights.length ? (
-					flights.map((f) => <SearchResultCard key={f.id} outbound={f} />)
-				) : (
-					<Typography>{UI_LABELS.SCHEDULE.no_results}</Typography>
-				)}
-			</Box>
-		</Base>
-	);
+                        <Box sx={{ p: 3 }}>
+                                <Typography variant='subtitle1'>
+                                        {UI_LABELS.SCHEDULE.from_to(from || '', to || '')}
+                                </Typography>
+                                <Typography variant='h4' component='h1' gutterBottom sx={{ mt: 3 }}>
+                                        {UI_LABELS.SCHEDULE.title}
+                                </Typography>
+                                <Typography variant='h5' sx={{ mt: 3, mb: 1 }}>
+                                        {UI_LABELS.SCHEDULE.outbound}
+                                </Typography>
+                                {outboundFlights.length ? (
+                                        <ScheduleTable flights={outboundFlights} airlines={airlines} />
+                                ) : (
+                                        <Typography>{UI_LABELS.SCHEDULE.no_results}</Typography>
+                                )}
+                                <Typography variant='h5' sx={{ mt: 4, mb: 1 }}>
+                                        {UI_LABELS.SCHEDULE.return}
+                                </Typography>
+                                {returnFlights.length ? (
+                                        <ScheduleTable flights={returnFlights} airlines={airlines} />
+                                ) : (
+                                        <Typography>{UI_LABELS.SCHEDULE.no_results}</Typography>
+                                )}
+                        </Box>
+                </Base>
+        );
 };
 
 export default Schedule;

--- a/client/src/components/search/ScheduleTable.js
+++ b/client/src/components/search/ScheduleTable.js
@@ -1,0 +1,141 @@
+import React, { useMemo, useState } from 'react';
+import {
+        Box,
+        Table,
+        TableBody,
+        TableCell,
+        TableContainer,
+        TableHead,
+        TableRow,
+        TableSortLabel,
+        TextField,
+        Paper,
+} from '@mui/material';
+import { FIELD_LABELS, ENUM_LABELS, UI_LABELS } from '../../constants';
+import { formatDate, formatTime } from '../utils';
+
+function descendingComparator(a, b, orderBy) {
+        if (b[orderBy] < a[orderBy]) {
+                return -1;
+        }
+        if (b[orderBy] > a[orderBy]) {
+                return 1;
+        }
+        return 0;
+}
+
+function getComparator(order, orderBy) {
+        return order === 'desc'
+                ? (a, b) => descendingComparator(a, b, orderBy)
+                : (a, b) => -descendingComparator(a, b, orderBy);
+}
+
+function stableSort(array, comparator) {
+        const stabilized = array.map((el, index) => [el, index]);
+        stabilized.sort((a, b) => {
+                const order = comparator(a[0], b[0]);
+                if (order !== 0) return order;
+                return a[1] - b[1];
+        });
+        return stabilized.map((el) => el[0]);
+}
+
+const ScheduleTable = ({ flights, airlines }) => {
+        const [order, setOrder] = useState('asc');
+        const [orderBy, setOrderBy] = useState('date');
+        const [filter, setFilter] = useState('');
+
+        const rows = useMemo(
+                () =>
+                        flights.map((f) => {
+                                const airline = airlines.find((a) => a.id === f.airline_id);
+                                return {
+                                        id: f.id,
+                                        date: formatDate(f.scheduled_departure, 'dd.MM.yyyy'),
+                                        departure: formatTime(f.scheduled_departure_time),
+                                        arrival: formatTime(f.scheduled_arrival_time),
+                                        airline: airline ? airline.name : f.airline_id,
+                                        price: f.min_price
+                                                ? `${f.min_price} ${
+                                                          ENUM_LABELS.CURRENCY_SYMBOL[f.currency] || ''
+                                                  }`
+                                                : '',
+                                };
+                        }),
+                [flights, airlines],
+        );
+
+        const handleRequestSort = (property) => {
+                const isAsc = orderBy === property && order === 'asc';
+                setOrder(isAsc ? 'desc' : 'asc');
+                setOrderBy(property);
+        };
+
+        const filteredRows = useMemo(() => {
+                if (!filter) return rows;
+                const lower = filter.toLowerCase();
+                return rows.filter((r) =>
+                        Object.values(r).some((v) => String(v).toLowerCase().includes(lower)),
+                );
+        }, [rows, filter]);
+
+        const sortedRows = useMemo(
+                () => stableSort(filteredRows, getComparator(order, orderBy)),
+                [filteredRows, order, orderBy],
+        );
+
+        const headCells = [
+                { id: 'date', label: FIELD_LABELS.FLIGHT.scheduled_departure },
+                { id: 'departure', label: FIELD_LABELS.FLIGHT.scheduled_departure_time },
+                { id: 'arrival', label: FIELD_LABELS.FLIGHT.scheduled_arrival_time },
+                { id: 'airline', label: FIELD_LABELS.FLIGHT.airline_id },
+                { id: 'price', label: FIELD_LABELS.TARIFF.price },
+        ];
+
+        return (
+                <Box>
+                        <TextField
+                                size='small'
+                                label={UI_LABELS.SCHEDULE.filter}
+                                value={filter}
+                                onChange={(e) => setFilter(e.target.value)}
+                                sx={{ mb: 2 }}
+                        />
+                        <TableContainer component={Paper}>
+                                <Table size='small'>
+                                        <TableHead>
+                                                <TableRow>
+                                                        {headCells.map((headCell) => (
+                                                                <TableCell
+                                                                        key={headCell.id}
+                                                                        sortDirection={orderBy === headCell.id ? order : false}
+                                                                >
+                                                                        <TableSortLabel
+                                                                                active={orderBy === headCell.id}
+                                                                                direction={orderBy === headCell.id ? order : 'asc'}
+                                                                                onClick={() => handleRequestSort(headCell.id)}
+                                                                        >
+                                                                                {headCell.label}
+                                                                        </TableSortLabel>
+                                                                </TableCell>
+                                                        ))}
+                                                </TableRow>
+                                        </TableHead>
+                                        <TableBody>
+                                                {sortedRows.map((row) => (
+                                                        <TableRow key={row.id}>
+                                                                <TableCell>{row.date}</TableCell>
+                                                                <TableCell>{row.departure}</TableCell>
+                                                                <TableCell>{row.arrival}</TableCell>
+                                                                <TableCell>{row.airline}</TableCell>
+                                                                <TableCell>{row.price}</TableCell>
+                                                        </TableRow>
+                                                ))}
+                                        </TableBody>
+                                </Table>
+                        </TableContainer>
+                </Box>
+        );
+};
+
+export default ScheduleTable;

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -281,14 +281,17 @@ export const UI_LABELS = {
 			add_passenger: 'Добавить пассажира',
 		},
 	},
-	SCHEDULE: {
-		title: 'Расписание рейсов',
-		results: 'Результаты поиска',
-		no_results: 'Рейсы не найдены',
-		from_to: (from, to) => {
-			return `${from} → ${to}`;
-		},
-	},
+        SCHEDULE: {
+                title: 'Расписание рейсов',
+                results: 'Результаты поиска',
+                no_results: 'Рейсы не найдены',
+                outbound: 'Выбранное направление',
+                return: 'Обратное направление',
+                filter: 'Фильтр',
+                from_to: (from, to) => {
+                        return `${from} → ${to}`;
+                },
+        },
 	SEARCH: {
 		results: 'Результаты поиска',
 		no_results: 'Рейсы не найдены',


### PR DESCRIPTION
## Summary
- Split schedule page into outbound and return sections with headings and direction info
- Introduced `ScheduleTable` component showing flights in sortable, filterable table
- Added schedule-specific labels for sections and filter

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest -q` *(fails: SQLALCHEMY_DATABASE_URI or SQLALCHEMY_BINDS must be set)*

------
https://chatgpt.com/codex/tasks/task_e_688e6e8d0778832fbeb953768bcd3d1d