### PR TITLE
refactor: centralize color palette usage

### DIFF
--- a/client/src/components/admin/AdminDataTable.js
+++ b/client/src/components/admin/AdminDataTable.js
@@ -38,6 +38,7 @@ import { UI_LABELS, ENUM_LABELS } from '../../constants';
 import { createFieldRenderer, FIELD_TYPES } from '../utils';
 import { formatDate } from '../utils';
 import { isDev } from '../../redux/reducers/auth';
+import { useTheme, alpha } from '@mui/material/styles';
 
 const AdminDataTable = ({
 	title,
@@ -76,8 +77,9 @@ const AdminDataTable = ({
 		direction: 'asc',
 	});
 	const [filters, setFilters] = useState({});
-	const [page, setPage] = useState(0);
-	const [rowsPerPage, setRowsPerPage] = useState(10);
+        const [page, setPage] = useState(0);
+        const [rowsPerPage, setRowsPerPage] = useState(10);
+        const theme = useTheme();
 
 	const [uploadDialog, setUploadDialog] = useState(false);
 	const [uploading, setUploading] = useState(false);
@@ -558,24 +560,24 @@ const AdminDataTable = ({
 							}
 						/>
 					</Box>
-					{isLoading && (
-						<Box
-							sx={{
-								position: 'absolute',
-								top: 0,
-								left: 0,
-								right: 0,
-								bottom: 0,
-								backgroundColor: 'rgba(255, 255, 255, 0.8)',
-								display: 'flex',
-								alignItems: 'center',
-								justifyContent: 'center',
-								zIndex: 1,
-							}}
-						>
-							<CircularProgress />
-						</Box>
-					)}
+                                        {isLoading && (
+                                                <Box
+                                                        sx={{
+                                                                position: 'absolute',
+                                                                top: 0,
+                                                                left: 0,
+                                                                right: 0,
+                                                                bottom: 0,
+                                                                backgroundColor: alpha(theme.palette.white, 0.8),
+                                                                display: 'flex',
+                                                                alignItems: 'center',
+                                                                justifyContent: 'center',
+                                                                zIndex: 1,
+                                                        }}
+                                                >
+                                                        <CircularProgress />
+                                                </Box>
+                                        )}
 				</Box>
 
 				{/* Add/edit dialog */}
@@ -658,7 +660,7 @@ const AdminDataTable = ({
 					</DialogActions>
 				</Dialog>
 
-				<Backdrop open={uploading} sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}>
+                                <Backdrop open={uploading} sx={{ color: theme.palette.white, zIndex: (theme) => theme.zIndex.drawer + 1 }}>
 					<CircularProgress color='inherit' />
 				</Backdrop>
 				<Snackbar

--- a/client/src/components/admin/BookingManagement.js
+++ b/client/src/components/admin/BookingManagement.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Box, Typography } from '@mui/material';
+import { useTheme, alpha } from '@mui/material/styles';
 
 import AdminDataTable from '../../components/admin/AdminDataTable';
 
@@ -23,7 +24,9 @@ const BookingManagement = () => {
 	const dispatch = useDispatch();
 	const { bookings, isLoading, errors } = useSelector((state) => state.bookings);
 	const { bookingPassengers, isLoading: bookingPassengersLoading } = useSelector((state) => state.bookingPassengers);
-	const { passengers, isLoading: passengersLoading } = useSelector((state) => state.passengers);
+        const { passengers, isLoading: passengersLoading } = useSelector((state) => state.passengers);
+
+        const theme = useTheme();
 
 	useEffect(() => {
 		dispatch(fetchBookings());
@@ -136,7 +139,7 @@ const BookingManagement = () => {
 										display: 'flex',
 										alignItems: 'center',
 										mb: 0.5,
-										backgroundColor: 'rgba(0,0,0,0.04)',
+                                                                                backgroundColor: alpha(theme.palette.black, 0.04),
 										borderRadius: 1,
 										p: 0.5,
 										width: 'auto',

--- a/client/src/components/admin/FlightManagement.js
+++ b/client/src/components/admin/FlightManagement.js
@@ -1,16 +1,17 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-	Tooltip,
-	IconButton,
-	Button,
-	Box,
-	Typography,
-	Dialog,
-	DialogContent,
-	DialogTitle,
-	DialogActions,
+        Tooltip,
+        IconButton,
+        Button,
+        Box,
+        Typography,
+        Dialog,
+        DialogContent,
+        DialogTitle,
+        DialogActions,
 } from '@mui/material';
+import { useTheme, alpha } from '@mui/material/styles';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -35,8 +36,10 @@ const FlightManagement = () => {
 	const { routes, isLoading: routesLoading } = useSelector((state) => state.routes);
 	const { airlines, isLoading: airlinesLoading } = useSelector((state) => state.airlines);
 	const { tariffs, isLoading: tariffsLoading } = useSelector((state) => state.tariffs);
-	const { flightTariffs, isLoading: flightTariffsLoading } = useSelector((state) => state.flightTariffs);
-	const { airports, isLoading: airportsLoading } = useSelector((state) => state.airports);
+        const { flightTariffs, isLoading: flightTariffsLoading } = useSelector((state) => state.flightTariffs);
+        const { airports, isLoading: airportsLoading } = useSelector((state) => state.airports);
+
+        const theme = useTheme();
 
 	const [tariffDialogOpen, setTariffDialogOpen] = useState(false);
 	const [tariffAction, setTariffAction] = useState(null);
@@ -293,7 +296,7 @@ const FlightManagement = () => {
 												display: 'flex',
 												alignItems: 'center',
 												mb: 0.5,
-												backgroundColor: 'rgba(0,0,0,0.04)',
+                                                                                                backgroundColor: alpha(theme.palette.black, 0.04),
 												borderRadius: 1,
 												p: 0.5,
 												width: 'auto',

--- a/client/src/components/cart/PassengerForm.js
+++ b/client/src/components/cart/PassengerForm.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
 import { Box, Grid, TextField, Select, MenuItem, FormControl, InputLabel, Typography, IconButton } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DescriptionIcon from '@mui/icons-material/Description';
 import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
@@ -65,8 +66,10 @@ const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument }) => {
 		validate();
 	}, [data.type, data.birthDate]);
 
-	return (
-		<Box sx={{ p: 2, border: '1px solid #ddd', borderRadius: 2, mb: 3 }}>
+        const theme = useTheme();
+
+        return (
+                <Box sx={{ p: 2, border: `1px solid ${theme.palette.grey[200]}`, borderRadius: 2, mb: 3 }}>
 			<Box
 				sx={{
 					display: 'flex',

--- a/client/src/components/search/SearchForm.js
+++ b/client/src/components/search/SearchForm.js
@@ -2,18 +2,19 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-	Box,
-	Button,
-	IconButton,
-	Typography,
-	Collapse,
-	Paper,
-	Switch,
-	RadioGroup,
-	Radio,
-	TextField,
-	FormControlLabel,
+        Box,
+        Button,
+        IconButton,
+        Typography,
+        Collapse,
+        Paper,
+        Switch,
+        RadioGroup,
+        Radio,
+        TextField,
+        FormControlLabel,
 } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import { FIELD_TYPES, createFormFields, formatDate } from '../utils';
 
@@ -96,8 +97,9 @@ const parseDate = (value) => {
 const STORAGE_KEY = 'lastSearchParams';
 
 const SearchForm = ({ initialParams = {} }) => {
-	const navigate = useNavigate();
-	const dispatch = useDispatch();
+        const navigate = useNavigate();
+        const dispatch = useDispatch();
+        const theme = useTheme();
 
 	const { airports } = useSelector((state) => state.search);
 
@@ -330,17 +332,17 @@ const SearchForm = ({ initialParams = {} }) => {
 		<Box
 			component='form'
 			onSubmit={handleSubmit}
-			sx={{
-				display: 'grid',
-				background: '#fff',
-				p: 1,
-				mt: 2,
-				alignItems: 'start',
-				rowGap: 1,
-				columnGap: 1,
-				borderBottom: 1,
-				borderColor: 'divider',
-			}}
+                        sx={{
+                                display: 'grid',
+                                backgroundColor: theme.palette.background.paper,
+                                p: 1,
+                                mt: 2,
+                                alignItems: 'start',
+                                rowGap: 1,
+                                columnGap: 1,
+                                borderBottom: 1,
+                                borderColor: 'divider',
+                        }}
 		>
 			<Box
 				sx={{
@@ -601,17 +603,16 @@ const SearchForm = ({ initialParams = {} }) => {
 					justifyContent: 'center',
 				}}
 			>
-				<Button
-					variant='contained'
-					color='primary'
-					onClick={onScheduleClick}
-					disabled={!isScheduleClickOpen}
-					sx={{
-						color: '#fff',
-						borderRadius: 1.5,
-						whiteSpace: 'nowrap',
-					}}
-				>
+                                <Button
+                                        variant='contained'
+                                        color='primary'
+                                        onClick={onScheduleClick}
+                                        disabled={!isScheduleClickOpen}
+                                        sx={{
+                                                borderRadius: 1.5,
+                                                whiteSpace: 'nowrap',
+                                        }}
+                                >
 					{UI_LABELS.HOME.search.show_schedule}
 				</Button>
 			</Box>
@@ -625,17 +626,15 @@ const SearchForm = ({ initialParams = {} }) => {
 					justifyContent: 'center',
 				}}
 			>
-				<Button
-					type='submit'
-					variant='contained'
-					sx={{
-						background: '#ff7f2a',
-						color: '#fff',
-						borderRadius: 1.5,
-						whiteSpace: 'nowrap',
-						'&:hover': { background: '#ff6600' },
-					}}
-				>
+                                <Button
+                                        type='submit'
+                                        variant='contained'
+                                        color='orange'
+                                        sx={{
+                                                borderRadius: 1.5,
+                                                whiteSpace: 'nowrap',
+                                        }}
+                                >
 					{UI_LABELS.HOME.search.button}
 				</Button>
 			</Box>

--- a/client/src/components/search/SearchResultCard.js
+++ b/client/src/components/search/SearchResultCard.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Card, Box, Typography, Button, Divider, IconButton } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import FlightIcon from '@mui/icons-material/Flight';
 import ShareIcon from '@mui/icons-material/Share';
 import { ENUM_LABELS, UI_LABELS, DATE_WEEKDAY_FORMAT } from '../../constants';
@@ -128,7 +129,8 @@ const Segment = ({ flight, isOutbound }) => {
 };
 
 const SearchResultCard = ({ outbound, returnFlight }) => {
-	const currency = outbound.currency || returnFlight?.currency;
+        const theme = useTheme();
+        const currency = outbound.currency || returnFlight?.currency;
 	const currencySymbol = currency ? ENUM_LABELS.CURRENCY_SYMBOL[currency] : '';
 	const totalPrice =
 		outbound.price + (returnFlight?.price || 0) || outbound.min_price || returnFlight?.min_price || 0;
@@ -136,31 +138,29 @@ const SearchResultCard = ({ outbound, returnFlight }) => {
 	return (
 		<Card sx={{ display: 'flex', p: 2, mb: 2 }}>
 			<Box
-				sx={{
-					width: 160,
-					textAlign: 'center',
-					pr: 2,
-					borderRight: '1px solid #eee',
-					display: 'flex',
-					flexDirection: 'column',
-					justifyContent: 'center',
-				}}
+                                sx={{
+                                        width: 160,
+                                        textAlign: 'center',
+                                        pr: 2,
+                                        borderRight: `1px solid ${theme.palette.grey[100]}`,
+                                        display: 'flex',
+                                        flexDirection: 'column',
+                                        justifyContent: 'center',
+                                }}
 			>
 				<Typography variant='h5' sx={{ fontWeight: 'bold', mb: 1 }}>
 					{`${totalPrice !== 0 ? totalPrice : '--'} ${currencySymbol}`}
 				</Typography>
-				<Button
-					variant='contained'
-					sx={{
-						background: '#ff7f2a',
-						color: '#fff',
-						borderRadius: 2,
-						boxShadow: 'none',
-						textTransform: 'none',
-						whiteSpace: 'nowrap',
-						'&:hover': { background: '#ff6600' },
-					}}
-					onClick={() => {
+                                <Button
+                                        variant='contained'
+                                        color='orange'
+                                        sx={{
+                                                borderRadius: 2,
+                                                boxShadow: 'none',
+                                                textTransform: 'none',
+                                                whiteSpace: 'nowrap',
+                                        }}
+                                        onClick={() => {
 						const url = `/cart?flight=${outbound.id}${returnFlight ? `&return=${returnFlight.id}` : ''}`;
 						window.open(url, '_blank');
 					}}

--- a/client/src/theme/components.js
+++ b/client/src/theme/components.js
@@ -1,3 +1,6 @@
+import { alpha } from '@mui/material/styles';
+import palette from './palette';
+
 const components = {
 	MuiCssBaseline: {
 		styleOverrides: `
@@ -48,8 +51,8 @@ const components = {
           padding: 0;
           font-family: 'PTRootUI', sans-serif;
           font-weight: 400;
-          color: #525665;
-          background-color: #FFFFFF;
+          color: ${palette.text.primary};
+          background-color: ${palette.background.default};
           -webkit-font-smoothing: antialiased;
           -moz-osx-font-smoothing: grayscale;
         }
@@ -93,32 +96,32 @@ const components = {
 				},
 			},
 			containedPrimary: {
-				backgroundColor: '#0084FF', // blue
-				'&:hover': {
-					backgroundColor: '#0066CC', // blue
-				},
-			},
-			containedSecondary: {
-				backgroundColor: '#7D71FF', // violet
-				'&:hover': {
-					backgroundColor: '#5F55CC', // darker violet
-				},
-			},
-			outlinedPrimary: {
-				borderColor: '#0084FF', // blue
-				'&:hover': {
-					backgroundColor: 'rgba(0, 132, 255, 0.08)',
-				},
-			},
-		},
-	},
+                                backgroundColor: palette.primary.main,
+                                '&:hover': {
+                                        backgroundColor: palette.primary.dark,
+                                },
+                        },
+                        containedSecondary: {
+                                backgroundColor: palette.secondary.main,
+                                '&:hover': {
+                                        backgroundColor: palette.secondary.dark,
+                                },
+                        },
+                        outlinedPrimary: {
+                                borderColor: palette.primary.main,
+                                '&:hover': {
+                                        backgroundColor: palette.action.hover,
+                                },
+                        },
+                },
+        },
 
 	// Card styles
 	MuiCard: {
 		styleOverrides: {
 			root: {
 				borderRadius: '0.75rem', // --radius-md
-				boxShadow: '0 2px 6px rgba(0,0,0,.08)', // shadow-elev1
+                                boxShadow: `0 2px 6px ${alpha(palette.black, 0.08)}`, // shadow-elev1
 				padding: '16px',
 				transition: '150ms ease-in-out',
 			},
@@ -136,14 +139,14 @@ const components = {
 						height: 'auto',
 					},
 					'& fieldset': {
-						borderColor: '#E0E0E0',
-					},
-					'&:hover fieldset': {
-						borderColor: 'rgba(0, 132, 255, 0.4)',
-					},
-					'&.Mui-focused fieldset': {
-						borderColor: '#0084FF',
-					},
+                                                borderColor: palette.grey[300],
+                                        },
+                                        '&:hover fieldset': {
+                                                borderColor: palette.action.focus,
+                                        },
+                                        '&.Mui-focused fieldset': {
+                                                borderColor: palette.primary.main,
+                                        },
 				},
 				'& .MuiInputBase-input': {
 					padding: '14px 16px',
@@ -165,9 +168,9 @@ const components = {
 		styleOverrides: {
 			root: {
 				strokeWidth: 1.5,
-				'&.active': {
-					color: '#0084FF', // blue
-				},
+                                        '&.active': {
+                                                color: palette.primary.main,
+                                        },
 			},
 		},
 	},
@@ -177,8 +180,8 @@ const components = {
 		styleOverrides: {
 			root: {
 				'&.section-bg': {
-					backgroundColor: '#F3F4F8', // gray-100
-					borderRadius: '0.75rem', // radius-md
+                                        backgroundColor: palette.background.section, // gray-100
+                                        borderRadius: '0.75rem', // radius-md
 				},
 			},
 		},

--- a/client/src/theme/palette.js
+++ b/client/src/theme/palette.js
@@ -36,32 +36,43 @@ const palette = {
 		dark: '#E65100',
 		contrastText: '#FFFFFF',
 	},
-	info: {
-		main: '#0288D1',
-		light: '#03A9F4',
-		dark: '#01579B',
-		contrastText: '#FFFFFF',
-	},
-	grey: {
-		main: '#626572ff',
-		light: '#717280',
-		dark: '#4c4d50ff',
-		contrastText: '#FFFFFF',
-	},
-	action: {
-		active: '#717280',
-		hover: 'rgba(0, 132, 255, 0.08)',
-		selected: 'rgba(0, 132, 255, 0.16)',
-	},
-	text: {
-		primary: '#525665',
-		secondary: '#717280',
-	},
-	background: {
-		default: '#FFFFFF',
-		paper: '#FFFFFF',
-		section: '#F3F4F8',
-	},
+        info: {
+                main: '#0288D1',
+                light: '#03A9F4',
+                dark: '#01579B',
+                contrastText: '#FFFFFF',
+        },
+       indigo: {
+               main: '#0D0B68',
+               light: '#6c63ff',
+       },
+       grey: {
+                main: '#626572ff',
+                light: '#717280',
+                dark: '#4c4d50ff',
+               contrastText: '#FFFFFF',
+               100: '#EEEEEE',
+               200: '#DDDDDD',
+               300: '#E0E0E0',
+       },
+       action: {
+                active: '#717280',
+                hover: 'rgba(0, 132, 255, 0.08)',
+               selected: 'rgba(0, 132, 255, 0.16)',
+               focus: 'rgba(0, 132, 255, 0.4)',
+       },
+        text: {
+                primary: '#525665',
+                secondary: '#717280',
+        },
+        background: {
+                default: '#FFFFFF',
+                paper: '#FFFFFF',
+               section: '#F3F4F8',
+               lightBlue: '#f0f2ff',
+        },
+       white: '#FFFFFF',
+       black: '#000000',
 };
 
 export default palette;

--- a/client/src/theme/styles.js
+++ b/client/src/theme/styles.js
@@ -1,5 +1,7 @@
+import palette from './palette';
+
 export const authIconContainer = {
-	bgcolor: '#f0f2ff',
+        bgcolor: palette.background.lightBlue,
 	borderRadius: '50%',
 	p: 2,
 	display: 'flex',
@@ -8,12 +10,12 @@ export const authIconContainer = {
 };
 
 export const authIcon = {
-	fontSize: 40,
-	color: '#6c63ff',
+        fontSize: 40,
+        color: palette.indigo.light,
 };
 
 export const authLink = {
-	color: '#6c63ff',
-	textDecoration: 'none',
-	cursor: 'pointer',
+        color: palette.indigo.light,
+        textDecoration: 'none',
+        cursor: 'pointer',
 };

--- a/client/src/theme/typography.js
+++ b/client/src/theme/typography.js
@@ -1,3 +1,5 @@
+import palette from './palette';
+
 const typography = {
 	fontFamily: ['PTRootUI', 'Roboto', 'Arial', 'sans-serif'].join(','),
 	fontSize: 16,
@@ -10,7 +12,7 @@ const typography = {
 		fontWeight: 700,
 		fontSize: '2.5rem', // 40px
 		lineHeight: 1.2,
-		color: '#0D0B68', // indigo
+                color: palette.indigo.main, // indigo
 		marginBottom: '1rem',
 	},
 	h2: {
@@ -18,7 +20,7 @@ const typography = {
 		fontWeight: 700,
 		fontSize: '2rem', // 32px
 		lineHeight: 1.25,
-		color: '#0D0B68', // indigo
+                color: palette.indigo.main, // indigo
 		marginBottom: '0.75rem',
 	},
 	h3: {
@@ -26,7 +28,7 @@ const typography = {
 		fontWeight: 600,
 		fontSize: '1.5rem', // 24px
 		lineHeight: 1.3,
-		color: '#0D0B68', // indigo
+                color: palette.indigo.main, // indigo
 		marginBottom: '0.5rem',
 	},
 	h4: {
@@ -34,7 +36,7 @@ const typography = {
 		fontWeight: 600,
 		fontSize: '1.25rem', // 20px
 		lineHeight: 1.4,
-		color: '#0D0B68', // indigo
+                color: palette.indigo.main, // indigo
 		marginBottom: '0.5rem',
 	},
 	body1: {
@@ -42,14 +44,14 @@ const typography = {
 		fontWeight: 400,
 		fontSize: '1rem', // 16px
 		lineHeight: 1.5,
-		color: '#525665', // gray-700
+                color: palette.text.primary, // gray-700
 	},
 	body2: {
 		fontFamily: 'PTRootUI, sans-serif',
 		fontWeight: 400,
 		fontSize: '0.875rem', // 14px
 		lineHeight: 1.43,
-		color: '#525665', // gray-700
+                color: palette.text.primary, // gray-700
 	},
 	button: {
 		fontFamily: 'PTRootUI, sans-serif',


### PR DESCRIPTION
## Summary
- add missing colors to theme palette
- update components to consume colors from palette

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68904023d580832f81c3ba4a5dcfd619