### PR TITLE
refactor: improve schedule search UX

### DIFF
--- a/client/src/components/search/Schedule.js
+++ b/client/src/components/search/Schedule.js
@@ -1,7 +1,7 @@
-import React, { useEffect, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { Box, Typography } from '@mui/material';
+import { Box, Typography, Button, CircularProgress } from '@mui/material';
 import Base from '../Base';
 import SearchForm from './SearchForm';
 import ScheduleTable from './ScheduleTable';
@@ -11,10 +11,11 @@ import { fetchAirlines } from '../../redux/actions/airline';
 import { formatDate } from '../utils';
 
 const Schedule = () => {
-	const dispatch = useDispatch();
-	const { flights } = useSelector((state) => state.search);
-	const { airlines } = useSelector((state) => state.airlines);
-	const [params] = useSearchParams();
+        const dispatch = useDispatch();
+        const navigate = useNavigate();
+        const { flights, isLoading: flightsLoading } = useSelector((state) => state.search);
+        const { airlines, isLoading: airlinesLoading } = useSelector((state) => state.airlines);
+        const [params] = useSearchParams();
 	const paramObj = Object.fromEntries(params.entries());
 	const paramStr = params.toString();
 	const from = params.get('from');
@@ -42,34 +43,108 @@ const Schedule = () => {
 
 	const outboundFlights = useMemo(() => flights.filter((f) => f.direction === 'outbound'), [flights]);
 
-	const returnFlights = useMemo(() => flights.filter((f) => f.direction === 'return'), [flights]);
+        const returnFlights = useMemo(() => flights.filter((f) => f.direction === 'return'), [flights]);
 
-	return (
+        const [selectedOutbound, setSelectedOutbound] = useState(null);
+        const [selectedReturn, setSelectedReturn] = useState(null);
+
+        const filteredReturnFlights = useMemo(() => {
+                if (!selectedOutbound) return returnFlights;
+                return returnFlights.filter(
+                        (f) => new Date(f.scheduled_departure) >= new Date(selectedOutbound.scheduled_departure)
+                );
+        }, [returnFlights, selectedOutbound]);
+
+        useEffect(() => {
+                if (selectedReturn && !filteredReturnFlights.some((f) => f.id === selectedReturn.id)) {
+                        setSelectedReturn(null);
+                }
+        }, [filteredReturnFlights, selectedReturn]);
+
+        const handleSelectFlights = () => {
+                if (!selectedOutbound) return;
+                if (
+                        selectedReturn &&
+                        new Date(selectedReturn.scheduled_departure) < new Date(selectedOutbound.scheduled_departure)
+                ) {
+                        alert(UI_LABELS.HOME.search.errors.invalid_return);
+                        return;
+                }
+                const params = new URLSearchParams();
+                params.set('from', from);
+                params.set('to', to);
+                params.set('when', selectedOutbound.scheduled_departure);
+                params.set('date_mode', 'exact');
+                params.set('flight', selectedOutbound.airline_flight_number);
+                if (selectedReturn) params.set('return', selectedReturn.scheduled_departure);
+                navigate(`/search?${params.toString()}`);
+        };
+
+        const isLoading = (flightsLoading && flights.length === 0) || (airlinesLoading && airlines.length === 0);
+
+        return (
 		<Base maxWidth='xl'>
 			<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
 				<SearchForm initialParams={paramObj} />
 			</Box>
-			<Box sx={{ p: 3 }}>
-				<Typography variant='h4' component='h1' gutterBottom sx={{ mt: 3 }}>
-					{UI_LABELS.SCHEDULE.title}
-				</Typography>
-				<Typography variant='subtitle1' sx={{ fontWeight: 'bold', mt: 3, mb: 1 }}>
-					{UI_LABELS.SCHEDULE.from_to(from || '', to || '')}
-				</Typography>
-				{outboundFlights.length ? (
-					<ScheduleTable flights={outboundFlights} airlines={airlines} from={from} to={to} />
-				) : (
-					<Typography>{UI_LABELS.SCHEDULE.no_results}</Typography>
-				)}
-				<Typography variant='subtitle1' sx={{ fontWeight: 'bold', mt: 4, mb: 1 }}>
-					{UI_LABELS.SCHEDULE.from_to(to || '', from || '')}
-				</Typography>
-				{returnFlights.length ? (
-					<ScheduleTable flights={returnFlights} airlines={airlines} from={to} to={from} />
-				) : (
-					<Typography>{UI_LABELS.SCHEDULE.no_results}</Typography>
-				)}
-			</Box>
+                        <Box sx={{ p: 3 }}>
+                                <Typography variant='h4' component='h1' gutterBottom sx={{ mt: 3 }}>
+                                        {UI_LABELS.SCHEDULE.title}
+                                </Typography>
+                                <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
+                                        <Button variant='contained' disabled={!selectedOutbound} onClick={handleSelectFlights}>
+                                                {UI_LABELS.SCHEDULE.select_flights}
+                                        </Button>
+                                </Box>
+
+                                {isLoading ? (
+                                        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 3 }}>
+                                                <CircularProgress />
+                                        </Box>
+                                ) : (
+                                        <>
+                                                <Typography variant='subtitle1' sx={{ fontWeight: 'bold', mt: 3, mb: 1 }}>
+                                                        {UI_LABELS.SCHEDULE.from_to(from || '', to || '')}
+                                                </Typography>
+                                                {outboundFlights.length ? (
+                                                        <ScheduleTable
+                                                                flights={outboundFlights}
+                                                                airlines={airlines}
+                                                                selectedId={selectedOutbound?.id || null}
+                                                                onSelect={(f) =>
+                                                                        setSelectedOutbound(
+                                                                                selectedOutbound && selectedOutbound.id === f?.id
+                                                                                        ? null
+                                                                                        : f
+                                                                        )
+                                                                }
+                                                        />
+                                                ) : (
+                                                        <Typography>{UI_LABELS.SCHEDULE.no_results}</Typography>
+                                                )}
+
+                                                <Typography variant='subtitle1' sx={{ fontWeight: 'bold', mt: 4, mb: 1 }}>
+                                                        {UI_LABELS.SCHEDULE.from_to(to || '', from || '')}
+                                                </Typography>
+                                                {filteredReturnFlights.length ? (
+                                                        <ScheduleTable
+                                                                flights={filteredReturnFlights}
+                                                                airlines={airlines}
+                                                                selectedId={selectedReturn?.id || null}
+                                                                onSelect={(f) =>
+                                                                        setSelectedReturn(
+                                                                                selectedReturn && selectedReturn.id === f?.id
+                                                                                        ? null
+                                                                                        : f
+                                                                        )
+                                                                }
+                                                        />
+                                                ) : (
+                                                        <Typography>{UI_LABELS.SCHEDULE.no_results}</Typography>
+                                                )}
+                                        </>
+                                )}
+                        </Box>
 		</Base>
 	);
 };

--- a/client/src/components/search/ScheduleTable.js
+++ b/client/src/components/search/ScheduleTable.js
@@ -1,25 +1,18 @@
 import React, { useMemo, useState } from 'react';
 import {
-	Box,
-	Table,
-	TableBody,
-	TableCell,
-	TableContainer,
-	TableHead,
-	TableRow,
-	TableSortLabel,
-	TextField,
-	Button,
-	Dialog,
-	DialogTitle,
-	DialogContent,
-	DialogActions,
-	FormControlLabel,
-	Switch,
+        Box,
+        Table,
+        TableBody,
+        TableCell,
+        TableContainer,
+        TableHead,
+        TableRow,
+        TableSortLabel,
+        Radio,
+        TablePagination,
 } from '@mui/material';
-import { FIELD_LABELS, ENUM_LABELS, UI_LABELS } from '../../constants';
+import { FIELD_LABELS, ENUM_LABELS } from '../../constants';
 import { formatDate, formatTime } from '../utils';
-import { useNavigate } from 'react-router-dom';
 
 function descendingComparator(a, b, orderBy) {
 	if (b[orderBy] < a[orderBy]) {
@@ -47,31 +40,31 @@ function stableSort(array, comparator) {
 	return stabilized.map((el) => el[0]);
 }
 
-const ScheduleTable = ({ flights, airlines, from, to }) => {
-	const [order, setOrder] = useState('asc');
-	const [orderBy, setOrderBy] = useState('date');
-	const [dialogOpen, setDialogOpen] = useState(false);
-	const [needReturn, setNeedReturn] = useState(false);
-	const [returnDate, setReturnDate] = useState('');
-	const [selected, setSelected] = useState(null);
-	const navigate = useNavigate();
+const ScheduleTable = ({ flights, airlines, selectedId = null, onSelect = () => {} }) => {
+        const [order, setOrder] = useState('asc');
+        const [orderBy, setOrderBy] = useState('date');
+        const [page, setPage] = useState(0);
+        const [rowsPerPage, setRowsPerPage] = useState(10);
 
 	const rows = useMemo(
 		() =>
 			flights.map((f) => {
 				const airline = airlines.find((a) => a.id === f.airline_id);
-				return {
-					id: f.id,
-					flight_number: f.airline_flight_number,
-					date: formatDate(f.scheduled_departure, 'dd.MM.yyyy'),
-					dateRaw: f.scheduled_departure,
-					departure: formatTime(f.scheduled_departure_time),
-					airline: airline ? airline.name : f.airline_id,
-					price: f.min_price ? `${f.min_price} ${ENUM_LABELS.CURRENCY_SYMBOL[f.currency] || ''}` : '',
-				};
-			}),
-		[flights, airlines]
-	);
+                                return {
+                                        id: f.id,
+                                        flight: f,
+                                        flight_number: f.airline_flight_number,
+                                        date: formatDate(f.scheduled_departure, 'dd.MM.yyyy'),
+                                        dateRaw: f.scheduled_departure,
+                                        departure: formatTime(f.scheduled_departure_time),
+                                        airline: airline ? airline.name : f.airline_id,
+                                        price: f.min_price
+                                                ? `${f.min_price} ${ENUM_LABELS.CURRENCY_SYMBOL[f.currency] || ''}`
+                                                : '',
+                                };
+                        }),
+                [flights, airlines]
+        );
 
 	const handleRequestSort = (property) => {
 		const isAsc = orderBy === property && order === 'asc';
@@ -84,14 +77,14 @@ const ScheduleTable = ({ flights, airlines, from, to }) => {
 		[rows, order, orderBy]
 	);
 
-	const headCells = [
-		{ id: 'flight_number', label: FIELD_LABELS.FLIGHT.flight_number },
-		{ id: 'date', label: FIELD_LABELS.FLIGHT.scheduled_departure },
-		{ id: 'departure', label: FIELD_LABELS.FLIGHT.scheduled_departure_time },
-		{ id: 'airline', label: FIELD_LABELS.FLIGHT.airline_id },
-		{ id: 'price', label: FIELD_LABELS.TARIFF.price },
-		{ id: 'action', label: '' },
-	];
+        const headCells = [
+                { id: 'select', label: '' },
+                { id: 'flight_number', label: FIELD_LABELS.FLIGHT.flight_number },
+                { id: 'date', label: FIELD_LABELS.FLIGHT.scheduled_departure },
+                { id: 'departure', label: FIELD_LABELS.FLIGHT.scheduled_departure_time },
+                { id: 'airline', label: FIELD_LABELS.FLIGHT.airline_id },
+                { id: 'price', label: FIELD_LABELS.TARIFF.price },
+        ];
 
 	return (
 		<Box>
@@ -99,98 +92,71 @@ const ScheduleTable = ({ flights, airlines, from, to }) => {
 				<Table size='small'>
 					<TableHead>
 						<TableRow>
-							{headCells.map((headCell) => (
-								<TableCell
-									key={headCell.id}
-									sortDirection={orderBy === headCell.id ? order : false}
-									sx={{
-										fontWeight: 'bold',
-										cursor: headCell.id !== 'action' ? 'pointer' : 'default',
-									}}
-								>
-									{headCell.id !== 'action' ? (
-										<TableSortLabel
-											active={orderBy === headCell.id}
-											direction={orderBy === headCell.id ? order : 'asc'}
-											onClick={() => handleRequestSort(headCell.id)}
-										>
-											{headCell.label}
-										</TableSortLabel>
-									) : (
-										headCell.label
-									)}
-								</TableCell>
-							))}
-						</TableRow>
-					</TableHead>
-					<TableBody>
-						{sortedRows.map((row) => (
-							<TableRow key={row.id}>
-								<TableCell>{row.flight_number}</TableCell>
-								<TableCell>{row.date}</TableCell>
-								<TableCell>{row.departure}</TableCell>
-								<TableCell>{row.airline}</TableCell>
-								<TableCell>{row.price}</TableCell>
-								<TableCell>
-									<Button
-										size='small'
-										variant='outlined'
-										onClick={() => {
-											setSelected(row);
-											setNeedReturn(false);
-											setReturnDate('');
-											setDialogOpen(true);
-										}}
-									>
-										{UI_LABELS.SCHEDULE.discuss}
-									</Button>
-								</TableCell>
-							</TableRow>
-						))}
-					</TableBody>
-				</Table>
-			</TableContainer>
-
-			<Dialog open={dialogOpen} onClose={() => setDialogOpen(false)}>
-				<DialogTitle>{UI_LABELS.SCHEDULE.discuss}</DialogTitle>
-				<DialogContent>
-					<FormControlLabel
-						control={<Switch checked={needReturn} onChange={(e) => setNeedReturn(e.target.checked)} />}
-						label={UI_LABELS.SCHEDULE.ask_return}
-					/>
-					{needReturn && (
-						<TextField
-							type='date'
-							label={UI_LABELS.HOME.search.return}
-							value={returnDate}
-							onChange={(e) => setReturnDate(e.target.value)}
-							InputLabelProps={{ shrink: true }}
-							sx={{ mt: 2 }}
-						/>
-					)}
-				</DialogContent>
-				<DialogActions>
-					<Button onClick={() => setDialogOpen(false)}>{UI_LABELS.BUTTONS.cancel}</Button>
-					<Button
-						onClick={() => {
-							if (!selected) return;
-							const params = new URLSearchParams();
-							params.set('from', from);
-							params.set('to', to);
-							params.set('when', selected.dateRaw);
-							params.set('date_mode', 'exact');
-							params.set('flight', selected.flight_number);
-							if (needReturn && returnDate) params.set('return', returnDate);
-							navigate(`/search?${params.toString()}`);
-						}}
-						disabled={needReturn && !returnDate}
-					>
-						{UI_LABELS.BUTTONS.confirm}
-					</Button>
-				</DialogActions>
-			</Dialog>
-		</Box>
-	);
+                                                        {headCells.map((headCell) => (
+                                                                <TableCell
+                                                                        key={headCell.id}
+                                                                        sortDirection={orderBy === headCell.id ? order : false}
+                                                                        sx={{
+                                                                                fontWeight: 'bold',
+                                                                                cursor: headCell.id !== 'select' ? 'pointer' : 'default',
+                                                                        }}
+                                                                >
+                                                                        {headCell.id !== 'select' ? (
+                                                                                <TableSortLabel
+                                                                                        active={orderBy === headCell.id}
+                                                                                        direction={orderBy === headCell.id ? order : 'asc'}
+                                                                                        onClick={() => handleRequestSort(headCell.id)}
+                                                                                >
+                                                                                        {headCell.label}
+                                                                                </TableSortLabel>
+                                                                        ) : (
+                                                                                headCell.label
+                                                                        )}
+                                                                </TableCell>
+                                                        ))}
+                                                </TableRow>
+                                        </TableHead>
+                                        <TableBody>
+                                                {sortedRows
+                                                        .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+                                                        .map((row) => (
+                                                                <TableRow key={row.id}>
+                                                                        <TableCell padding='checkbox'>
+                                                                                <Radio
+                                                                                        checked={selectedId === row.id}
+                                                                                        onClick={() =>
+                                                                                                onSelect(
+                                                                                                        selectedId === row.id
+                                                                                                                ? null
+                                                                                                                : row.flight
+                                                                                                )
+                                                                                        }
+                                                                                />
+                                                                        </TableCell>
+                                                                        <TableCell>{row.flight_number}</TableCell>
+                                                                        <TableCell>{row.date}</TableCell>
+                                                                        <TableCell>{row.departure}</TableCell>
+                                                                        <TableCell>{row.airline}</TableCell>
+                                                                        <TableCell>{row.price}</TableCell>
+                                                                </TableRow>
+                                                        ))}
+                                        </TableBody>
+                                </Table>
+                        </TableContainer>
+                        <TablePagination
+                                rowsPerPageOptions={[5, 10, 25]}
+                                component='div'
+                                count={sortedRows.length}
+                                rowsPerPage={rowsPerPage}
+                                page={page}
+                                onPageChange={(e, newPage) => setPage(newPage)}
+                                onRowsPerPageChange={(e) => {
+                                        setRowsPerPage(parseInt(e.target.value, 10));
+                                        setPage(0);
+                                }}
+                        />
+                </Box>
+        );
 };
 
 export default ScheduleTable;

--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { Box, Typography, FormControl, InputLabel, Select, MenuItem, Button } from '@mui/material';
+import { Box, Typography, FormControl, InputLabel, Select, MenuItem, Button, CircularProgress } from '@mui/material';
 import Base from '../Base';
 import SearchForm from './SearchForm';
 import SearchResultCard from './SearchResultCard';
@@ -11,7 +11,7 @@ import { formatDate, getFlightDurationMinutes } from '../utils';
 
 const Search = () => {
 	const dispatch = useDispatch();
-	const { flights, nearbyFlights } = useSelector((state) => state.search);
+        const { flights, nearbyFlights, isLoading } = useSelector((state) => state.search);
 	const navigate = useNavigate();
 	const [params] = useSearchParams();
 	const paramObj = Object.fromEntries(params.entries());
@@ -27,8 +27,9 @@ const Search = () => {
 	const isExact = params.get('date_mode') === 'exact';
 	const hasReturn = returnDate || returnFrom || returnTo;
 
-	const [sortKey, setSortKey] = useState('price');
-	const [nearDates, setNearDates] = useState([]);
+        const [sortKey, setSortKey] = useState('price');
+        const [nearDates, setNearDates] = useState([]);
+        const [visibleCount, setVisibleCount] = useState(10);
 
 	useEffect(() => {
 		dispatch(fetchSearchFlights(paramObj));
@@ -194,13 +195,25 @@ const Search = () => {
 					</Select>
 				</FormControl>
 
-				{sortedGrouped && sortedGrouped.length ? (
-					sortedGrouped.map((g, idx) => (
-						<SearchResultCard key={idx} outbound={g.outbound} returnFlight={g.returnFlight} />
-					))
-				) : (
-					<Typography>{UI_LABELS.SEARCH.no_results}</Typography>
-				)}
+                                {isLoading && flights.length === 0 ? (
+                                        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+                                                <CircularProgress />
+                                        </Box>
+                                ) : sortedGrouped && sortedGrouped.length ? (
+                                        sortedGrouped.slice(0, visibleCount).map((g, idx) => (
+                                                <SearchResultCard key={idx} outbound={g.outbound} returnFlight={g.returnFlight} />
+                                        ))
+                                ) : (
+                                        <Typography>{UI_LABELS.SEARCH.no_results}</Typography>
+                                )}
+
+                                {visibleCount < sortedGrouped.length && (
+                                        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
+                                                <Button variant='contained' onClick={() => setVisibleCount((v) => v + 10)}>
+                                                        {UI_LABELS.SEARCH.show_more}
+                                                </Button>
+                                        </Box>
+                                )}
 			</Box>
 		</Base>
 	);

--- a/client/src/components/search/SearchForm.js
+++ b/client/src/components/search/SearchForm.js
@@ -9,11 +9,10 @@ import {
 	Collapse,
 	Paper,
 	Switch,
-	RadioGroup,
-	Radio,
-	TextField,
-	FormControlLabel,
-	CircularProgress,
+        RadioGroup,
+        Radio,
+        TextField,
+        FormControlLabel,
 } from '@mui/material';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import { FIELD_TYPES, createFormFields, formatDate } from '../utils';
@@ -132,8 +131,7 @@ const SearchForm = ({ initialParams = {} }) => {
 	const [dateMode, setDateMode] = useState(combinedParams.date_mode || 'exact');
 	const [seatClass, setSeatClass] = useState(combinedParams.class || seatClassOptions[0].value);
 	const [showPassengers, setShowPassengers] = useState(false);
-	const [validationErrors, setValidationErrors] = useState({});
-	const [isLoading, setIsLoading] = useState(false);
+        const [validationErrors, setValidationErrors] = useState({});
 
 	const passengersRef = useRef(null);
 	const departToRef = useRef(null);
@@ -278,8 +276,7 @@ const SearchForm = ({ initialParams = {} }) => {
 	const handleSubmit = (e) => {
 		e.preventDefault();
 		if (!validateForm()) return;
-		setIsLoading(true);
-		const params = new URLSearchParams();
+                const params = new URLSearchParams();
 		params.set('from', formValues.from);
 		params.set('to', formValues.to);
 		params.set('date_mode', dateMode);
@@ -299,15 +296,12 @@ const SearchForm = ({ initialParams = {} }) => {
 		params.set('children', passengers.children);
 		params.set('infants', passengers.infants);
 		params.set('class', seatClass);
-		setTimeout(() => {
-			try {
-				saveToLocalStorage();
-			} catch (e) {
-				console.error('Failed to save search params', e);
-			}
-			navigate(`/search?${params.toString()}`);
-			setIsLoading(false);
-		}, 250);
+                try {
+                        saveToLocalStorage();
+                } catch (e) {
+                        console.error('Failed to save search params', e);
+                }
+                navigate(`/search?${params.toString()}`);
 	};
 
 	const isScheduleClickOpen = useMemo(
@@ -317,21 +311,17 @@ const SearchForm = ({ initialParams = {} }) => {
 
 	const onScheduleClick = () => {
 		if (!isScheduleClickOpen) return;
-		setIsLoading(true);
-		setValidationErrors({});
-		const { from, to } = formValues;
-		const params = new URLSearchParams();
+                setValidationErrors({});
+                const { from, to } = formValues;
+                const params = new URLSearchParams();
 		params.set('from', from);
 		params.set('to', to);
-		setTimeout(() => {
-			try {
-				saveToLocalStorage();
-			} catch (e) {
-				console.error('Failed to save search params', e);
-			}
-			navigate(`/schedule?${params.toString()}`);
-			setIsLoading(false);
-		}, 250);
+                try {
+                        saveToLocalStorage();
+                } catch (e) {
+                        console.error('Failed to save search params', e);
+                }
+                navigate(`/schedule?${params.toString()}`);
 	};
 
 	const fromValue = airportOptions.some((o) => o.value === formValues.from) ? formValues.from : '';
@@ -611,17 +601,17 @@ const SearchForm = ({ initialParams = {} }) => {
 					justifyContent: 'center',
 				}}
 			>
-				<Button
-					variant='contained'
-					color='primary'
-					onClick={onScheduleClick}
-					disabled={!isScheduleClickOpen || isLoading}
-					sx={{
-						color: '#fff',
-						borderRadius: 1.5,
-						whiteSpace: 'nowrap',
-					}}
-				>
+                                <Button
+                                        variant='contained'
+                                        color='primary'
+                                        onClick={onScheduleClick}
+                                        disabled={!isScheduleClickOpen}
+                                        sx={{
+                                                color: '#fff',
+                                                borderRadius: 1.5,
+                                                whiteSpace: 'nowrap',
+                                        }}
+                                >
 					{UI_LABELS.HOME.search.show_schedule}
 				</Button>
 			</Box>
@@ -635,41 +625,22 @@ const SearchForm = ({ initialParams = {} }) => {
 					justifyContent: 'center',
 				}}
 			>
-				<Button
-					type='submit'
-					variant='contained'
-					disabled={isLoading}
-					sx={{
-						background: '#ff7f2a',
-						color: '#fff',
-						borderRadius: 1.5,
-						whiteSpace: 'nowrap',
-						'&:hover': { background: '#ff6600' },
-					}}
-				>
+                                <Button
+                                        type='submit'
+                                        variant='contained'
+                                        sx={{
+                                                background: '#ff7f2a',
+                                                color: '#fff',
+                                                borderRadius: 1.5,
+                                                whiteSpace: 'nowrap',
+                                                '&:hover': { background: '#ff6600' },
+                                        }}
+                                >
 					{UI_LABELS.HOME.search.button}
 				</Button>
 			</Box>
 
-			{/* Loading overlay */}
-			{isLoading && (
-				<Box
-					sx={{
-						position: 'absolute',
-						top: 0,
-						left: 0,
-						right: 0,
-						bottom: 0,
-						backgroundColor: 'rgba(255, 255, 255, 0.8)',
-						display: 'flex',
-						alignItems: 'center',
-						justifyContent: 'center',
-						zIndex: 1000,
-					}}
-				>
-					<CircularProgress />
-				</Box>
-			)}
+                        {/* Loading overlay removed */}
 		</Box>
 	);
 };

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -289,12 +289,13 @@ export const UI_LABELS = {
 		outbound: 'Выбранное направление',
 		return: 'Обратное направление',
 		filter: 'Фильтр',
-		discuss: 'Обсудить',
-		ask_return: 'Нужен ли обратный билет?',
-		from_to: (from, to) => {
-			return `${from} → ${to}`;
-		},
-	},
+                discuss: 'Обсудить',
+                ask_return: 'Нужен ли обратный билет?',
+                select_flights: 'Выбрать рейсы',
+                from_to: (from, to) => {
+                        return `${from} → ${to}`;
+                },
+        },
 	SEARCH: {
 		results: 'Результаты поиска',
 		no_results: 'Рейсы не найдены',
@@ -309,15 +310,16 @@ export const UI_LABELS = {
 			departure_arrival: 'Время отправления - Время прибытия',
 			price: 'Цена',
 		},
-		sort: {
-			label: 'Сортировка',
-			price: 'По цене',
-			arrival: 'По времени прибытия',
-			departure: 'По времени отправления',
-			duration: 'По времени в пути',
-		},
-		nearby_dates: 'Ближайшие даты',
-	},
+                sort: {
+                        label: 'Сортировка',
+                        price: 'По цене',
+                        arrival: 'По времени прибытия',
+                        departure: 'По времени отправления',
+                        duration: 'По времени в пути',
+                },
+                nearby_dates: 'Ближайшие даты',
+                show_more: 'Показать еще билеты',
+        },
 };
 
 export default UI_LABELS;


### PR DESCRIPTION
## Summary
- move loading off search bar into pages and remove artificial delay
- paginate and sort flight schedules with selectable radio rows
- add “show more tickets” option to search results and top-level schedule selection flow

## Testing
- `npm test --prefix client -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688f26a8ce34832f80888b20b77c135e