### PR TITLE
refactor: simplify admin hook usage

### DIFF
--- a/client/src/components/admin/AirlineManagement.js
+++ b/client/src/components/admin/AirlineManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from './AdminDataTable';
@@ -25,10 +25,10 @@ const AirlineManagement = () => {
 		dispatch(fetchCountries());
 	}, [dispatch]);
 
-	const countryOptions = useMemo(() => {
-		if (!countries || !Array.isArray(countries)) return [];
-		return countries.map((c) => ({ value: c.id, label: c.name }));
-	}, [countries]);
+        const countryOptions =
+                !countries || !Array.isArray(countries)
+                        ? []
+                        : countries.map((c) => ({ value: c.id, label: c.name }));
 
 	const getCountryById = (id) => {
 		if (!countries || !Array.isArray(countries)) return null;
@@ -84,14 +84,10 @@ const AirlineManagement = () => {
 		},
 	};
 
-	const adminManager = useMemo(
-		() =>
-			createAdminManager(FIELDS, {
-				addButtonText: (item) => UI_LABELS.ADMIN.modules.airlines.add_button,
-				editButtonText: (item) => UI_LABELS.ADMIN.modules.airlines.edit_button,
-			}),
-		[FIELDS, getCountryById]
-	);
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: (item) => UI_LABELS.ADMIN.modules.airlines.add_button,
+                editButtonText: (item) => UI_LABELS.ADMIN.modules.airlines.edit_button,
+        });
 
 	const handleAddAirline = (data) => dispatch(createAirline(adminManager.toApiFormat(data))).unwrap();
 	const handleEditAirline = (data) => dispatch(updateAirline(adminManager.toApiFormat(data))).unwrap();

--- a/client/src/components/admin/AirportManagement.js
+++ b/client/src/components/admin/AirportManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from '../../components/admin/AdminDataTable';
@@ -29,15 +29,15 @@ const AirportManagement = () => {
 		dispatch(fetchTimezones());
 	}, [dispatch]);
 
-	const countryOptions = useMemo(() => {
-		if (!countries || !Array.isArray(countries)) return [];
-		return countries.map((c) => ({ value: c.id, label: c.name }));
-	}, [countries]);
+        const countryOptions =
+                !countries || !Array.isArray(countries)
+                        ? []
+                        : countries.map((c) => ({ value: c.id, label: c.name }));
 
-	const timezoneOptions = useMemo(() => {
-		if (!timezones || !Array.isArray(timezones)) return [];
-		return timezones.map((tz) => ({ value: tz.id, label: tz.name }));
-	}, [timezones]);
+        const timezoneOptions =
+                !timezones || !Array.isArray(timezones)
+                        ? []
+                        : timezones.map((tz) => ({ value: tz.id, label: tz.name }));
 
 	const getCountryById = (id) => {
 		if (!countries || !Array.isArray(countries)) return null;

--- a/client/src/components/admin/BookingManagement.js
+++ b/client/src/components/admin/BookingManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Box, Typography } from '@mui/material';
@@ -34,7 +34,7 @@ const BookingManagement = () => {
 		dispatch(fetchPassengers());
 	}, [dispatch]);
 
