### PR TITLE
Reduce redundant search result requests

### DIFF
--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -7,11 +7,18 @@ import SearchForm from './SearchForm';
 import SearchResultCard from './SearchResultCard';
 import { UI_LABELS, ENUM_LABELS } from '../../constants';
 import { fetchSearchFlights, fetchNearbyDateFlights } from '../../redux/actions/search';
+import { fetchAirports } from '../../redux/actions/airport';
+import { fetchAirlines } from '../../redux/actions/airline';
+import { fetchRoutes } from '../../redux/actions/route';
 import { formatDate, getFlightDurationMinutes } from '../utils';
 
 const Search = () => {
-	const dispatch = useDispatch();
-	const { flights, nearbyFlights, isLoading } = useSelector((state) => state.search);
+        const dispatch = useDispatch();
+        const { flights, nearbyFlights, isLoading } = useSelector((state) => state.search);
+        const { airlines, isLoading: airlinesLoading } = useSelector((state) => state.airlines);
+        const { airports, isLoading: airportsLoading } = useSelector((state) => state.airports);
+        const { routes, isLoading: routesLoading } = useSelector((state) => state.routes);
+        const detailsLoading = airlinesLoading || airportsLoading || routesLoading;
 	const navigate = useNavigate();
 	const [params] = useSearchParams();
 	const paramObj = Object.fromEntries(params.entries());
@@ -27,13 +34,19 @@ const Search = () => {
 	const isExact = params.get('date_mode') === 'exact';
 	const hasReturn = returnDate || returnFrom || returnTo;
 
-	const [sortKey, setSortKey] = useState('price');
-	const [nearDates, setNearDates] = useState([]);
-	const [visibleCount, setVisibleCount] = useState(10);
+        const [sortKey, setSortKey] = useState('price');
+        const [nearDates, setNearDates] = useState([]);
+        const [visibleCount, setVisibleCount] = useState(10);
 
-	useEffect(() => {
-		dispatch(fetchSearchFlights(paramObj));
-	}, [dispatch, paramStr]);
+        useEffect(() => {
+                dispatch(fetchAirports());
+                dispatch(fetchAirlines());
+                dispatch(fetchRoutes());
+        }, [dispatch]);
+
+        useEffect(() => {
+                dispatch(fetchSearchFlights(paramObj));
+        }, [dispatch, paramStr]);
 
 	useEffect(() => {
 		const titleFrom = departFrom || depart || '';
@@ -200,14 +213,22 @@ const Search = () => {
 						<CircularProgress />
 					</Box>
 				) : sortedGrouped && sortedGrouped.length ? (
-					sortedGrouped
-						.slice(0, visibleCount)
-						.map((g, idx) => (
-							<SearchResultCard key={idx} outbound={g.outbound} returnFlight={g.returnFlight} />
-						))
-				) : (
-					<Typography>{UI_LABELS.SEARCH.no_results}</Typography>
-				)}
+                                        sortedGrouped
+                                                .slice(0, visibleCount)
+                                                .map((g, idx) => (
+                                                        <SearchResultCard
+                                                                key={idx}
+                                                                outbound={g.outbound}
+                                                                returnFlight={g.returnFlight}
+                                                                airlines={airlines}
+                                                                airports={airports}
+                                                                routes={routes}
+                                                                isLoading={detailsLoading}
+                                                        />
+                                                ))
+                                ) : (
+                                        <Typography>{UI_LABELS.SEARCH.no_results}</Typography>
+                                )}
 
 				{visibleCount < sortedGrouped.length && (
 					<Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>


### PR DESCRIPTION
## Summary
- fetch airport, airline, and route data once in search page and share with result cards
- pass loading state and fetched data to SearchResultCard to manage skeletons correctly

## Testing
- `pytest` *(fails: Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set)*
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68904da06fc8832f84c1ad329825e99b