### PR TITLE
refactor: simplify hooks in search components

### DIFF
--- a/client/src/components/search/Schedule.js
+++ b/client/src/components/search/Schedule.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { Box, Typography, Button, CircularProgress } from '@mui/material';
@@ -46,8 +46,8 @@ const Schedule = () => {
 		return airlines.find((a) => a.id === id);
 	};
 
-	const outboundFlights = useMemo(() => flights.filter((f) => f.direction === 'outbound'), [flights]);
-	const returnFlights = useMemo(() => flights.filter((f) => f.direction === 'return'), [flights]);
+        const outboundFlights = flights.filter((f) => f.direction === 'outbound');
+        const returnFlights = flights.filter((f) => f.direction === 'return');
 
 	const [selectedOutbound, setSelectedOutbound] = useState(null);
 	const [selectedReturn, setSelectedReturn] = useState(null);

--- a/client/src/components/search/ScheduleTable.js
+++ b/client/src/components/search/ScheduleTable.js
@@ -46,35 +46,33 @@ const ScheduleTable = ({ flights, airlines, selectedId = null, onSelect = () => 
 	const [page, setPage] = useState(0);
 	const [rowsPerPage, setRowsPerPage] = useState(10);
 
-	const rows = useMemo(
-		() =>
-			flights.map((f) => {
-				const airline = airlines.find((a) => a.id === f.airline_id);
-				return {
-					id: f.id,
-					flightNumber: f.flight_number,
-					airlineFlightNumber: f.airline_flight_number,
-					scheduledDepartureDate: new Date(f.scheduled_departure),
-					scheduledDepartureTime: f.scheduled_departure_time,
-					airlineId: f.airline_id,
-					airline: airline ? airline.name : f.airline_id,
-					price: f.min_price
-						? `${UI_LABELS.SEARCH.flight_details.price_from.toLowerCase()} ${formatNumber(f.min_price)} ${
-								ENUM_LABELS.CURRENCY_SYMBOL[f.currency] || ''
-						  }`
-						: '',
-				};
-			}),
-		[flights, airlines]
-	);
+        const handleRequestSort = (property) => {
+                const isAsc = orderBy === property && order === 'asc';
+                setOrder(isAsc ? 'desc' : 'asc');
+                setOrderBy(property);
+        };
 
-	const handleRequestSort = (property) => {
-		const isAsc = orderBy === property && order === 'asc';
-		setOrder(isAsc ? 'desc' : 'asc');
-		setOrderBy(property);
-	};
+        const sortedRows = useMemo(() => {
+                const rows = flights.map((f) => {
+                        const airline = airlines.find((a) => a.id === f.airline_id);
+                        return {
+                                id: f.id,
+                                flightNumber: f.flight_number,
+                                airlineFlightNumber: f.airline_flight_number,
+                                scheduledDepartureDate: new Date(f.scheduled_departure),
+                                scheduledDepartureTime: f.scheduled_departure_time,
+                                airlineId: f.airline_id,
+                                airline: airline ? airline.name : f.airline_id,
+                                price: f.min_price
+                                        ? `${UI_LABELS.SEARCH.flight_details.price_from.toLowerCase()} ${formatNumber(f.min_price)} ${
+                                                        ENUM_LABELS.CURRENCY_SYMBOL[f.currency] || ''
+                                                }`
+                                        : '',
+                        };
+                });
 
-	const sortedRows = useMemo(() => stableSort(rows, getComparator(order, orderBy)), [rows, order, orderBy]);
+                return stableSort(rows, getComparator(order, orderBy));
+        }, [flights, airlines, order, orderBy]);
 
 	const headCells = [
 		{ id: 'airlineFlightNumber', label: FIELD_LABELS.FLIGHT.flight_number },

--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -132,13 +132,10 @@ const Search = () => {
 		dispatch(fetchNearbyDateFlights(requestParams));
 	};
 
-	useEffect(() => {
-		fetchNearbyDates(depart, 'outbound');
-	}, [dispatch, isExact, from, to, depart, returnDate]);
-
-	useEffect(() => {
-		fetchNearbyDates(returnDate, 'return');
-	}, [dispatch, isExact, from, to, depart, returnDate]);
+        useEffect(() => {
+                fetchNearbyDates(depart, 'outbound');
+                fetchNearbyDates(returnDate, 'return');
+        }, [dispatch, isExact, from, to, depart, returnDate]);
 
 	const grouped = [];
 	if (hasReturn) {

--- a/client/src/components/search/SearchForm.js
+++ b/client/src/components/search/SearchForm.js
@@ -101,17 +101,16 @@ const SearchForm = ({ initialParams = {} }) => {
 	const dispatch = useDispatch();
 	const theme = useTheme();
 
-	const { airports } = useSelector((state) => state.search);
+        const { airports } = useSelector((state) => state.search);
 
-	const storedParams = useMemo(() => {
-		try {
-			return JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
-		} catch (e) {
-			return {};
-		}
-	}, [initialParams]);
+        let storedParams = {};
+        try {
+                storedParams = JSON.parse(localStorage.getItem(STORAGE_KEY)) || {};
+        } catch (e) {
+                storedParams = {};
+        }
 
-	const combinedParams = useMemo(() => ({ ...storedParams, ...initialParams }), [storedParams, initialParams]);
+        const combinedParams = { ...storedParams, ...initialParams };
 
 	const [formValues, setFormValues] = useState({
 		from: combinedParams.from || '',
@@ -143,25 +142,11 @@ const SearchForm = ({ initialParams = {} }) => {
 		[airports]
 	);
 
-	// Initialize form
-	useEffect(() => {
-		setFormValues({
-			from: combinedParams.from || '',
-			to: combinedParams.to || '',
-			departDate: parseDate(combinedParams.when),
-			returnDate: parseDate(combinedParams.return),
-			departFrom: parseDate(combinedParams.when_from),
-			departTo: parseDate(combinedParams.when_to),
-			returnFrom: parseDate(combinedParams.return_from),
-			returnTo: parseDate(combinedParams.return_to),
-		});
-	}, []);
-
-	// Update on specific parameter changes
-	useEffect(() => {
-		if (initialParams.from || initialParams.to || initialParams.when || initialParams.return) {
-			setFormValues((prev) => ({
-				...prev,
+        // Update on specific parameter changes
+        useEffect(() => {
+                if (initialParams.from || initialParams.to || initialParams.when || initialParams.return) {
+                        setFormValues((prev) => ({
+                                ...prev,
 				from: initialParams.from || prev.from,
 				to: initialParams.to || prev.to,
 				departDate: initialParams.when ? parseDate(initialParams.when) : prev.departDate,
@@ -215,24 +200,20 @@ const SearchForm = ({ initialParams = {} }) => {
 	const passengerWord = UI_LABELS.HOME.search.passenger_word(totalPassengers);
 	const seatClassLabel = seatClassOptions.find((o) => o.value === seatClass)?.label;
 
-	const fields = useMemo(
-		() => ({
-			from: { key: 'from', label: UI_LABELS.HOME.search.from, type: FIELD_TYPES.SELECT, options: airportOptions },
-			to: { key: 'to', label: UI_LABELS.HOME.search.to, type: FIELD_TYPES.SELECT, options: airportOptions },
-			departDate: { key: 'departDate', label: UI_LABELS.HOME.search.when, type: FIELD_TYPES.DATE },
-			returnDate: { key: 'returnDate', label: UI_LABELS.HOME.search.return, type: FIELD_TYPES.DATE },
-			departFrom: { key: 'departFrom', label: UI_LABELS.HOME.search.when_from, type: FIELD_TYPES.DATE },
-			departTo: { key: 'departTo', label: UI_LABELS.HOME.search.when_to, type: FIELD_TYPES.DATE },
-			returnFrom: { key: 'returnFrom', label: UI_LABELS.HOME.search.return_from, type: FIELD_TYPES.DATE },
-			returnTo: { key: 'returnTo', label: UI_LABELS.HOME.search.return_to, type: FIELD_TYPES.DATE },
-		}),
-		[airportOptions]
-	);
-
-	const formFields = useMemo(() => {
-		const arr = createFormFields(fields);
-		return arr.reduce((acc, f) => ({ ...acc, [f.name]: f }), {});
-	}, [fields]);
+        const formFields = useMemo(() => {
+                const fields = {
+                        from: { key: 'from', label: UI_LABELS.HOME.search.from, type: FIELD_TYPES.SELECT, options: airportOptions },
+                        to: { key: 'to', label: UI_LABELS.HOME.search.to, type: FIELD_TYPES.SELECT, options: airportOptions },
+                        departDate: { key: 'departDate', label: UI_LABELS.HOME.search.when, type: FIELD_TYPES.DATE },
+                        returnDate: { key: 'returnDate', label: UI_LABELS.HOME.search.return, type: FIELD_TYPES.DATE },
+                        departFrom: { key: 'departFrom', label: UI_LABELS.HOME.search.when_from, type: FIELD_TYPES.DATE },
+                        departTo: { key: 'departTo', label: UI_LABELS.HOME.search.when_to, type: FIELD_TYPES.DATE },
+                        returnFrom: { key: 'returnFrom', label: UI_LABELS.HOME.search.return_from, type: FIELD_TYPES.DATE },
+                        returnTo: { key: 'returnTo', label: UI_LABELS.HOME.search.return_to, type: FIELD_TYPES.DATE },
+                };
+                const arr = createFormFields(fields);
+                return arr.reduce((acc, f) => ({ ...acc, [f.name]: f }), {});
+        }, [airportOptions]);
 
 	const saveToLocalStorage = () => {
 		const isExact = dateMode === 'exact';

--- a/client/src/components/search/SearchResultCard.js
+++ b/client/src/components/search/SearchResultCard.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { Card, Box, Typography, Button, Divider, IconButton, Skeleton } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -70,27 +70,17 @@ const SegmentSkeleton = () => {
 const Segment = ({ flight, isOutbound, airlines, airports, routes }) => {
 	if (!flight) return null;
 
-	const airline = useMemo(() => {
-		return airlines.find((a) => a.id === flight.airline_id) || null;
-	}, [airlines, flight.airline_id]);
+        const airline = airlines.find((a) => a.id === flight.airline_id) || null;
 
-	const route = useMemo(() => {
-		return routes.find((r) => r.id === flight.route_id) || null;
-	}, [routes, flight.route_id]);
+        const route = routes.find((r) => r.id === flight.route_id) || null;
 
-	const originAirport = useMemo(() => {
-		if (route) {
-			return airports.find((a) => a.id === route.origin_airport_id) || null;
-		}
-		return null;
-	}, [airports, route]);
+        const originAirport = route
+                ? airports.find((a) => a.id === route.origin_airport_id) || null
+                : null;
 
-	const destinationAirport = useMemo(() => {
-		if (route) {
-			return airports.find((a) => a.id === route.destination_airport_id) || null;
-		}
-		return null;
-	}, [airports, route]);
+        const destinationAirport = route
+                ? airports.find((a) => a.id === route.destination_airport_id) || null
+                : null;
 
 	return (
 		<Box sx={{ mb: 1 }}>


### PR DESCRIPTION
## Summary
- streamline nearby date fetching in Search by merging effects
- drop redundant memoization from Schedule and SearchResultCard
- collapse schedule table row mapping and simplify SearchForm initialization

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68910ed06844832f9825bfb7b8b7b616