-	const currencyOptions = useMemo(() => getEnumOptions('CURRENCY'), []);
+        const currencyOptions = getEnumOptions('CURRENCY');
 
 	const FIELDS = {
 		id: { key: 'id', apiKey: 'id' },

--- a/client/src/components/admin/FlightManagement.js
+++ b/client/src/components/admin/FlightManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
 	Tooltip,
@@ -83,32 +83,30 @@ const FlightManagement = () => {
 		return tariffs.find((tariff) => tariff.id === id);
 	};
 
-	const routeOptions = useMemo(() => {
-		if (routesLoading || airportsLoading || !Array.isArray(routes) || !Array.isArray(airports)) {
-			return [];
-		}
-		return routes.map((route) => {
-			const origin = getAirportById(route.origin_airport_id);
-			const dest = getAirportById(route.destination_airport_id);
+        const routeOptions =
+                routesLoading ||
+                airportsLoading ||
+                !Array.isArray(routes) ||
+                !Array.isArray(airports)
+                        ? []
+                        : routes.map((route) => {
+                                const origin = getAirportById(route.origin_airport_id);
+                                const dest = getAirportById(route.destination_airport_id);
 
-			return {
-				value: route.id,
-				label: `${origin?.city_name} (${origin?.iata_code || '…'}) → ${dest?.city_name} (${
-					dest?.iata_code || '…'
-				})`,
-			};
-		});
-	}, [routes, airports, routesLoading, airportsLoading]);
+                                return {
+                                        value: route.id,
+                                        label: `${origin?.city_name} (${origin?.iata_code || '…'}) → ${dest?.city_name} (${dest?.iata_code || '…'})`,
+                                };
+                        });
 
-	const airlineOptions = useMemo(() => {
-		if (!airlines || !Array.isArray(airlines)) {
-			return [];
-		}
-		return airlines.map((airline) => ({
-			value: airline.id,
-			label: `${airline.name} (${airline.iata_code})`,
-		}));
-	}, [airlines]);
+        const airlineOptions =
+                !airlines || !Array.isArray(airlines)
+                        ? []
+                        : airlines.map((airline) => ({
+                                value: airline.id,
+                                label: `${airline.name} (${airline.iata_code})`,
+                        }));
+
 
 	const [deleteFlightTariffDialog, setDeleteFlightTariffDialog] = useState({
 		open: false,
@@ -370,14 +368,10 @@ const FlightManagement = () => {
 		},
 	};
 
-	const adminManager = useMemo(
-		() =>
-			createAdminManager(FIELDS, {
-				addButtonText: (item) => UI_LABELS.ADMIN.modules.flights.add_button,
-				editButtonText: (item) => UI_LABELS.ADMIN.modules.flights.edit_button,
-			}),
-		[FIELDS, getRouteById, getAirlineById]
-	);
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: (item) => UI_LABELS.ADMIN.modules.flights.add_button,
+                editButtonText: (item) => UI_LABELS.ADMIN.modules.flights.edit_button,
+        });
 
 	const handleAddFlight = (flightData) => dispatch(createFlight(adminManager.toApiFormat(flightData))).unwrap();
 	const handleEditFlight = (flightData) => dispatch(updateFlight(adminManager.toApiFormat(flightData))).unwrap();

--- a/client/src/components/admin/FlightTariffManagement.js
+++ b/client/src/components/admin/FlightTariffManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Typography, Dialog, DialogContent } from '@mui/material';
 
@@ -47,18 +47,14 @@ export const FlightTariffManagement = ({ flightId, tariffDialogOpen, onClose, ac
 		}
 	}, [formUpdates]);
 
-	const seatClassOptions = useMemo(() => getEnumOptions('SEAT_CLASS'), []);
+        const seatClassOptions = getEnumOptions('SEAT_CLASS');
 
