### PR TITLE
feat: add loading indicators to admin tables

### DIFF
--- a/client/src/components/admin/AdminDataTable.js
+++ b/client/src/components/admin/AdminDataTable.js
@@ -49,10 +49,11 @@ const AdminDataTable = ({
 	onDeleteAll = null,
 	renderForm,
 	getUploadTemplate = () => {},
-	onUpload = () => Promise.resolve(),
-	addButtonText = null,
-	uploadButtonText = null,
-	uploadTemplateButtonText = null,
+        onUpload = () => Promise.resolve(),
+        addButtonText = null,
+        uploadButtonText = null,
+        uploadTemplateButtonText = null,
+        isLoading = false,
 }) => {
 	const [openDialog, setOpenDialog] = useState(false);
 	const [deleteDialog, setDeleteDialog] = useState({
@@ -361,33 +362,35 @@ const AdminDataTable = ({
 						{UI_LABELS.BUTTONS.delete_all}
 					</Button>
 				)}
-				<TableContainer sx={{ maxHeight: 800, mb: 2 }}>
-					<Box
-						sx={{
-							display: 'flex',
-							justifyContent: 'flex-end',
-							alignItems: 'center',
-						}}
-					>
-						<Button
-							variant='contained'
-							color='action'
-							size='small'
-							startIcon={showFilters ? <FilterListOffIcon /> : <FilterListIcon />}
-							onClick={() => setShowFilters((prev) => !prev)}
-							sx={{
-								fontSize: '0.75rem',
-								fontWeight: 400,
-								minHeight: 28,
-								px: 1.5,
-								py: 0.5,
-							}}
-						>
-							{showFilters ? UI_LABELS.ADMIN.filter.hide : UI_LABELS.ADMIN.filter.show}
-						</Button>
-					</Box>
-					<Table stickyHeader sx={{ tableLayout: 'auto' }}>
-						<TableHead>
+                               <Box sx={{ position: 'relative' }}>
+                                       <Box sx={{ visibility: isLoading ? 'hidden' : 'visible' }}>
+                                               <TableContainer sx={{ maxHeight: 800, mb: 2 }}>
+                                                       <Box
+                                                               sx={{
+                                                                       display: 'flex',
+                                                                       justifyContent: 'flex-end',
+                                                                       alignItems: 'center',
+                                                               }}
+                                                       >
+                                                               <Button
+                                                                       variant='contained'
+                                                                       color='action'
+                                                                       size='small'
+                                                                       startIcon={showFilters ? <FilterListOffIcon /> : <FilterListIcon />}
+                                                                       onClick={() => setShowFilters((prev) => !prev)}
+                                                                       sx={{
+                                                                               fontSize: '0.75rem',
+                                                                               fontWeight: 400,
+                                                                               minHeight: 28,
+                                                                               px: 1.5,
+                                                                               py: 0.5,
+                                                                       }}
+                                                               >
+                                                                       {showFilters ? UI_LABELS.ADMIN.filter.hide : UI_LABELS.ADMIN.filter.show}
+                                                               </Button>
+                                                       </Box>
+                                                       <Table stickyHeader sx={{ tableLayout: 'auto' }}>
+                                               <TableHead>
 							<TableRow>
 								{columns.map((column, index) => (
 									<TableCell
@@ -525,23 +528,43 @@ const AdminDataTable = ({
 								</TableRow>
 							))}
 						</TableBody>
-					</Table>
-				</TableContainer>
-				<TablePagination
-					component='div'
-					count={sortedData.length}
-					page={page}
-					onPageChange={handleChangePage}
-					rowsPerPage={rowsPerPage}
-					onRowsPerPageChange={handleChangeRowsPerPage}
-					rowsPerPageOptions={[10, 25, 50]}
-					labelRowsPerPage={UI_LABELS.ADMIN.rows.per_page}
-					labelDisplayedRows={({ from, to, count }) =>
-						`${from}-${to} ${UI_LABELS.ADMIN.rows.from} ${
-							count !== -1 ? count : `${UI_LABELS.ADMIN.rows.more_than} ${to}`
-						}`
-					}
-				/>
+                                                       </Table>
+                                               </TableContainer>
+                                               <TablePagination
+                                                       component='div'
+                                                       count={sortedData.length}
+                                                       page={page}
+                                                       onPageChange={handleChangePage}
+                                                       rowsPerPage={rowsPerPage}
+                                                       onRowsPerPageChange={handleChangeRowsPerPage}
+                                                       rowsPerPageOptions={[10, 25, 50]}
+                                                       labelRowsPerPage={UI_LABELS.ADMIN.rows.per_page}
+                                                       labelDisplayedRows={({ from, to, count }) =>
+                                                               `${from}-${to} ${UI_LABELS.ADMIN.rows.from} ${
+                                                                       count !== -1 ? count : `${UI_LABELS.ADMIN.rows.more_than} ${to}`
+                                                               }`
+                                                       }
+                                               />
+                                       </Box>
+                                       {isLoading && (
+                                               <Box
+                                                       sx={{
+                                                               position: 'absolute',
+                                                               top: 0,
+                                                               left: 0,
+                                                               right: 0,
+                                                               bottom: 0,
+                                                               backgroundColor: 'rgba(255, 255, 255, 0.8)',
+                                                               display: 'flex',
+                                                               alignItems: 'center',
+                                                               justifyContent: 'center',
+                                                               zIndex: 1,
+                                                       }}
+                                               >
+                                                       <CircularProgress />
+                                               </Box>
+                                       )}
+                               </Box>
 
 				{/* Add/edit dialog */}
 				<Dialog open={openDialog} onClose={handleCloseDialog} maxWidth='md' fullWidth>

--- a/client/src/components/admin/AirportManagement.js
+++ b/client/src/components/admin/AirportManagement.js
@@ -19,9 +19,9 @@ import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES } from '../../constants';
 
 const AirportManagement = () => {
 	const dispatch = useDispatch();
-	const { airports, isLoading, errors } = useSelector((state) => state.airports);
-	const { countries, isLoading: countriesLoading } = useSelector((state) => state.countries);
-	const { timezones, isLoading: tzLoading } = useSelector((state) => state.timezones);
+        const { airports, isLoading, errors } = useSelector((state) => state.airports);
+        const { countries, isLoading: countriesLoading } = useSelector((state) => state.countries);
+        const { timezones, isLoading: tzLoading } = useSelector((state) => state.timezones);
 
 	useEffect(() => {
 		dispatch(fetchAirports());
@@ -168,7 +168,7 @@ const AirportManagement = () => {
 			uploadTemplateButtonText={UI_LABELS.ADMIN.modules.airports.upload_template_button}
 			getUploadTemplate={handleGetTemplate}
 			onUpload={handleUpload}
-			isLoading={isLoading || countriesLoading}
+                        isLoading={isLoading || countriesLoading || tzLoading}
 			error={errors}
 		/>
 	);

--- a/client/src/components/admin/BookingManagement.js
+++ b/client/src/components/admin/BookingManagement.js
@@ -21,9 +21,9 @@ import { formatDate, validateEmail, validatePhoneNumber } from '../utils';
 
 const BookingManagement = () => {
 	const dispatch = useDispatch();
-	const { bookings, isLoading, errors } = useSelector((state) => state.bookings);
-	const { bookingPassengers } = useSelector((state) => state.bookingPassengers);
-	const { passengers } = useSelector((state) => state.passengers);
+        const { bookings, isLoading, errors } = useSelector((state) => state.bookings);
+        const { bookingPassengers, isLoading: bookingPassengersLoading } = useSelector((state) => state.bookingPassengers);
+        const { passengers, isLoading: passengersLoading } = useSelector((state) => state.passengers);
 
 	useEffect(() => {
 		dispatch(fetchBookings());
@@ -190,7 +190,7 @@ const BookingManagement = () => {
 			onDeleteAll={handleDeleteAllBookings}
 			renderForm={adminManager.renderForm}
 			addButtonText={UI_LABELS.ADMIN.modules.bookings.add_button}
-			isLoading={isLoading}
+                        isLoading={isLoading || bookingPassengersLoading || passengersLoading}
 			error={errors}
 		/>
 	);

--- a/client/src/components/admin/TicketManagement.js
+++ b/client/src/components/admin/TicketManagement.js
@@ -14,11 +14,11 @@ import { FIELD_LABELS, UI_LABELS } from '../../constants';
 
 const TicketManagement = () => {
 	const dispatch = useDispatch();
-	const { tickets, isLoading, errors } = useSelector((state) => state.tickets);
-	const { flights } = useSelector((state) => state.flights);
-	const { bookings } = useSelector((state) => state.bookings);
-	const { passengers } = useSelector((state) => state.passengers);
-	const { discounts } = useSelector((state) => state.discounts);
+        const { tickets, isLoading, errors } = useSelector((state) => state.tickets);
+        const { flights, isLoading: flightsLoading } = useSelector((state) => state.flights);
+        const { bookings, isLoading: bookingsLoading } = useSelector((state) => state.bookings);
+        const { passengers, isLoading: passengersLoading } = useSelector((state) => state.passengers);
+        const { discounts, isLoading: discountsLoading } = useSelector((state) => state.discounts);
 
 	useEffect(() => {
 		dispatch(fetchTickets());
@@ -136,7 +136,13 @@ const TicketManagement = () => {
 			onDeleteAll={handleDeleteAllTickets}
 			renderForm={adminManager.renderForm}
 			addButtonText={UI_LABELS.ADMIN.modules.tickets.add_button}
-			isLoading={isLoading}
+                        isLoading={
+                                isLoading ||
+                                flightsLoading ||
+                                bookingsLoading ||
+                                passengersLoading ||
+                                discountsLoading
+                        }
 			error={errors}
 		/>
 	);

--- a/client/src/components/admin/TimezoneManagement.js
+++ b/client/src/components/admin/TimezoneManagement.js
@@ -3,7 +3,13 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from './AdminDataTable';
 import { downloadTemplate, uploadFile } from '../../api';
-import { fetchTimezones, createTimezone, updateTimezone, deleteTimezone } from '../../redux/actions/timezone';
+import {
+        fetchTimezones,
+        createTimezone,
+        updateTimezone,
+        deleteTimezone,
+        deleteAllTimezones,
+} from '../../redux/actions/timezone';
 import { createAdminManager } from './utils';
 import { FIELD_TYPES } from '../utils';
 import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES } from '../../constants';


### PR DESCRIPTION
## Summary
- hide AdminDataTable until data loading completes and show spinner overlay
- propagate loading flags in admin modules and combine related fetch states
- ensure airports, bookings and tickets wait for all dependent data before rendering
- import deleteAllTimezones for proper bulk deletion

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688f27f72d78832f976a67648d7d2c29