### PR TITLE
Fix AdminDataTable sorting

### DIFF
--- a/client/src/components/admin/AdminDataTable.js
+++ b/client/src/components/admin/AdminDataTable.js
@@ -35,8 +35,7 @@ import ClearAllIcon from '@mui/icons-material/ClearAll';
 
 import Base from '../Base';
 import { UI_LABELS, ENUM_LABELS, DATE_API_FORMAT } from '../../constants';
-import { createFieldRenderer, FIELD_TYPES } from '../utils';
-import { formatDate } from '../utils';
+import { createFieldRenderer, FIELD_TYPES, parseTime, formatDate } from '../utils';
 import { isDev } from '../../redux/reducers/auth';
 import { useTheme, alpha } from '@mui/material/styles';
 
@@ -160,17 +159,20 @@ const AdminDataTable = ({
 		setDeleteAllDialog(false);
 	};
 
-	const handleSort = (field) => {
-		setSortConfig((prev) => {
-			if (prev.field === field) {
-				return {
-					field,
-					direction: prev.direction === 'asc' ? 'desc' : 'asc',
-				};
-			}
-			return { field, direction: 'asc' };
-		});
-	};
+        const handleSort = (field) => {
+                const column = columns.find((c) => c.field === field);
+                if (!column || column.type === FIELD_TYPES.CUSTOM) return;
+
+                setSortConfig((prev) => {
+                        if (prev.field === field) {
+                                return {
+                                        field,
+                                        direction: prev.direction === 'asc' ? 'desc' : 'asc',
+                                };
+                        }
+                        return { field, direction: 'asc' };
+                });
+        };
 
 	const handleFilterChange = (field, value, type = null) => {
 		setFilters((prev) => {
@@ -261,32 +263,51 @@ const AdminDataTable = ({
 		setPage(0);
 	};
 
-	const applySorting = (items) => {
-		if (!sortConfig.field) return items;
-		const column = columns.find((c) => c.field === sortConfig.field);
+        const applySorting = (items) => {
+                if (!sortConfig.field) return items;
+                const column = columns.find((c) => c.field === sortConfig.field);
+                if (!column || column.type === FIELD_TYPES.CUSTOM) return items;
 
-		const getSortValue = (item) => {
-			const raw = item[sortConfig.field];
-			if (!column) return raw;
-			if (column.formatter) return column.formatter(raw);
-			if (column.type === FIELD_TYPES.SELECT) {
-				const opt = column.options?.find((o) => o.value === raw);
-				return opt ? opt.label : raw;
-			}
-			if (column.type === FIELD_TYPES.BOOLEAN) {
-				return raw ? ENUM_LABELS.BOOLEAN.true : ENUM_LABELS.BOOLEAN.false;
-			}
-			return raw;
-		};
+                const getSortValue = (item) => {
+                        const raw = item[sortConfig.field];
+                        switch (column.type) {
+                                case FIELD_TYPES.DATE:
+                                case FIELD_TYPES.DATETIME:
+                                        return raw ? new Date(raw).getTime() : 0;
+                                case FIELD_TYPES.TIME:
+                                        return raw ? parseTime(raw) : 0;
+                                case FIELD_TYPES.NUMBER:
+                                        return raw === undefined || raw === null ? 0 : Number(raw);
+                                case FIELD_TYPES.BOOLEAN:
+                                        return raw ? 1 : 0;
+                                case FIELD_TYPES.SELECT: {
+                                        const opt = column.options?.find((o) => o.value === raw);
+                                        const label = opt ? opt.label : column.formatter ? column.formatter(raw) : raw;
+                                        return label ? String(label).toLowerCase() : '';
+                                }
+                                case FIELD_TYPES.TEXT:
+                                case FIELD_TYPES.TEXT_AREA:
+                                case FIELD_TYPES.EMAIL:
+                                case FIELD_TYPES.PHONE:
+                                        return raw ? String(raw).toLowerCase() : '';
+                                default:
+                                        return raw;
+                        }
+                };
 
-		return [...items].sort((a, b) => {
-			const aVal = getSortValue(a);
-			const bVal = getSortValue(b);
-			if (aVal < bVal) return sortConfig.direction === 'asc' ? -1 : 1;
-			if (aVal > bVal) return sortConfig.direction === 'asc' ? 1 : -1;
-			return 0;
-		});
-	};
+                return [...items].sort((a, b) => {
+                        const aVal = getSortValue(a);
+                        const bVal = getSortValue(b);
+
+                        if (typeof aVal === 'string' && typeof bVal === 'string') {
+                                const comparison = aVal.localeCompare(bVal);
+                                return sortConfig.direction === 'asc' ? comparison : -comparison;
+                        }
+                        if (aVal < bVal) return sortConfig.direction === 'asc' ? -1 : 1;
+                        if (aVal > bVal) return sortConfig.direction === 'asc' ? 1 : -1;
+                        return 0;
+                });
+        };
 
 	const filteredData = applyFilters(data);
 	const sortedData = applySorting(filteredData);
@@ -388,24 +409,33 @@ const AdminDataTable = ({
 							<Table stickyHeader sx={{ tableLayout: 'auto' }}>
 								<TableHead>
 									<TableRow>
-										{columns.map((column, index) => (
-											<TableCell
-												key={index}
-												align={column.align || 'left'}
-												sx={{
-													fontWeight: 'bold',
-													cursor: 'pointer',
-												}}
-												onClick={() => handleSort(column.field)}
-											>
-												<TableSortLabel
-													active={sortConfig.field === column.field}
-													direction={sortConfig.direction}
-												>
-													{column.header}
-												</TableSortLabel>
-											</TableCell>
-										))}
+                                                                                {columns.map((column, index) => (
+                                                                                        <TableCell
+                                                                                                key={index}
+                                                                                                align={column.align || 'left'}
+                                                                                                sx={{
+                                                                                                        fontWeight: 'bold',
+                                                                                                        cursor:
+                                                                                                                column.type === FIELD_TYPES.CUSTOM
+                                                                                                                        ? 'default'
+                                                                                                                        : 'pointer',
+                                                                                                }}
+                                                                                                {...(column.type !== FIELD_TYPES.CUSTOM
+                                                                                                        ? { onClick: () => handleSort(column.field) }
+                                                                                                        : {})}
+                                                                                        >
+                                                                                                {column.type !== FIELD_TYPES.CUSTOM ? (
+                                                                                                        <TableSortLabel
+                                                                                                                active={sortConfig.field === column.field}
+                                                                                                                direction={sortConfig.direction}
+                                                                                                        >
+                                                                                                                {column.header}
+                                                                                                        </TableSortLabel>
+                                                                                                ) : (
+                                                                                                        column.header
+                                                                                                )}
+                                                                                        </TableCell>
+                                                                                ))}
 										<TableCell align='right' sx={{ fontWeight: 'bold' }}>
 											{UI_LABELS.ADMIN.actions}
 										</TableCell>


### PR DESCRIPTION
## Summary
- handle sorting per type in AdminDataTable
- skip custom fields from sorting
- sort select columns by label text

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68920574a22c832fb23badb03e22e34b