-	const tariffOptions = useMemo(() => {
-		return tariffs
-			.filter((t) => t.seat_class === seatClass)
-			.map((t) => ({
-				value: t.id,
-				label: `${ENUM_LABELS.SEAT_CLASS[t.seat_class]} - ${UI_LABELS.ADMIN.modules.tariffs.tariff} ${
-					t.order_number
-				} (${formatNumber(t.price)} ${ENUM_LABELS.CURRENCY[t.currency]})`,
-			}));
-	}, [tariffs, seatClass]);
+        const tariffOptions = tariffs
+                .filter((t) => t.seat_class === seatClass)
+                .map((t) => ({
+                        value: t.id,
+                        label: `${ENUM_LABELS.SEAT_CLASS[t.seat_class]} - ${UI_LABELS.ADMIN.modules.tariffs.tariff} ${t.order_number} (${formatNumber(t.price)} ${ENUM_LABELS.CURRENCY[t.currency]})`,
+                }));
 
 	const FIELDS = {
 		id: { key: 'id', apiKey: 'id' },
@@ -93,31 +89,27 @@ export const FlightTariffManagement = ({ flightId, tariffDialogOpen, onClose, ac
 		},
 	};
 
-	const tariffManager = useMemo(
-		() =>
-			createAdminManager(FIELDS, {
-				addButtonText: () => UI_LABELS.ADMIN.modules.tariffs.add_button,
-				editButtonText: () => UI_LABELS.ADMIN.modules.tariffs.edit_button,
-			}),
-		[FIELDS]
-	);
+        const tariffManager = createAdminManager(FIELDS, {
+                addButtonText: () => UI_LABELS.ADMIN.modules.tariffs.add_button,
+                editButtonText: () => UI_LABELS.ADMIN.modules.tariffs.edit_button,
+        });
 
-	const currentItem = useMemo(() => {
-		if (isEditing) {
-			if (flightTariff && Array.isArray(tariffs) && tariffs.length > 0) {
-				const tariff = tariffs.find((t) => t.id === flightTariff.tariff_id);
-				const originalSeatClass = tariff ? tariff.seat_class : '';
-				return {
-					id: flightTariffId,
-					flightId: flightId,
-					seatClass: seatClass || originalSeatClass,
-					seatsNumber: flightTariff.seats_number,
-					flightTariffId: seatClass && seatClass !== originalSeatClass ? '' : flightTariff.tariff_id,
-				};
-			}
-		}
-		return { flightId, seatClass, seatsNumber: 0, flightTariffId: '' };
-	}, [isEditing, flightTariff, tariffs, flightId, seatClass]);
+        const currentItem = (() => {
+                if (isEditing) {
+                        if (flightTariff && Array.isArray(tariffs) && tariffs.length > 0) {
+                                const tariff = tariffs.find((t) => t.id === flightTariff.tariff_id);
+                                const originalSeatClass = tariff ? tariff.seat_class : '';
+                                return {
+                                        id: flightTariffId,
+                                        flightId: flightId,
+                                        seatClass: seatClass || originalSeatClass,
+                                        seatsNumber: flightTariff.seats_number,
+                                        flightTariffId: seatClass && seatClass !== originalSeatClass ? '' : flightTariff.tariff_id,
+                                };
+                        }
+                }
+                return { flightId, seatClass, seatsNumber: 0, flightTariffId: '' };
+        })();
 
 	const handleSaveTariff = (tariffData) => {
 		const formattedData = tariffManager.toApiFormat({

--- a/client/src/components/admin/PassengerManagement.js
+++ b/client/src/components/admin/PassengerManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from '../../components/admin/AdminDataTable';
@@ -45,16 +45,78 @@ const PassengerManagement = () => {
 		dispatch(fetchCountries());
 	}, [dispatch]);
 
-	const bookingOptions = useMemo(
-		() => bookings.map((b) => ({ value: b.id, label: `${b.booking_number} - ${formatDate(b.booking_date)}` })),
-		[bookings]
-	);
-	const citizenshipOptions = useMemo(() => countries.map((c) => ({ value: c.id, label: c.name })), [countries]);
+        const bookingOptions = bookings.map((b) => ({
+                value: b.id,
+                label: `${b.booking_number} - ${formatDate(b.booking_date)}`,
+        }));
+        const citizenshipOptions = countries.map((c) => ({ value: c.id, label: c.name }));
 
 	const getCountryById = (id) => countries.find((c) => c.id === id);
 
-	const FIELDS = useMemo(
-		() => ({
+        const FIELDS = {
+                id: { key: 'id', apiKey: 'id' },
+                passengerId: { key: 'passengerId', apiKey: 'passenger_id', excludeFromForm: true, excludeFromTable: true },
+                bookingId: {
+                        key: 'bookingId',
+                        apiKey: 'booking_id',
+                        label: FIELD_LABELS.BOOKING_PASSENGER.booking_id,
+                        type: FIELD_TYPES.SELECT,
+                        fullWidth: true,
+                        options: bookingOptions,
+                        formatter: (value) => {
+                                const booking = bookingOptions.find((b) => b.value === value);
+                                return booking ? booking.label : value;
+                        },
+                },
+                lastName: {
+                        key: 'lastName',
+                        apiKey: 'last_name',
+                        label: FIELD_LABELS.PASSENGER.last_name,
+                        type: FIELD_TYPES.TEXT,
+                        validate: (value) => (!value ? VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED : null),
+                },
+                firstName: {
+                        key: 'firstName',
+                        apiKey: 'first_name',
+                        label: FIELD_LABELS.PASSENGER.first_name,
+                        type: FIELD_TYPES.TEXT,
+                        validate: (value) => (!value ? VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED : null),
+                },
+                gender: {
+                        key: 'gender',
+                        apiKey: 'gender',
+                        label: FIELD_LABELS.PASSENGER.gender,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('GENDER'),
+                        formatter: (value) => ENUM_LABELS.GENDER_SHORT[value] || value,
+                },
+                birthDate: {
+                        key: 'birthDate',
+                        apiKey: 'birth_date',
+                        label: FIELD_LABELS.PASSENGER.birth_date,
+                        type: FIELD_TYPES.DATE,
+                        formatter: (value) => formatDate(value),
+                        validate: (value) => {
+                                if (value && !validateDate(value)) return VALIDATION_MESSAGES.GENERAL.INVALID_DATE;
+                                return null;
+                        },
+                },
+                documentType: {
+                        key: 'documentType',
+                        apiKey: 'document_type',
+                        label: FIELD_LABELS.PASSENGER.document_type,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('DOCUMENT_TYPE'),
+                        excludeFromTable: true,
+                        validate: (value) => (!value ? VALIDATION_MESSAGES.PASSENGER.document_type.REQUIRED : null),
+                },
+                documentNumber: {
+                        key: 'documentNumber',
+                        apiKey: 'document_number',
+                        label: FIELD_LABELS.PASSENGER.document_number,
+                        type: FIELD_TYPES.TEXT,
+                        validate: (value) => (!value ? VALIDATION_MESSAGES.PASSENGER.document_number.REQUIRED : null),
+                },
 			id: { key: 'id', apiKey: 'id' },
 			passengerId: { key: 'passengerId', apiKey: 'passenger_id', excludeFromForm: true, excludeFromTable: true },
 			bookingId: {
@@ -156,19 +218,14 @@ const PassengerManagement = () => {
 				label: FIELD_LABELS.BOOKING_PASSENGER.is_contact,
 				type: FIELD_TYPES.BOOLEAN,
 				excludeFromTable: true,
-			},
-		}),
-		[bookingOptions, citizenshipOptions, bookings, countries]
-	);
+                        },
+                },
+        };
 
-	const adminManager = useMemo(
-		() =>
-			createAdminManager(FIELDS, {
-				addButtonText: () => UI_LABELS.ADMIN.modules.passengers.add_button,
-				editButtonText: () => UI_LABELS.ADMIN.modules.passengers.edit_button,
-			}),
-		[FIELDS]
-	);
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: () => UI_LABELS.ADMIN.modules.passengers.add_button,
+                editButtonText: () => UI_LABELS.ADMIN.modules.passengers.edit_button,
+        });
 
 	const handleAddPassenger = async (data) => {
 		const apiData = adminManager.toApiFormat(data);

--- a/client/src/components/admin/RouteManagement.js
+++ b/client/src/components/admin/RouteManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from '../../components/admin/AdminDataTable';
@@ -19,15 +19,13 @@ const RouteManagement = () => {
 		dispatch(fetchAirports());
 	}, [dispatch]);
 
