### PR TITLE
feat: add seat and passenger selection dialog

### DIFF
--- a/client/src/components/search/SearchResultCard.js
+++ b/client/src/components/search/SearchResultCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Card, Box, Typography, Button, Divider, IconButton, Skeleton } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -7,6 +7,7 @@ import ShareIcon from '@mui/icons-material/Share';
 
 import { ENUM_LABELS, UI_LABELS, DATE_WEEKDAY_FORMAT } from '../../constants';
 import { formatDate, formatTime, formatDuration, formatNumber } from '../utils';
+import SelectTicketDialog from './SelectTicketDialog';
 
 const SegmentSkeleton = () => {
 	return (
@@ -155,11 +156,12 @@ const Segment = ({ flight, isOutbound, airlines, airports, routes }) => {
 };
 
 const SearchResultCard = ({ outbound, returnFlight, airlines, airports, routes, isLoading }) => {
-	const theme = useTheme();
-	const currency = isLoading ? '' : outbound?.currency || returnFlight?.currency;
-	const currencySymbol = isLoading ? '' : currency ? ENUM_LABELS.CURRENCY_SYMBOL[currency] : '';
-	const totalPrice = isLoading ? 0 : outbound.price + (returnFlight?.price || 0);
-	const totalMinPrice = isLoading ? 0 : outbound.min_price + (returnFlight?.min_price || 0);
+        const theme = useTheme();
+        const currency = isLoading ? '' : outbound?.currency || returnFlight?.currency;
+        const currencySymbol = isLoading ? '' : currency ? ENUM_LABELS.CURRENCY_SYMBOL[currency] : '';
+        const totalPrice = isLoading ? 0 : outbound.price + (returnFlight?.price || 0);
+        const totalMinPrice = isLoading ? 0 : outbound.min_price + (returnFlight?.min_price || 0);
+        const [openDialog, setOpenDialog] = useState(false);
 
 	const priceText = isLoading
 		? ''
@@ -170,73 +172,81 @@ const SearchResultCard = ({ outbound, returnFlight, airlines, airports, routes, 
 		  )} ${currencySymbol}`;
 
 	return (
-		<Card sx={{ display: 'flex', p: 2, mb: 2 }}>
-			<Box
-				sx={{
-					width: 180,
-					textAlign: 'center',
-					pr: 2,
-					borderRight: `1px solid ${theme.palette.grey[100]}`,
-					display: 'flex',
-					flexDirection: 'column',
-					justifyContent: 'center',
-				}}
-			>
-				{isLoading ? (
-					<Skeleton variant='rectangular' width={150} height={40} sx={{ mb: 1, mx: 'auto' }} />
-				) : (
-					<>
-						<Typography variant='h5' sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
-							{priceText}
-						</Typography>
-						<Typography variant='subtitle2' color='text.secondary' sx={{ mb: 1 }}>
-							{UI_LABELS.SEARCH.flight_details.price_per_passenger.toLowerCase()}
-						</Typography>
-					</>
-				)}
-				<Button
-					variant='contained'
-					color='orange'
-					disabled={isLoading}
-					sx={{
-						borderRadius: 2,
-						boxShadow: 'none',
-						textTransform: 'none',
-						whiteSpace: 'nowrap',
-					}}
-					onClick={() => {
-						const url = `/cart?flight=${outbound.id}${returnFlight ? `&return=${returnFlight.id}` : ''}`;
-						window.open(url, '_blank');
-					}}
-				>
-					{UI_LABELS.SEARCH.flight_details.select_flight}
-				</Button>
-			</Box>
-			<Box sx={{ flexGrow: 1, pl: 2 }}>
-				{isLoading ? (
-					<>
-						<SegmentSkeleton />
-						{returnFlight && <Divider sx={{ my: 1 }} />}
-						{returnFlight && <SegmentSkeleton />}
-					</>
-				) : (
-					<>
-						<Segment flight={outbound} isOutbound airlines={airlines} airports={airports} routes={routes} />
-						{returnFlight && <Divider sx={{ my: 1 }} />}
-						{returnFlight && (
-							<Segment
-								flight={returnFlight}
-								isOutbound={false}
-								airlines={airlines}
-								airports={airports}
-								routes={routes}
-							/>
-						)}
-					</>
-				)}
-			</Box>
-		</Card>
-	);
+                <>
+                        <Card sx={{ display: 'flex', p: 2, mb: 2 }}>
+                                <Box
+                                        sx={{
+                                                width: 180,
+                                                textAlign: 'center',
+                                                pr: 2,
+                                                borderRight: `1px solid ${theme.palette.grey[100]}`,
+                                                display: 'flex',
+                                                flexDirection: 'column',
+                                                justifyContent: 'center',
+                                        }}
+                                >
+                                        {isLoading ? (
+                                                <Skeleton variant='rectangular' width={150} height={40} sx={{ mb: 1, mx: 'auto' }} />
+                                        ) : (
+                                                <>
+                                                        <Typography variant='h5' sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+                                                                {priceText}
+                                                        </Typography>
+                                                        <Typography variant='subtitle2' color='text.secondary' sx={{ mb: 1 }}>
+                                                                {UI_LABELS.SEARCH.flight_details.price_per_passenger.toLowerCase()}
+                                                        </Typography>
+                                                </>
+                                        )}
+                                        <Button
+                                                variant='contained'
+                                                color='orange'
+                                                disabled={isLoading}
+                                                sx={{
+                                                        borderRadius: 2,
+                                                        boxShadow: 'none',
+                                                        textTransform: 'none',
+                                                        whiteSpace: 'nowrap',
+                                                }}
+                                                onClick={() => setOpenDialog(true)}
+                                        >
+                                                {UI_LABELS.SEARCH.flight_details.select_flight}
+                                        </Button>
+                                </Box>
+                                <Box sx={{ flexGrow: 1, pl: 2 }}>
+                                        {isLoading ? (
+                                                <>
+                                                        <SegmentSkeleton />
+                                                        {returnFlight && <Divider sx={{ my: 1 }} />}
+                                                        {returnFlight && <SegmentSkeleton />}
+                                                </>
+                                        ) : (
+                                                <>
+                                                        <Segment flight={outbound} isOutbound airlines={airlines} airports={airports} routes={routes} />
+                                                        {returnFlight && <Divider sx={{ my: 1 }} />}
+                                                        {returnFlight && (
+                                                                <Segment
+                                                                        flight={returnFlight}
+                                                                        isOutbound={false}
+                                                                        airlines={airlines}
+                                                                        airports={airports}
+                                                                        routes={routes}
+                                                                />
+                                                        )}
+                                                </>
+                                        )}
+                                </Box>
+                        </Card>
+                        <SelectTicketDialog
+                                open={openDialog}
+                                onClose={() => setOpenDialog(false)}
+                                outbound={outbound}
+                                returnFlight={returnFlight}
+                                airlines={airlines}
+                                airports={airports}
+                                routes={routes}
+                        />
+                </>
+        );
 };
 
 export default SearchResultCard;

--- a/client/src/components/search/SelectTicketDialog.js
+++ b/client/src/components/search/SelectTicketDialog.js
@@ -1,0 +1,225 @@
+import React, { useState, useMemo } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Typography,
+  Card,
+  CardActionArea,
+  IconButton,
+  Divider
+} from '@mui/material';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { UI_LABELS, ENUM_LABELS, MAX_PASSENGERS } from '../../constants';
+import { formatTime, formatDate, formatNumber } from '../utils';
+
+const passengerCategories = UI_LABELS.HOME.search.passenger_categories;
+
+const buildTariffOptions = (outbound, returnFlight) => {
+  const map = {};
+  (outbound?.tariffs || []).forEach((t) => {
+    map[t.seat_class] = {
+      price: t.price,
+      currency: t.currency,
+      seats_left: t.seats_left
+    };
+  });
+  if (returnFlight) {
+    (returnFlight.tariffs || []).forEach((t) => {
+      if (map[t.seat_class]) {
+        map[t.seat_class].price += t.price;
+        if (t.seats_left !== undefined) {
+          const current = map[t.seat_class].seats_left;
+          map[t.seat_class].seats_left =
+            current !== undefined ? Math.min(current, t.seats_left) : t.seats_left;
+        }
+      } else {
+        map[t.seat_class] = {
+          price: t.price,
+          currency: t.currency,
+          seats_left: t.seats_left
+        };
+      }
+    });
+  }
+  return Object.entries(map).map(([seat_class, info]) => ({
+    seat_class,
+    ...info
+  }));
+};
+
+const FlightInfo = ({ flight, airlines, airports, routes }) => {
+  if (!flight) return null;
+  const airline = airlines.find((a) => a.id === flight.airline_id) || {};
+  const route = routes.find((r) => r.id === flight.route_id) || {};
+  const origin = airports.find((a) => a.id === route.origin_airport_id) || {};
+  const dest = airports.find((a) => a.id === route.destination_airport_id) || {};
+
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography variant='subtitle2' sx={{ fontWeight: 600 }}>
+        {airline.name || airline.id}
+      </Typography>
+      <Typography variant='body2' color='text.secondary'>
+        {origin.name || origin.id} → {dest.name || dest.id}
+      </Typography>
+      <Typography variant='body2' color='text.secondary'>
+        {formatDate(flight.scheduled_departure, 'dd.MM.yyyy')} {formatTime(flight.scheduled_departure_time)} - {formatDate(flight.scheduled_arrival, 'dd.MM.yyyy')} {formatTime(flight.scheduled_arrival_time)}
+      </Typography>
+    </Box>
+  );
+};
+
+const SelectTicketDialog = ({ open, onClose, outbound, returnFlight, airlines, airports, routes }) => {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+
+  const tariffOptions = useMemo(
+    () => buildTariffOptions(outbound, returnFlight),
+    [outbound, returnFlight]
+  );
+
+  const initialSeatClass = params.get('class') || tariffOptions[0]?.seat_class || '';
+  const [seatClass, setSeatClass] = useState(initialSeatClass);
+
+  const [passengers, setPassengers] = useState({
+    adults: parseInt(params.get('adults') || '1', 10),
+    children: parseInt(params.get('children') || '0', 10),
+    infants: parseInt(params.get('infants') || '0', 10)
+  });
+
+  const totalPassengers =
+    passengers.adults + passengers.children + passengers.infants;
+
+  const selectedTariff = tariffOptions.find((t) => t.seat_class === seatClass) || tariffOptions[0];
+  const currencySymbol = selectedTariff
+    ? ENUM_LABELS.CURRENCY_SYMBOL[selectedTariff.currency] || ''
+    : '';
+  const totalPrice = selectedTariff
+    ? selectedTariff.price * totalPassengers
+    : 0;
+
+  const handlePassengerChange = (key, delta) => {
+    setPassengers((prev) => {
+      const nextVal = prev[key] + delta;
+      const newTotal =
+        prev.adults + prev.children + prev.infants + delta;
+      const min = key === 'adults' ? 1 : 0;
+      if (nextVal < min || newTotal < 1 || newTotal > MAX_PASSENGERS)
+        return prev;
+      return { ...prev, [key]: nextVal };
+    });
+  };
+
+  const handleConfirm = () => {
+    const query = new URLSearchParams();
+    query.set('flight', outbound.id);
+    if (returnFlight) query.set('return', returnFlight.id);
+    if (seatClass) query.set('class', seatClass);
+    query.set('adults', passengers.adults);
+    query.set('children', passengers.children);
+    query.set('infants', passengers.infants);
+    navigate(`/cart?${query.toString()}`);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth='sm'>
+      <DialogTitle>{UI_LABELS.SEARCH.flight_details.select_flight}</DialogTitle>
+      <DialogContent dividers>
+        <FlightInfo
+          flight={outbound}
+          airlines={airlines}
+          airports={airports}
+          routes={routes}
+        />
+        {returnFlight && (
+          <>
+            <FlightInfo
+              flight={returnFlight}
+              airlines={airlines}
+              airports={airports}
+              routes={routes}
+            />
+            <Divider sx={{ mb: 2 }} />
+          </>
+        )}
+
+        <Typography gutterBottom>
+          {UI_LABELS.HOME.search.seat_class_title}
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
+          {tariffOptions.map((t) => (
+            <Card
+              key={t.seat_class}
+              variant={t.seat_class === seatClass ? 'outlined' : 'elevation'}
+              sx={{ minWidth: 100 }}
+            >
+              <CardActionArea onClick={() => setSeatClass(t.seat_class)} sx={{ p: 1 }}>
+                <Typography>{ENUM_LABELS.SEAT_CLASS[t.seat_class]}</Typography>
+                <Typography>
+                  {formatNumber(t.price)} {ENUM_LABELS.CURRENCY_SYMBOL[t.currency] || ''}
+                </Typography>
+                <Typography variant='caption' color='text.secondary'>
+                  Мест: {t.seats_left ?? '-'}
+                </Typography>
+              </CardActionArea>
+            </Card>
+          ))}
+        </Box>
+
+        <Typography gutterBottom>
+          {UI_LABELS.HOME.search.passengers}
+        </Typography>
+        <Box>
+          {passengerCategories.map((row) => (
+            <Card key={row.key} sx={{ p: 1, mb: 1, display: 'flex', alignItems: 'center' }}>
+              <Box sx={{ flexGrow: 1 }}>
+                <Typography>{row.label}</Typography>
+                <Typography variant='body2' color='text.secondary'>
+                  {row.desc}
+                </Typography>
+              </Box>
+              <IconButton
+                onClick={() => handlePassengerChange(row.key, -1)}
+                disabled={
+                  passengers[row.key] <= (row.key === 'adults' ? 1 : 0)
+                }
+              >
+                -
+              </IconButton>
+              <Typography sx={{ width: 20, textAlign: 'center' }}>
+                {passengers[row.key]}
+              </Typography>
+              <IconButton
+                onClick={() => handlePassengerChange(row.key, 1)}
+                disabled={totalPassengers >= MAX_PASSENGERS}
+              >
+                +
+              </IconButton>
+            </Card>
+          ))}
+        </Box>
+
+        <Typography sx={{ mt: 2, textAlign: 'right' }}>
+          {UI_LABELS.SEARCH.flight_details.price}: {formatNumber(totalPrice)} {currencySymbol}
+        </Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{UI_LABELS.BUTTONS.close}</Button>
+        <Button
+          variant='contained'
+          color='orange'
+          onClick={handleConfirm}
+        >
+          {UI_LABELS.SEARCH.flight_details.select_flight}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default SelectTicketDialog;
+


### PR DESCRIPTION
## Summary
- add SelectTicketDialog component to pick seat class and passengers with flight details
- show total price for passengers and navigate to cart on confirmation
- open dialog from search results instead of direct cart redirect

## Testing
- `npm test`
- `pytest` *(fails: SERVER_JWT_EXP_HOURS not set)*

------
https://chatgpt.com/codex/tasks/task_e_68919e55e444832f911606fcfb0d7447