### PR TITLE
feat: improve flight sorting and near date suggestions

### DIFF
--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -8,15 +8,16 @@ import Base from '../Base';
 import SearchForm from './SearchForm';
 import SearchResultCard from './SearchResultCard';
 import { UI_LABELS, ENUM_LABELS, DATE_API_FORMAT } from '../../constants';
-import { fetchSearchFlights, fetchNearbyDateFlights } from '../../redux/actions/search';
+import { fetchSearchFlights } from '../../redux/actions/search';
 import { fetchAirports } from '../../redux/actions/airport';
 import { fetchAirlines } from '../../redux/actions/airline';
 import { fetchRoutes } from '../../redux/actions/route';
 import { formatDate, formatNumber, getFlightDurationMinutes } from '../utils';
+import { serverApi } from '../../api';
 
 const Search = () => {
 	const dispatch = useDispatch();
-	const { flights, nearbyFlights, isLoading } = useSelector((state) => state.search);
+        const { flights, isLoading } = useSelector((state) => state.search);
 	const { airlines, isLoading: airlinesLoading } = useSelector((state) => state.airlines);
 	const { airports, isLoading: airportsLoading } = useSelector((state) => state.airports);
 	const { routes, isLoading: routesLoading } = useSelector((state) => state.routes);
@@ -36,9 +37,11 @@ const Search = () => {
 	const isExact = params.get('date_mode') === 'exact';
 	const hasReturn = returnDate || returnFrom || returnTo;
 
-	const [sortKey, setSortKey] = useState('price');
-	const [nearDates, setNearDates] = useState([]);
-	const [visibleCount, setVisibleCount] = useState(10);
+        const [sortKey, setSortKey] = useState('price');
+        const [sortOrder, setSortOrder] = useState('asc');
+        const [nearDatesOutbound, setNearDatesOutbound] = useState([]);
+        const [nearDatesReturn, setNearDatesReturn] = useState([]);
+        const [visibleCount, setVisibleCount] = useState(10);
 
 	useEffect(() => {
 		dispatch(fetchAirports());
@@ -59,55 +62,75 @@ const Search = () => {
 		};
 	}, [from, to, depart, returnDate, departFrom, returnTo]);
 
-	useEffect(() => {
-		const fetchNearDates = () => {
-			if (!from || !to || !(depart || departFrom)) {
-				setNearDates([]);
-				return;
-			}
-			const baseDate = departFrom || depart;
-			try {
-				const start = new Date(baseDate);
-				const end = new Date(baseDate);
-				start.setDate(start.getDate() - 30);
-				end.setDate(end.getDate() + 30);
-				const paramsRange = {
-					from,
-					to,
-					when_from: formatDate(start, DATE_API_FORMAT),
-					when_to: formatDate(end, DATE_API_FORMAT),
-					class: params.get('class'),
-				};
-				dispatch(fetchNearbyDateFlights(paramsRange));
-			} catch (e) {
-				console.error(e);
-				setNearDates([]);
-			}
-		};
-		fetchNearDates();
-	}, [from, to, depart, departFrom, dispatch, params]);
+        const buildNearDates = (flights) => {
+                const map = {};
+                for (const f of flights) {
+                        const d = f.scheduled_departure;
+                        const price = f.price || f.min_price || 0;
+                        if (!map[d] || price < map[d].price) {
+                                map[d] = { price, currency: f.currency };
+                        }
+                }
+                return Object.entries(map)
+                        .sort((a, b) => new Date(a[0]) - new Date(b[0]))
+                        .map(([date, info]) => ({ date, price: info.price, currency: info.currency }));
+        };
 
-	useEffect(() => {
-		if (!nearbyFlights.length) {
-			setNearDates([]);
-			return;
-		}
+        useEffect(() => {
+                const fetchNearDates = async () => {
+                        if (!isExact || !from || !to || !depart) {
+                                setNearDatesOutbound([]);
+                                return;
+                        }
+                        try {
+                                const start = new Date(depart);
+                                const end = new Date(depart);
+                                start.setDate(start.getDate() - 30);
+                                end.setDate(end.getDate() + 30);
+                                const paramsRange = {
+                                        from,
+                                        to,
+                                        when_from: formatDate(start, DATE_API_FORMAT),
+                                        when_to: formatDate(end, DATE_API_FORMAT),
+                                        class: params.get('class'),
+                                };
+                                const res = await serverApi.get('/search/flights', { params: paramsRange });
+                                setNearDatesOutbound(buildNearDates(res.data));
+                        } catch (e) {
+                                console.error(e);
+                                setNearDatesOutbound([]);
+                        }
+                };
+                fetchNearDates();
+        }, [isExact, from, to, depart, params]);
 
-		const map = {};
-		for (const f of nearbyFlights) {
-			const d = f.scheduled_departure;
-			const price = f.price || f.min_price || 0;
-			if (!map[d] || price < map[d].price) {
-				map[d] = { price, currency: f.currency };
-			}
-		}
-
-		const arr = Object.entries(map)
-			.sort((a, b) => new Date(a[0]) - new Date(b[0]))
-			.map(([date, info]) => ({ date, price: info.price, currency: info.currency }));
-
-		setNearDates(arr);
-	}, [nearbyFlights]);
+        useEffect(() => {
+                const fetchReturnNearDates = async () => {
+                        if (!isExact || !from || !to || !returnDate) {
+                                setNearDatesReturn([]);
+                                return;
+                        }
+                        try {
+                                const start = new Date(returnDate);
+                                const end = new Date(returnDate);
+                                start.setDate(start.getDate() - 30);
+                                end.setDate(end.getDate() + 30);
+                                const paramsRange = {
+                                        from: to,
+                                        to: from,
+                                        when_from: formatDate(start, DATE_API_FORMAT),
+                                        when_to: formatDate(end, DATE_API_FORMAT),
+                                        class: params.get('class'),
+                                };
+                                const res = await serverApi.get('/search/flights', { params: paramsRange });
+                                setNearDatesReturn(buildNearDates(res.data));
+                        } catch (e) {
+                                console.error(e);
+                                setNearDatesReturn([]);
+                        }
+                };
+                fetchReturnNearDates();
+        }, [isExact, from, to, returnDate, params]);
 
 	const grouped = [];
 	if (!isExact) {
@@ -135,28 +158,53 @@ const Search = () => {
 		);
 	};
 
-	const sortGroups = (items) => {
-		return [...items].sort((a, b) => {
-			switch (sortKey) {
-				case 'price':
-					return getTotalPrice(a) - getTotalPrice(b);
-				case 'arrival':
-					return (a.outbound.scheduled_arrival_time || '').localeCompare(
-						b.outbound.scheduled_arrival_time || ''
-					);
-				case 'departure':
-					return (a.outbound.scheduled_departure_time || '').localeCompare(
-						b.outbound.scheduled_departure_time || ''
-					);
-				case 'duration':
-					return getFlightDurationMinutes(a.outbound) - getFlightDurationMinutes(b.outbound);
-				default:
-					return 0;
-			}
-		});
-	};
+        const parseTime = (t) => {
+                if (!t) return 0;
+                const [h = 0, m = 0, s = 0] = t.split(':').map((v) => parseInt(v, 10));
+                return h * 3600 + m * 60 + s;
+        };
 
-	const sortedGrouped = sortGroups(grouped);
+        const sortGroups = (items) => {
+                return [...items].sort((a, b) => {
+                        let res = 0;
+                        switch (sortKey) {
+                                case 'price':
+                                        res = getTotalPrice(a) - getTotalPrice(b);
+                                        break;
+                                case 'arrival_time':
+                                        res = parseTime(a.outbound.scheduled_arrival_time) - parseTime(b.outbound.scheduled_arrival_time);
+                                        break;
+                                case 'arrival_date':
+                                        res = new Date(a.outbound.scheduled_arrival) - new Date(b.outbound.scheduled_arrival);
+                                        break;
+                                case 'departure_time':
+                                        res =
+                                                parseTime(a.outbound.scheduled_departure_time) -
+                                                parseTime(b.outbound.scheduled_departure_time);
+                                        break;
+                                case 'departure_date':
+                                        res = new Date(a.outbound.scheduled_departure) - new Date(b.outbound.scheduled_departure);
+                                        break;
+                                case 'duration':
+                                        res = getFlightDurationMinutes(a.outbound) - getFlightDurationMinutes(b.outbound);
+                                        break;
+                                default:
+                                        res = 0;
+                        }
+                        return sortOrder === 'asc' ? res : -res;
+                });
+        };
+
+        const sortedGrouped = sortGroups(grouped);
+
+        const handleSort = (key) => {
+                if (key === sortKey) {
+                        setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc'));
+                } else {
+                        setSortKey(key);
+                        setSortOrder('asc');
+                }
+        };
 
 	return (
 		<Base>
@@ -168,99 +216,173 @@ const Search = () => {
 					{UI_LABELS.SEARCH.results}
 				</Typography>
 
-				<Box
-					sx={{
-						display: 'flex',
-						mb: 2,
-						alignItems: 'center',
-						justifyContent: 'space-between',
-						gap: 2,
-					}}
-				>
-					<Box
-						sx={{
-							display: 'flex',
-							alignItems: 'center',
-							flex: 1,
-							minWidth: 0,
-						}}
-					>
-						{nearDates.length > 0 && (
-							<Box
-								sx={{
-									display: 'flex',
-									alignItems: 'center',
-									width: '100%',
-									overflow: 'hidden',
-								}}
-							>
-								<Box
-									sx={{
-										display: 'flex',
-										alignItems: 'center',
-										mr: 2,
-										flexShrink: 0,
-										'& > svg': { mr: 1 },
-									}}
-								>
-									<CalendarMonthIcon color='action' />
-									<Typography variant='subtitle1'>{UI_LABELS.SEARCH.nearby_dates}:</Typography>
-								</Box>
-								<Box
-									sx={{
-										display: 'flex',
-										gap: 1,
-										flexWrap: 'nowrap',
-										overflowX: 'auto',
-										pb: 1,
-										flex: 1,
-										minWidth: 0,
-									}}
-								>
-									{nearDates.map((d) => (
-										<Button
-											key={d.date}
-											size='small'
-											variant='outlined'
-											sx={{
-												flexShrink: 0,
-												minWidth: 'auto',
-												borderRadius: 1,
-												px: 1.5,
-											}}
-											onClick={() => {
-												const newParams = new URLSearchParams(paramObj);
-												newParams.set('when', d.date);
-												newParams.delete('when_from');
-												newParams.delete('when_to');
-												navigate(`/search?${newParams.toString()}`);
-											}}
-										>
-											{`${formatDate(d.date, 'dd.MM')} - ${formatNumber(d.price)} ${
-												ENUM_LABELS.CURRENCY_SYMBOL[d.currency] || ''
-											}`}
-										</Button>
-									))}
-								</Box>
-							</Box>
-						)}
-					</Box>
+                                <Box
+                                        sx={{
+                                                display: 'flex',
+                                                mb: 2,
+                                                alignItems: 'center',
+                                                justifyContent: 'space-between',
+                                                gap: 2,
+                                        }}
+                                >
+                                        <Box
+                                                sx={{
+                                                        display: 'flex',
+                                                        alignItems: 'center',
+                                                        flex: 1,
+                                                        minWidth: 0,
+                                                        gap: 2,
+                                                }}
+                                        >
+                                                {nearDatesOutbound.length > 0 && (
+                                                        <Box
+                                                                sx={{
+                                                                        display: 'flex',
+                                                                        alignItems: 'center',
+                                                                        width: '100%',
+                                                                        overflow: 'hidden',
+                                                                }}
+                                                        >
+                                                                <Box
+                                                                        sx={{
+                                                                                display: 'flex',
+                                                                                alignItems: 'center',
+                                                                                mr: 2,
+                                                                                flexShrink: 0,
+                                                                                '& > svg': { mr: 1 },
+                                                                        }}
+                                                                >
+                                                                        <CalendarMonthIcon color='action' />
+                                                                        <Typography variant='subtitle1'>{UI_LABELS.SEARCH.nearby_dates}:</Typography>
+                                                                </Box>
+                                                                <Box
+                                                                        sx={{
+                                                                                display: 'flex',
+                                                                                gap: 1,
+                                                                                flexWrap: 'nowrap',
+                                                                                overflowX: 'auto',
+                                                                                pb: 1,
+                                                                                flex: 1,
+                                                                                minWidth: 0,
+                                                                        }}
+                                                                >
+                                                                        {nearDatesOutbound.map((d) => (
+                                                                                <Button
+                                                                                        key={d.date}
+                                                                                        size='small'
+                                                                                        variant='outlined'
+                                                                                        sx={{
+                                                                                                flexShrink: 0,
+                                                                                                minWidth: 'auto',
+                                                                                                borderRadius: 1,
+                                                                                                px: 1.5,
+                                                                                        }}
+                                                                                        onClick={() => {
+                                                                                                const newParams = new URLSearchParams(paramObj);
+                                                                                                newParams.set('when', d.date);
+                                                                                                newParams.delete('when_from');
+                                                                                                newParams.delete('when_to');
+                                                                                                navigate(`/search?${newParams.toString()}`);
+                                                                                        }}
+                                                                                >
+                                                                                        {`${formatDate(d.date, 'dd.MM')} - ${formatNumber(d.price)} ${
+                                                                                                ENUM_LABELS.CURRENCY_SYMBOL[d.currency] || ''
+                                                                                        }`}
+                                                                                </Button>
+                                                                        ))}
+                                                                </Box>
+                                                        </Box>
+                                                )}
+                                                {nearDatesReturn.length > 0 && (
+                                                        <Box
+                                                                sx={{
+                                                                        display: 'flex',
+                                                                        alignItems: 'center',
+                                                                        width: '100%',
+                                                                        overflow: 'hidden',
+                                                                }}
+                                                        >
+                                                                <Box
+                                                                        sx={{
+                                                                                display: 'flex',
+                                                                                alignItems: 'center',
+                                                                                mr: 2,
+                                                                                flexShrink: 0,
+                                                                                '& > svg': { mr: 1 },
+                                                                        }}
+                                                                >
+                                                                        <CalendarMonthIcon color='action' />
+                                                                        <Typography variant='subtitle1'>{UI_LABELS.SEARCH.nearby_dates}:</Typography>
+                                                                </Box>
+                                                                <Box
+                                                                        sx={{
+                                                                                display: 'flex',
+                                                                                gap: 1,
+                                                                                flexWrap: 'nowrap',
+                                                                                overflowX: 'auto',
+                                                                                pb: 1,
+                                                                                flex: 1,
+                                                                                minWidth: 0,
+                                                                        }}
+                                                                >
+                                                                        {nearDatesReturn.map((d) => (
+                                                                                <Button
+                                                                                        key={d.date}
+                                                                                        size='small'
+                                                                                        variant='outlined'
+                                                                                        sx={{
+                                                                                                flexShrink: 0,
+                                                                                                minWidth: 'auto',
+                                                                                                borderRadius: 1,
+                                                                                                px: 1.5,
+                                                                                        }}
+                                                                                        onClick={() => {
+                                                                                                const newParams = new URLSearchParams(paramObj);
+                                                                                                newParams.set('return', d.date);
+                                                                                                newParams.delete('return_from');
+                                                                                                newParams.delete('return_to');
+                                                                                                navigate(`/search?${newParams.toString()}`);
+                                                                                        }}
+                                                                                >
+                                                                                        {`${formatDate(d.date, 'dd.MM')} - ${formatNumber(d.price)} ${
+                                                                                                ENUM_LABELS.CURRENCY_SYMBOL[d.currency] || ''
+                                                                                        }`}
+                                                                                </Button>
+                                                                        ))}
+                                                                </Box>
+                                                        </Box>
+                                                )}
+                                        </Box>
 
-					<FormControl size='small' sx={{ width: 200, flexShrink: 0 }}>
-						<InputLabel id='sort-label'>{UI_LABELS.SEARCH.sort.label}</InputLabel>
-						<Select
-							labelId='sort-label'
-							value={sortKey}
-							label={UI_LABELS.SEARCH.sort.label}
-							onChange={(e) => setSortKey(e.target.value)}
-						>
-							<MenuItem value='price'>{UI_LABELS.SEARCH.sort.price}</MenuItem>
-							<MenuItem value='arrival'>{UI_LABELS.SEARCH.sort.arrival}</MenuItem>
-							<MenuItem value='departure'>{UI_LABELS.SEARCH.sort.departure}</MenuItem>
-							<MenuItem value='duration'>{UI_LABELS.SEARCH.sort.duration}</MenuItem>
-						</Select>
-					</FormControl>
-				</Box>
+                                        <FormControl size='small' sx={{ width: 200, flexShrink: 0 }}>
+                                                <InputLabel id='sort-label'>{UI_LABELS.SEARCH.sort.label}</InputLabel>
+                                                <Select
+                                                        labelId='sort-label'
+                                                        value={sortKey}
+                                                        label={UI_LABELS.SEARCH.sort.label}
+                                                        onChange={() => {}}
+                                                >
+                                                        <MenuItem value='price' onClick={() => handleSort('price')}>
+                                                                {UI_LABELS.SEARCH.sort.price}
+                                                        </MenuItem>
+                                                        <MenuItem value='arrival_time' onClick={() => handleSort('arrival_time')}>
+                                                                {UI_LABELS.SEARCH.sort.arrival_time}
+                                                        </MenuItem>
+                                                        <MenuItem value='arrival_date' onClick={() => handleSort('arrival_date')}>
+                                                                {UI_LABELS.SEARCH.sort.arrival_date}
+                                                        </MenuItem>
+                                                        <MenuItem value='departure_time' onClick={() => handleSort('departure_time')}>
+                                                                {UI_LABELS.SEARCH.sort.departure_time}
+                                                        </MenuItem>
+                                                        <MenuItem value='departure_date' onClick={() => handleSort('departure_date')}>
+                                                                {UI_LABELS.SEARCH.sort.departure_date}
+                                                        </MenuItem>
+                                                        <MenuItem value='duration' onClick={() => handleSort('duration')}>
+                                                                {UI_LABELS.SEARCH.sort.duration}
+                                                        </MenuItem>
+                                                </Select>
+                                        </FormControl>
+                                </Box>
 
 				{isLoading && flights.length === 0 ? (
 					<Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -312,16 +312,18 @@ export const UI_LABELS = {
 			price: 'Цена',
 			price_from: 'От',
 		},
-		sort: {
-			label: 'Сортировка',
-			price: 'По цене',
-			arrival: 'По времени прибытия',
-			departure: 'По времени отправления',
-			duration: 'По времени в пути',
-		},
-		nearby_dates: 'Ближайшие даты',
-		show_more: 'Показать еще билеты',
-	},
+                sort: {
+                        label: 'Сортировка',
+                        price: 'По цене',
+                        arrival_time: 'По времени прибытия',
+                        arrival_date: 'По дате прибытия',
+                        departure_time: 'По времени отправления',
+                        departure_date: 'По дате отправления',
+                        duration: 'По времени в пути',
+                },
+                nearby_dates: 'Ближайшие даты',
+                show_more: 'Показать еще билеты',
+        },
 };
 
 export default UI_LABELS;


### PR DESCRIPTION
## Summary
- allow toggling ascending/descending sort order and add date/time sorting options
- suggest nearby dates separately for outbound and return legs when searching fixed dates

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6890b07fbc6c832f8a2dda06542a6323