-	const airportOptions = useMemo(() => {
-		if (!airports || !Array.isArray(airports)) {
-			return [];
-		}
-		return airports.map((airport) => ({
-			value: airport.id,
-			label: `${airport.name} (${airport.iata_code}) - ${airport.city_code}`,
-		}));
-	}, [airports]);
+        const airportOptions =
+                !airports || !Array.isArray(airports)
+                        ? []
+                        : airports.map((airport) => ({
+                                value: airport.id,
+                                label: `${airport.name} (${airport.iata_code}) - ${airport.city_code}`,
+                        }));
 
 	const getAirportLabelById = (id) => {
 		if (!airportOptions || !Array.isArray(airportOptions)) {
@@ -59,14 +57,10 @@ const RouteManagement = () => {
 		},
 	};
 
-	const adminManager = useMemo(
-		() =>
-			createAdminManager(FIELDS, {
-				addButtonText: (item) => UI_LABELS.ADMIN.modules.routes.add_button,
-				editButtonText: (item) => UI_LABELS.ADMIN.modules.routes.edit_button,
-			}),
-		[FIELDS]
-	);
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: (item) => UI_LABELS.ADMIN.modules.routes.add_button,
+                editButtonText: (item) => UI_LABELS.ADMIN.modules.routes.edit_button,
+        });
 
 	const handleAddRoute = (routeData) => dispatch(createRoute(adminManager.toApiFormat(routeData))).unwrap();
 	const handleEditRoute = (routeData) => dispatch(updateRoute(adminManager.toApiFormat(routeData))).unwrap();

