### PR TITLE
Annotate relationships and leverage backrefs

### DIFF
--- a/server/app/models/airline.py
+++ b/server/app/models/airline.py
@@ -1,9 +1,14 @@
+from typing import List, TYPE_CHECKING
+
 from sqlalchemy.orm import Session, Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
 from app.models.country import Country
 from app.utils.xlsx import parse_xlsx, generate_xlsx_template
+
+if TYPE_CHECKING:
+    from app.models.flight import Flight
 
 
 class Airline(BaseModel):
@@ -14,7 +19,8 @@ class Airline(BaseModel):
     name = db.Column(db.String, nullable=False)
     country_id = db.Column(db.Integer, db.ForeignKey('countries.id', ondelete='RESTRICT'), nullable=False)
 
-    country: Mapped[Country] = db.relationship('Country', backref=db.backref('airlines', lazy=True))
+    country: Mapped[Country] = db.relationship('Country', back_populates='airlines')
+    flights: Mapped[List['Flight']] = db.relationship('Flight', back_populates='airline', lazy='dynamic', cascade='all, delete-orphan')
 
     def to_dict(self):
         return {

--- a/server/app/models/airport.py
+++ b/server/app/models/airport.py
@@ -1,9 +1,13 @@
+from typing import List, TYPE_CHECKING
 from sqlalchemy.orm import Session, Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
 from app.models.country import Country
 from app.models.timezone import Timezone
+
+if TYPE_CHECKING:
+    from app.models.route import Route
 
 from app.utils.xlsx import parse_xlsx, generate_xlsx_template
 
@@ -21,8 +25,14 @@ class Airport(BaseModel):
     country_id = db.Column(db.Integer, db.ForeignKey('countries.id', ondelete='RESTRICT'), nullable=False)
     timezone_id = db.Column(db.Integer, db.ForeignKey('timezones.id', ondelete='RESTRICT'), nullable=True)
 
-    country: Mapped[Country] = db.relationship('Country', backref=db.backref('airports', lazy=True))
-    timezone: Mapped[Timezone] = db.relationship('Timezone', backref=db.backref('airports', lazy=True))
+    country: Mapped[Country] = db.relationship('Country', back_populates='airports')
+    timezone: Mapped[Timezone] = db.relationship('Timezone', back_populates='airports')
+    origin_routes: Mapped[List['Route']] = db.relationship(
+        'Route', back_populates='origin_airport', foreign_keys='Route.origin_airport_id', lazy='dynamic'
+    )
+    destination_routes: Mapped[List['Route']] = db.relationship(
+        'Route', back_populates='destination_airport', foreign_keys='Route.destination_airport_id', lazy='dynamic'
+    )
 
     def to_dict(self):
         return {

--- a/server/app/models/booking.py
+++ b/server/app/models/booking.py
@@ -1,10 +1,17 @@
 import random
 import string
-from sqlalchemy.orm import Session
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Session, Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
 from app.config import Config
+
+if TYPE_CHECKING:
+    from app.models.payment import Payment
+    from app.models.ticket import Ticket
+    from app.models.seat import Seat
+    from app.models.booking_passenger import BookingPassenger
 
 
 class Booking(BaseModel):
@@ -24,9 +31,18 @@ class Booking(BaseModel):
     final_price = db.Column(db.Float, nullable=False)
 
     # Relationships
-    payments = db.relationship('Payment', backref=db.backref('booking', lazy=True), lazy='dynamic', cascade='all, delete-orphan')
-    tickets = db.relationship('Ticket', backref=db.backref('booking', lazy=True), lazy='dynamic', cascade='all, delete-orphan')
-    seats = db.relationship('Seat', backref=db.backref('booking', lazy=True),lazy='dynamic', cascade='save-update, merge')
+    payments: Mapped[List['Payment']] = db.relationship(
+        'Payment', back_populates='booking', lazy='dynamic', cascade='all, delete-orphan'
+    )
+    tickets: Mapped[List['Ticket']] = db.relationship(
+        'Ticket', back_populates='booking', lazy='dynamic', cascade='all, delete-orphan'
+    )
+    seats: Mapped[List['Seat']] = db.relationship(
+        'Seat', back_populates='booking', lazy='dynamic', cascade='save-update, merge'
+    )
+    booking_passengers: Mapped[List['BookingPassenger']] = db.relationship(
+        'BookingPassenger', back_populates='booking', lazy='dynamic', cascade='all, delete-orphan'
+    )
 
     def to_dict(self):
         return {

--- a/server/app/models/booking_passenger.py
+++ b/server/app/models/booking_passenger.py
@@ -1,6 +1,13 @@
+from typing import TYPE_CHECKING
+from sqlalchemy.orm import Mapped
+
 from app.database import db
 from app.models._base_model import BaseModel
 from app.models._base_model import ModelValidationError
+
+if TYPE_CHECKING:
+    from app.models.booking import Booking
+    from app.models.passenger import Passenger
 
 class BookingPassenger(BaseModel):
     __tablename__ = 'booking_passengers'
@@ -8,6 +15,9 @@ class BookingPassenger(BaseModel):
     booking_id = db.Column(db.Integer, db.ForeignKey('bookings.id'), nullable=False)
     passenger_id = db.Column(db.Integer, db.ForeignKey('passengers.id'), nullable=False)
     is_contact = db.Column(db.Boolean, default=False, nullable=False)
+
+    booking: Mapped['Booking'] = db.relationship('Booking', back_populates='booking_passengers')
+    passenger: Mapped['Passenger'] = db.relationship('Passenger', back_populates='booking_passengers')
 
     __table_args__ = (
         db.UniqueConstraint(

--- a/server/app/models/country.py
+++ b/server/app/models/country.py
@@ -1,8 +1,14 @@
-from sqlalchemy.orm import Session
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Session, Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
 from app.utils.xlsx import parse_xlsx, generate_xlsx_template
+
+if TYPE_CHECKING:
+    from app.models.airline import Airline
+    from app.models.airport import Airport
+    from app.models.passenger import Passenger
 
 
 class Country(BaseModel):
@@ -12,6 +18,10 @@ class Country(BaseModel):
     name_en = db.Column(db.String, nullable=True)
     code_a2 = db.Column(db.String(2), nullable=False, unique=True)
     code_a3 = db.Column(db.String(3), nullable=False, unique=True)
+
+    airlines: Mapped[List['Airline']] = db.relationship('Airline', back_populates='country', lazy='dynamic')
+    airports: Mapped[List['Airport']] = db.relationship('Airport', back_populates='country', lazy='dynamic')
+    passengers: Mapped[List['Passenger']] = db.relationship('Passenger', back_populates='citizenship', lazy='dynamic')
 
     def to_dict(self):
         return {

--- a/server/app/models/discount.py
+++ b/server/app/models/discount.py
@@ -1,7 +1,13 @@
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Mapped
+
 from app.database import db
 from app.models._base_model import BaseModel
 
 from app.config import Config
+
+if TYPE_CHECKING:
+    from app.models.ticket import Ticket
 
 class Discount(BaseModel):
     __tablename__ = 'discounts'
@@ -9,6 +15,8 @@ class Discount(BaseModel):
     discount_name = db.Column(db.String, unique=True, nullable=False)
     discount_type = db.Column(db.Enum(Config.DISCOUNT_TYPE), nullable=False)
     percentage_value = db.Column(db.Float, nullable=False)
+
+    tickets: Mapped[List['Ticket']] = db.relationship('Ticket', back_populates='discount', lazy='dynamic')
 
     def to_dict(self):
         return {

--- a/server/app/models/flight_tariff.py
+++ b/server/app/models/flight_tariff.py
@@ -1,6 +1,13 @@
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Mapped
+
 from app.database import db
 from app.models._base_model import BaseModel, ModelValidationError
 from app.models.tariff import Tariff
+
+if TYPE_CHECKING:
+    from app.models.flight import Flight
+    from app.models.seat import Seat
 
 
 class FlightTariff(BaseModel):
@@ -9,6 +16,10 @@ class FlightTariff(BaseModel):
     flight_id = db.Column(db.Integer, db.ForeignKey('flights.id', ondelete='CASCADE'), nullable=False)
     tariff_id = db.Column(db.Integer, db.ForeignKey('tariffs.id', ondelete='CASCADE'), nullable=False)
     seats_number = db.Column(db.Integer, nullable=False)
+
+    flight: Mapped['Flight'] = db.relationship('Flight', back_populates='tariffs')
+    tariff: Mapped[Tariff] = db.relationship('Tariff', back_populates='flight_tariffs')
+    seats: Mapped[List['Seat']] = db.relationship('Seat', back_populates='tariff', lazy='dynamic', cascade='all, delete-orphan')
 
     @classmethod
     def __check_seat_class_unique(cls, session, flight_id, tariff_id, instance_id=None):

--- a/server/app/models/passenger.py
+++ b/server/app/models/passenger.py
@@ -1,10 +1,15 @@
 import datetime
+from typing import List, TYPE_CHECKING
 from sqlalchemy.orm import Session, Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
 from app.models.country import Country
 from app.config import Config
+
+if TYPE_CHECKING:
+    from app.models.booking_passenger import BookingPassenger
+    from app.models.ticket import Ticket
 
 
 class Passenger(BaseModel):
@@ -20,7 +25,13 @@ class Passenger(BaseModel):
     document_expiry_date = db.Column(db.Date, nullable=True)
     citizenship_id = db.Column(db.Integer, db.ForeignKey('countries.id'), nullable=False)
 
-    citizenship: Mapped[Country] = db.relationship('Country', backref=db.backref('passengers', lazy=True))
+    citizenship: Mapped[Country] = db.relationship('Country', back_populates='passengers')
+    booking_passengers: Mapped[List['BookingPassenger']] = db.relationship(
+        'BookingPassenger', back_populates='passenger', lazy='dynamic', cascade='all, delete-orphan'
+    )
+    tickets: Mapped[List['Ticket']] = db.relationship(
+        'Ticket', back_populates='passenger', lazy='dynamic', cascade='all, delete-orphan'
+    )
 
     __table_args__ = (
         db.UniqueConstraint(

--- a/server/app/models/password_reset_token.py
+++ b/server/app/models/password_reset_token.py
@@ -1,8 +1,13 @@
 import secrets
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+from sqlalchemy.orm import Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.user import User
 
 
 class PasswordResetToken(BaseModel):
@@ -13,7 +18,7 @@ class PasswordResetToken(BaseModel):
     expires_at = db.Column(db.DateTime, nullable=False)
     used = db.Column(db.Boolean, default=False, nullable=False)
 
-    user = db.relationship('User')
+    user: Mapped['User'] = db.relationship('User', back_populates='reset_tokens')
 
     @classmethod
     def create_token(cls, user, expires_in_hours=1):

--- a/server/app/models/payment.py
+++ b/server/app/models/payment.py
@@ -1,6 +1,12 @@
+from typing import TYPE_CHECKING
+from sqlalchemy.orm import Mapped
+
 from app.database import db
 from app.models._base_model import BaseModel
 from app.config import Config
+
+if TYPE_CHECKING:
+    from app.models.booking import Booking
 
 
 class Payment(BaseModel):
@@ -9,6 +15,8 @@ class Payment(BaseModel):
     booking_id = db.Column(db.Integer, db.ForeignKey('bookings.id', ondelete='CASCADE'), nullable=False)
     payment_method = db.Column(db.Enum(Config.PAYMENT_METHOD), nullable=False)
     payment_status = db.Column(db.Enum(Config.PAYMENT_STATUS), nullable=False, default=Config.DEFAULT_PAYMENT_STATUS)
+
+    booking: Mapped['Booking'] = db.relationship('Booking', back_populates='payments')
 
     def to_dict(self):
         return {

--- a/server/app/models/route.py
+++ b/server/app/models/route.py
@@ -1,6 +1,12 @@
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Mapped
+
 from app.database import db
 from app.models._base_model import BaseModel
 from app.models.airport import Airport
+
+if TYPE_CHECKING:
+    from app.models.flight import Flight
 
 
 class Route(BaseModel):
@@ -9,8 +15,13 @@ class Route(BaseModel):
     origin_airport_id = db.Column(db.Integer, db.ForeignKey('airports.id', ondelete='RESTRICT'), nullable=False)
     destination_airport_id = db.Column(db.Integer, db.ForeignKey('airports.id', ondelete='RESTRICT'), nullable=False)
 
-    origin_airport: Airport = db.relationship('Airport', foreign_keys=[origin_airport_id], backref=db.backref('origin_routes', lazy=True))
-    destination_airport: Airport = db.relationship('Airport', foreign_keys=[destination_airport_id], backref=db.backref('destination_routes', lazy=True))
+    origin_airport: Mapped[Airport] = db.relationship(
+        'Airport', foreign_keys=[origin_airport_id], back_populates='origin_routes'
+    )
+    destination_airport: Mapped[Airport] = db.relationship(
+        'Airport', foreign_keys=[destination_airport_id], back_populates='destination_routes'
+    )
+    flights: Mapped[List['Flight']] = db.relationship('Flight', back_populates='route', lazy='dynamic', cascade='all, delete-orphan')
 
     __table_args__ = (
         db.UniqueConstraint(

--- a/server/app/models/seat.py
+++ b/server/app/models/seat.py
@@ -1,7 +1,14 @@
+from typing import TYPE_CHECKING
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.booking import Booking
+    from app.models.flight_tariff import FlightTariff
+    from app.models.ticket import Ticket
 
 
 class Seat(BaseModel):
@@ -11,6 +18,10 @@ class Seat(BaseModel):
 
     booking_id = db.Column(db.Integer, db.ForeignKey('bookings.id', ondelete='SET NULL'), nullable=True)
     tariff_id = db.Column(db.Integer, db.ForeignKey('flight_tariffs.id', ondelete='RESTRICT'), nullable=False)
+
+    booking: Mapped['Booking'] = db.relationship('Booking', back_populates='seats')
+    tariff: Mapped['FlightTariff'] = db.relationship('FlightTariff', back_populates='seats')
+    ticket: Mapped['Ticket'] = db.relationship('Ticket', back_populates='seat', uselist=False)
 
     __table_args__ = (
         db.UniqueConstraint(

--- a/server/app/models/tariff.py
+++ b/server/app/models/tariff.py
@@ -1,8 +1,12 @@
-from sqlalchemy.orm import Session
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Session, Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
 from app.config import Config
+
+if TYPE_CHECKING:
+    from app.models.flight_tariff import FlightTariff
 
 
 class Tariff(BaseModel):
@@ -13,6 +17,10 @@ class Tariff(BaseModel):
     price = db.Column(db.Float, nullable=False)
     currency = db.Column(db.Enum(Config.CURRENCY), nullable=False, default=Config.DEFAULT_CURRENCY)
     conditions = db.Column(db.String, nullable=True)
+
+    flight_tariffs: Mapped[List['FlightTariff']] = db.relationship(
+        'FlightTariff', back_populates='tariff', lazy='dynamic', cascade='all, delete-orphan'
+    )
 
     def to_dict(self):
         return {

--- a/server/app/models/ticket.py
+++ b/server/app/models/ticket.py
@@ -1,5 +1,15 @@
+from typing import TYPE_CHECKING
+from sqlalchemy.orm import Mapped
+
 from app.database import db
 from app.models._base_model import BaseModel
+
+if TYPE_CHECKING:
+    from app.models.flight import Flight
+    from app.models.booking import Booking
+    from app.models.passenger import Passenger
+    from app.models.discount import Discount
+    from app.models.seat import Seat
 
 
 class Ticket(BaseModel):
@@ -12,6 +22,12 @@ class Ticket(BaseModel):
     passenger_id = db.Column(db.Integer, db.ForeignKey('passengers.id', ondelete='SET NULL'), nullable=True)
     discount_id = db.Column(db.Integer, db.ForeignKey('discounts.id', ondelete='SET NULL'), nullable=True)
     seat_id = db.Column(db.Integer, db.ForeignKey('seats.id', ondelete='CASCADE'), nullable=True, unique=True)
+
+    flight: Mapped['Flight'] = db.relationship('Flight', back_populates='tickets')
+    booking: Mapped['Booking'] = db.relationship('Booking', back_populates='tickets')
+    passenger: Mapped['Passenger'] = db.relationship('Passenger', back_populates='tickets')
+    discount: Mapped['Discount'] = db.relationship('Discount', back_populates='tickets')
+    seat: Mapped['Seat'] = db.relationship('Seat', back_populates='ticket', uselist=False)
 
     def to_dict(self):
         return {

--- a/server/app/models/timezone.py
+++ b/server/app/models/timezone.py
@@ -1,15 +1,21 @@
 from zoneinfo import ZoneInfo
-from sqlalchemy.orm import Session
+from typing import List, TYPE_CHECKING
+from sqlalchemy.orm import Session, Mapped
 
 from app.database import db
 from app.models._base_model import BaseModel
 from app.utils.xlsx import parse_xlsx, generate_xlsx_template
+
+if TYPE_CHECKING:
+    from app.models.airport import Airport
 
 
 class Timezone(BaseModel):
     __tablename__ = 'timezones'
 
     name = db.Column(db.String, nullable=False, unique=True)
+
+    airports: Mapped[List['Airport']] = db.relationship('Airport', back_populates='timezone', lazy='dynamic')
 
     def to_dict(self):
         return {

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -1,10 +1,14 @@
+from typing import List, TYPE_CHECKING
 from werkzeug.security import generate_password_hash, check_password_hash
 
 from app.database import db
 from app.models._base_model import BaseModel, ModelValidationError
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, Mapped
 from app.config import Config
+
+if TYPE_CHECKING:
+    from app.models.password_reset_token import PasswordResetToken
 
 
 class User(BaseModel):
@@ -14,6 +18,10 @@ class User(BaseModel):
     password = db.Column(db.String, nullable=False)
     role = db.Column(db.Enum(Config.USER_ROLE), nullable=False, default=Config.DEFAULT_USER_ROLE)
     is_active = db.Column(db.Boolean, default=True, nullable=False)
+
+    reset_tokens: Mapped[List['PasswordResetToken']] = db.relationship(
+        'PasswordResetToken', back_populates='user', lazy='dynamic', cascade='all, delete-orphan'
+    )
 
     def to_dict(self):
         return {


### PR DESCRIPTION
## Summary
- Annotate SQLAlchemy relationships with `Mapped` types and explicit `back_populates` across server models
- Use relationship backrefs instead of `query.get` in flight methods
- Expose ticket, payment, passenger, and route associations through typed backrefs

## Testing
- `pytest` *(fails: Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set)*

------
https://chatgpt.com/codex/tasks/task_e_688f13f7c92c832f88efe1ea6254e577