### PR TITLE
Fix select warnings and number field zero input

### DIFF
--- a/client/src/components/admin/AdminEntityForm.js
+++ b/client/src/components/admin/AdminEntityForm.js
@@ -116,17 +116,17 @@ const AdminEntityForm = ({
 				<Grid container spacing={2} sx={{ mt: 1 }}>
 					{fields.map((field, index) => (
 						<Grid item xs={12} sm={field.fullWidth ? 12 : 6} key={index}>
-							{field.renderField({
-								value: formData[field.name] || '',
-								onChange: (value) => handleChange(field.name, value),
-								fullWidth: true,
-								error: !!validationErrors[field.name],
-								helperText: validationErrors[field.name],
-							})}
-						</Grid>
-					))}
-				</Grid>
-			</DialogContent>
+                                                    {field.renderField({
+                                                            value: formData[field.name] ?? '',
+                                                            onChange: (value) => handleChange(field.name, value),
+                                                            fullWidth: true,
+                                                            error: !!validationErrors[field.name],
+                                                            helperText: validationErrors[field.name],
+                                                    })}
+                                           </Grid>
+                                   ))}
+                           </Grid>
+                   </DialogContent>
 			<DialogActions>
 				<Button onClick={onClose}>{UI_LABELS.BUTTONS.cancel}</Button>
 				<Button onClick={handleSubmit} variant='contained' disabled={!!successMessage}>

--- a/client/src/components/admin/FlightManagement.js
+++ b/client/src/components/admin/FlightManagement.js
@@ -335,10 +335,11 @@ const FlightManagement = () => {
 													<IconButton
 														size='small'
 														color='primary'
-														onClick={(e) => {
-															e.stopPropagation();
-															handleEditFlightTariff(item.id, ft.id);
-														}}
+                                                                                                                  onClick={(e) => {
+                                                                                                                         e.stopPropagation();
+                                                                                                                         e.currentTarget.blur();
+                                                                                                                         handleEditFlightTariff(item.id, ft.id);
+                                                                                                                  }}
 													>
 														<EditIcon fontSize='small' />
 													</IconButton>
@@ -350,10 +351,11 @@ const FlightManagement = () => {
 													<IconButton
 														size='small'
 														color='error'
-														onClick={(e) => {
-															e.stopPropagation();
-															handleOpenDeleteFlightTariffDialog(ft.id);
-														}}
+                                                                                                                  onClick={(e) => {
+                                                                                                                         e.stopPropagation();
+                                                                                                                         e.currentTarget.blur();
+                                                                                                                         handleOpenDeleteFlightTariffDialog(ft.id);
+                                                                                                                  }}
 													>
 														<DeleteIcon fontSize='small' />
 													</IconButton>
@@ -366,10 +368,11 @@ const FlightManagement = () => {
 									<IconButton
 										size='small'
 										color='primary'
-										onClick={(e) => {
-											e.stopPropagation();
-											handleAddFlightTariff(item.id);
-										}}
+                                                                                  onClick={(e) => {
+                                                                                          e.stopPropagation();
+                                                                                          e.currentTarget.blur();
+                                                                                          handleAddFlightTariff(item.id);
+                                                                                  }}
 										sx={{ mt: 0.5 }}
 									>
 										<AddCircleIcon />

--- a/client/src/components/utils.js
+++ b/client/src/components/utils.js
@@ -225,19 +225,24 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.SELECT: {
-				const {
-					value = '',
-					onChange,
-					fullWidth,
-					error,
-					helperText,
-					options = field.options || [],
-					MenuProps,
-					MenuItemProps,
-					displayEmpty,
-					simpleSelect,
-					sx,
-				} = allProps;
+                                const {
+                                        value = '',
+                                        onChange,
+                                        fullWidth,
+                                        error,
+                                        helperText,
+                                        options = field.options || [],
+                                        MenuProps,
+                                        MenuItemProps,
+                                        displayEmpty,
+                                        simpleSelect,
+                                        sx,
+                                } = allProps;
+
+                                const resolvedValue =
+                                        value !== undefined && value !== null ? value : field.defaultValue;
+                                const isValidValue = options.some((o) => o.value === resolvedValue);
+                                const safeValue = isValidValue ? resolvedValue : '';
 
 				if (!simpleSelect && options.length > 100) {
 					const valueObj = options.find((o) => o.value === value) || null;
@@ -269,13 +274,13 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				if (simpleSelect) {
 					return (
 						<Select
-							value={value || field.defaultValue || ''}
-							onChange={(e) => onChange(e.target.value)}
-							fullWidth={fullWidth}
-							MenuProps={MenuProps}
-							displayEmpty={displayEmpty}
-							sx={{ ...sx }}
-						>
+                                                        value={safeValue}
+                                                        onChange={(e) => onChange(e.target.value)}
+                                                        fullWidth={fullWidth}
+                                                        MenuProps={MenuProps}
+                                                        displayEmpty={displayEmpty}
+                                                        sx={{ ...sx }}
+                                                >
 							{options.map((option) => (
 								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
 									{option.label}
@@ -289,13 +294,13 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 					<FormControl fullWidth={fullWidth} error={!!error}>
 						<InputLabel>{field.label}</InputLabel>
 						<Select
-							value={value || field.defaultValue || ''}
-							onChange={(e) => onChange(e.target.value)}
-							label={field.label}
-							MenuProps={MenuProps}
-							displayEmpty={displayEmpty}
-							sx={{ ...sx }}
-						>
+                                                        value={safeValue}
+                                                        onChange={(e) => onChange(e.target.value)}
+                                                        label={field.label}
+                                                        MenuProps={MenuProps}
+                                                        displayEmpty={displayEmpty}
+                                                        sx={{ ...sx }}
+                                                >
 							{options.map((option) => (
 								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
 									{option.label}


### PR DESCRIPTION
## Summary
- normalize select field values against options to avoid MUI out-of-range warnings
- blur tariff action buttons before opening dialogs to prevent aria-hidden focus issues
- allow entering numeric zero in admin forms

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6891dd4ef564832f9a23e11825350b38