--- a/client/src/components/admin/TariffManagement.js
+++ b/client/src/components/admin/TariffManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from '../../components/admin/AdminDataTable';
@@ -16,8 +16,8 @@ const TariffManagement = () => {
 		dispatch(fetchTariffs());
 	}, [dispatch]);
 
-	const seatClassOptions = useMemo(() => getEnumOptions('SEAT_CLASS'), []);
-	const currencyOptions = useMemo(() => getEnumOptions('CURRENCY'), []);
+        const seatClassOptions = getEnumOptions('SEAT_CLASS');
+        const currencyOptions = getEnumOptions('CURRENCY');
 
 	const FIELDS = {
 		id: { key: 'id', apiKey: 'id' },
@@ -65,22 +65,18 @@ const TariffManagement = () => {
 		},
 	};
 
-	const adminManager = useMemo(
-		() =>
-			createAdminManager(FIELDS, {
-				addButtonText: (item) => UI_LABELS.ADMIN.modules.tariffs.add_button,
-				editButtonText: (item) => {
-					if (!item) return UI_LABELS.ADMIN.modules.tariffs.edit_button;
-					else {
-						const seatClass = ENUM_LABELS.SEAT_CLASS[item[FIELDS.seatClass.key]];
-						const orderNumber = item[FIELDS.orderNumber.key];
+        const adminManager = createAdminManager(FIELDS, {
+                addButtonText: (item) => UI_LABELS.ADMIN.modules.tariffs.add_button,
+                editButtonText: (item) => {
+                        if (!item) return UI_LABELS.ADMIN.modules.tariffs.edit_button;
+                        else {
+                                const seatClass = ENUM_LABELS.SEAT_CLASS[item[FIELDS.seatClass.key]];
+                                const orderNumber = item[FIELDS.orderNumber.key];
 
-						return `${UI_LABELS.BUTTONS.edit}: ${seatClass} — ${UI_LABELS.ADMIN.modules.tariffs.tariff} ${orderNumber}`;
-					}
-				},
-			}),
-		[FIELDS, tariffs]
-	);
+                                return `${UI_LABELS.BUTTONS.edit}: ${seatClass} — ${UI_LABELS.ADMIN.modules.tariffs.tariff} ${orderNumber}`;
+                        }
+                },
+        });
 
 	const handleAddTariff = (tariffData) => dispatch(createTariff(adminManager.toApiFormat(tariffData))).unwrap();
 	const handleEditTariff = (tariffData) => dispatch(updateTariff(adminManager.toApiFormat(tariffData))).unwrap();

--- a/client/src/components/admin/TicketManagement.js
+++ b/client/src/components/admin/TicketManagement.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from '../../components/admin/AdminDataTable';
@@ -28,41 +28,22 @@ const TicketManagement = () => {
 		dispatch(fetchDiscounts());
 	}, [dispatch]);
 
-	const flightOptions = useMemo(
-		() =>
-			flights.map((f) => ({
-				value: f.id,
-				label: f.id,
-			})),
-		[flights]
-	);
+        const flightOptions = flights.map((f) => ({ value: f.id, label: f.id }));
 
-	const bookingOptions = useMemo(
-		() =>
-			bookings.map((b) => ({
-				value: b.id,
-				label: b.booking_number,
-			})),
-		[bookings]
-	);
+        const bookingOptions = bookings.map((b) => ({
+                value: b.id,
+                label: b.booking_number,
+        }));
 
-	const passengerOptions = useMemo(
-		() =>
-			passengers.map((p) => ({
-				value: p.id,
-				label: `${p.first_name} ${p.last_name}`,
-			})),
-		[passengers]
-	);
+        const passengerOptions = passengers.map((p) => ({
+                value: p.id,
+                label: `${p.first_name} ${p.last_name}`,
+        }));
 
-	const discountOptions = useMemo(
-		() =>
-			discounts.map((d) => ({
-				value: d.id,
-				label: d.discount_name,
-			})),
-		[discounts]
-	);
+        const discountOptions = discounts.map((d) => ({
+                value: d.id,
+                label: d.discount_name,
+        }));
 
 	const FIELDS = {
 		id: { key: 'id', apiKey: 'id' },


### PR DESCRIPTION
## Summary
- streamline admin option generation by removing unnecessary `useMemo`
- compute admin managers directly instead of memoizing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689189d5cbf8832fa04b474f0c1ef057