### PR TITLE
fix(admin): prevent aria-hidden warning on dialog close

### DIFF
--- a/client/src/components/admin/AdminDataTable.js
+++ b/client/src/components/admin/AdminDataTable.js
@@ -302,16 +302,19 @@ const AdminDataTable = ({
 					<Typography variant='h4'>{title}</Typography>
 				</Box>
 
-				{addButtonText && (
-					<Button
-						variant='contained'
-						color='primary'
-						startIcon={<AddIcon />}
-						onClick={() => handleOpenDialog()}
-					>
-						{addButtonText}
-					</Button>
-				)}
+                                {addButtonText && (
+                                        <Button
+                                                variant='contained'
+                                                color='primary'
+                                                startIcon={<AddIcon />}
+                                                onClick={(e) => {
+                                                        e.currentTarget.blur();
+                                                        handleOpenDialog();
+                                                }}
+                                        >
+                                                {addButtonText}
+                                        </Button>
+                                )}
 
 				{uploadButtonText && uploadTemplateButtonText && (
 					<>
@@ -519,9 +522,15 @@ const AdminDataTable = ({
 												</TableCell>
 											))}
 											<TableCell align='right'>
-												<IconButton color='info' onClick={() => handleOpenDialog(item)}>
-													<EditIcon />
-												</IconButton>
+                                                                                                <IconButton
+                                                                                                        color='info'
+                                                                                                        onClick={(e) => {
+                                                                                                                e.currentTarget.blur();
+                                                                                                                handleOpenDialog(item);
+                                                                                                        }}
+                                                                                                >
+                                                                                                        <EditIcon />
+                                                                                                </IconButton>
 												<IconButton
 													color='error'
 													onClick={() => handleOpenDeleteDialog(item.id)}


### PR DESCRIPTION
## Summary
- blur trigger buttons before opening admin dialogs to avoid aria-hidden focus warning

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6891ecdad19c832fb90abaf9bc5b70e0