### PR TITLE
refactor: use explicit filtering and one_or_none

### DIFF
--- a/server/app/models/_base_model.py
+++ b/server/app/models/_base_model.py
@@ -79,7 +79,7 @@ class BaseModel(db.Model):
                 query = query.filter(getattr(cls, col) == data[col])
             if instance_id is not None:
                 query = query.filter(cls.id != instance_id)
-            if query.first() is not None:
+            if query.one_or_none() is not None:
                 for col in columns:
                     errors[col] = 'must be unique'
         return errors

--- a/server/app/models/airport.py
+++ b/server/app/models/airport.py
@@ -104,7 +104,7 @@ class Airport(BaseModel):
                     tz_name = row.get('time_zone')
                     tz = None
                     if tz_name:
-                        tz = Timezone.query.filter_by(name=tz_name).first()
+                        tz = Timezone.query.filter(Timezone.name == tz_name).one_or_none()
 
                     airport = cls.create(
                         session,

--- a/server/app/models/booking_passenger.py
+++ b/server/app/models/booking_passenger.py
@@ -37,10 +37,13 @@ class BookingPassenger(BaseModel):
     @classmethod
     def __check_is_contact_unique(cls, session, booking_id, instance_id=None):
         """Ensure only one contact passenger per booking"""
-        query = session.query(cls).filter_by(booking_id=booking_id, is_contact=True)
+        query = session.query(cls).filter(
+            cls.booking_id == booking_id,
+            cls.is_contact.is_(True)
+        )
         if instance_id is not None:
             query = query.filter(cls.id != instance_id)
-        if query.first() is not None:
+        if query.one_or_none() is not None:
             raise ModelValidationError({'is_contact': 'only one contact passenger per booking allowed'})
 
     @classmethod

--- a/server/app/models/flight.py
+++ b/server/app/models/flight.py
@@ -110,10 +110,10 @@ class Flight(BaseModel):
                     if not destination:
                         raise ValueError('Invalid destination airport code')
 
-                    route = Route.query.filter_by(
-                        origin_airport_id=origin.id,
-                        destination_airport_id=destination.id,
-                    ).first()
+                    route = Route.query.filter(
+                        Route.origin_airport_id == origin.id,
+                        Route.destination_airport_id == destination.id,
+                    ).one_or_none()
                     if not route:
                         raise ValueError('Route does not exist')
 
@@ -125,7 +125,9 @@ class Flight(BaseModel):
                     aircraft_id = None
                     aircraft_type = row.get('aircraft')
                     if aircraft_type:
-                        aircraft_obj = Aircraft.query.filter_by(type=aircraft_type).first()
+                        aircraft_obj = Aircraft.query.filter(
+                            Aircraft.type == aircraft_type
+                        ).one_or_none()
                         if not aircraft_obj:
                             raise ValueError('Invalid aircraft type')
                         aircraft_id = aircraft_obj.id
@@ -154,9 +156,10 @@ class Flight(BaseModel):
                         if seat_class in used_classes:
                             raise ValueError('Duplicate service class')
                         used_classes.add(seat_class)
-                        tariff = Tariff.query.filter_by(
-                            seat_class=seat_class, order_number=int(tariff_number)
-                        ).first()
+                        tariff = Tariff.query.filter(
+                            Tariff.seat_class == seat_class,
+                            Tariff.order_number == int(tariff_number)
+                        ).one_or_none()
                         if not tariff:
                             raise ValueError('Invalid tariff number or class')
                         FlightTariff.create(
@@ -246,14 +249,14 @@ class Flight(BaseModel):
                 cls.airline_id == airline_id,
                 cls.route_id == route_id,
                 cls.scheduled_departure == scheduled_departure
-            ).first()
+            ).one_or_none()
         else:
-            existing_flight = query.filter_by(
-                flight_number=flight_number,
-                airline_id=airline_id,
-                route_id=route_id,
-                scheduled_departure=scheduled_departure
-            ).first()
+            existing_flight = query.filter(
+                cls.flight_number == flight_number,
+                cls.airline_id == airline_id,
+                cls.route_id == route_id,
+                cls.scheduled_departure == scheduled_departure
+            ).one_or_none()
         if existing_flight:
             print(existing_flight.to_dict())
             raise ModelValidationError(

--- a/server/app/models/flight_tariff.py
+++ b/server/app/models/flight_tariff.py
@@ -29,7 +29,7 @@ class FlightTariff(BaseModel):
         query = query.filter(cls.flight_id == flight_id, Tariff.seat_class == tariff.seat_class)
         if instance_id is not None:
             query = query.filter(cls.id != instance_id)
-        if query.first() is not None:
+        if query.one_or_none() is not None:
             raise ModelValidationError({'seat_class': 'flight tariff for this class already exists'})
 
     def to_dict(self):

--- a/server/app/models/passenger.py
+++ b/server/app/models/passenger.py
@@ -87,13 +87,13 @@ class Passenger(BaseModel):
         ]
 
         if all(field in kwargs for field in unique_fields):
-            existing = session.query(cls).filter_by(
-                first_name=kwargs['first_name'],
-                last_name=kwargs['last_name'],
-                birth_date=kwargs['birth_date'],
-                document_type=kwargs['document_type'],
-                document_number=kwargs['document_number'],
-            ).first()
+            existing = session.query(cls).filter(
+                cls.first_name == kwargs['first_name'],
+                cls.last_name == kwargs['last_name'],
+                cls.birth_date == kwargs['birth_date'],
+                cls.document_type == kwargs['document_type'],
+                cls.document_number == kwargs['document_number'],
+            ).one_or_none()
             if existing and (current_id is None or existing.id != current_id):
                 super().update(existing.id, session, **kwargs)
                 return existing

--- a/server/app/models/password_reset_token.py
+++ b/server/app/models/password_reset_token.py
@@ -31,7 +31,10 @@ class PasswordResetToken(BaseModel):
 
     @classmethod
     def verify_token(cls, token):
-        instance = cls.query.filter_by(token=token, used=False).first()
+        instance = cls.query.filter(
+            cls.token == token,
+            cls.used.is_(False)
+        ).one_or_none()
         if not instance:
             return None
 

--- a/server/app/models/tariff.py
+++ b/server/app/models/tariff.py
@@ -42,7 +42,7 @@ class Tariff(BaseModel):
         seat_class = data.get('seat_class')
 
         if seat_class is not None:
-            query = session.query(cls).filter_by(seat_class=seat_class)
+            query = session.query(cls).filter(cls.seat_class == seat_class)
             max_order = query.order_by(cls.order_number.desc()).first()
             next_order = (max_order.order_number + 1) if max_order else 1
             data['order_number'] = next_order

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -63,7 +63,7 @@ class User(BaseModel):
     def get_by_email(cls, _email):
         if not isinstance(_email, str):
             return None
-        return cls.query.filter_by(email=_email.lower()).first()
+        return cls.query.filter(cls.email == _email.lower()).one_or_none()
 
     @classmethod
     def update(cls, _id, session: Session | None = None, **data):


### PR DESCRIPTION
## Summary
- replace filter_by with filter expressions across models
- use one_or_none for singular queries and uniqueness checks
- centralize uniqueness checks using one_or_none in BaseModel

## Testing
- `pytest tests/unit/test_flight_tariff.py::test_unique_class_on_create -q` *(fails: Working outside of application context)*

------
https://chatgpt.com/codex/tasks/task_e_689205dbc964832fbffcd76d8d7ffd16