### PR TITLE
Serialize models before deletion to prevent DetachedInstanceError

### DIFF
--- a/server/app/controllers/aircraft_controller.py
+++ b/server/app/controllers/aircraft_controller.py
@@ -31,4 +31,4 @@ def update_aircraft(current_user, aircraft_id):
 @admin_required
 def delete_aircraft(current_user, aircraft_id):
     aircraft = Aircraft.delete(aircraft_id)
-    return jsonify(aircraft.to_dict())
+    return jsonify(aircraft)

--- a/server/app/controllers/airline_controller.py
+++ b/server/app/controllers/airline_controller.py
@@ -32,7 +32,7 @@ def update_airline(current_user, airline_id):
 @admin_required
 def delete_airline(current_user, airline_id):
     deleted = Airline.delete_or_404(airline_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)
 
 
 @admin_required

--- a/server/app/controllers/airport_controller.py
+++ b/server/app/controllers/airport_controller.py
@@ -32,7 +32,7 @@ def update_airport(current_user, airport_id):
 @admin_required
 def delete_airport(current_user, airport_id):
     deleted = Airport.delete_or_404(airport_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)
 
 
 @admin_required

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -33,4 +33,4 @@ def update_booking(current_user, booking_id):
 @admin_required
 def delete_booking(current_user, booking_id):
     deleted = Booking.delete_or_404(booking_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/booking_passenger_controller.py
+++ b/server/app/controllers/booking_passenger_controller.py
@@ -33,4 +33,4 @@ def update_booking_passenger(current_user, booking_passenger_id):
 @admin_required
 def delete_booking_passenger(current_user, booking_passenger_id):
     deleted = BookingPassenger.delete_or_404(booking_passenger_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/country_controller.py
+++ b/server/app/controllers/country_controller.py
@@ -34,7 +34,7 @@ def update_country(current_user, country_id):
 @admin_required
 def delete_country(current_user, country_id):
     deleted = Country.delete_or_404(country_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)
 
 
 @admin_required

--- a/server/app/controllers/discount_controller.py
+++ b/server/app/controllers/discount_controller.py
@@ -33,4 +33,4 @@ def update_discount(current_user, discount_id):
 @admin_required
 def delete_discount(current_user, discount_id):
     deleted = Discount.delete_or_404(discount_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/flight_controller.py
+++ b/server/app/controllers/flight_controller.py
@@ -32,7 +32,7 @@ def update_flight(current_user, flight_id):
 @admin_required
 def delete_flight(current_user, flight_id):
     deleted = Flight.delete_or_404(flight_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)
 
 
 @admin_required

--- a/server/app/controllers/flight_tariff_controller.py
+++ b/server/app/controllers/flight_tariff_controller.py
@@ -35,4 +35,4 @@ def update_flight_tariff(current_user, flight_tariff_id):
 @admin_required
 def delete_flight_tariff(current_user, flight_tariff_id):
     deleted = FlightTariff.delete_or_404(flight_tariff_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/passenger_controller.py
+++ b/server/app/controllers/passenger_controller.py
@@ -33,4 +33,4 @@ def update_passenger(current_user, passenger_id):
 @admin_required
 def delete_passenger(current_user, passenger_id):
     deleted = Passenger.delete_or_404(passenger_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/payment_controller.py
+++ b/server/app/controllers/payment_controller.py
@@ -34,4 +34,4 @@ def update_payment(current_user, payment_id):
 @admin_required
 def delete_payment(current_user, payment_id):
     deleted = Payment.delete_or_404(payment_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/route_controller.py
+++ b/server/app/controllers/route_controller.py
@@ -32,4 +32,4 @@ def update_route(current_user, route_id):
 @admin_required
 def delete_route(current_user, route_id):
     deleted = Route.delete_or_404(route_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/seat_controller.py
+++ b/server/app/controllers/seat_controller.py
@@ -35,4 +35,4 @@ def update_seat(current_user, seat_id):
 @admin_required
 def delete_seat(current_user, seat_id):
     deleted = Seat.delete_or_404(seat_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/tariff_controller.py
+++ b/server/app/controllers/tariff_controller.py
@@ -31,4 +31,4 @@ def update_tariff(current_user, tariff_id):
 @admin_required
 def delete_tariff(current_user, tariff_id):
     deleted = Tariff.delete_or_404(tariff_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/ticket_controller.py
+++ b/server/app/controllers/ticket_controller.py
@@ -33,4 +33,4 @@ def update_ticket(current_user, ticket_id):
 @admin_required
 def delete_ticket(current_user, ticket_id):
     deleted = Ticket.delete_or_404(ticket_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)

--- a/server/app/controllers/timezone_controller.py
+++ b/server/app/controllers/timezone_controller.py
@@ -33,7 +33,7 @@ def update_timezone(current_user, timezone_id):
 @admin_required
 def delete_timezone(current_user, timezone_id):
     deleted = Timezone.delete_or_404(timezone_id)
-    return jsonify(deleted.to_dict())
+    return jsonify(deleted)
 
 
 @admin_required

--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -39,7 +39,7 @@ def update_user(current_user, user_id):
 @admin_required
 def delete_user(current_user, user_id):
     deleted_user = User.delete_or_404(user_id)
-    return jsonify(deleted_user.to_dict())
+    return jsonify(deleted_user)
 
 
 def __set_user_activity(user_id, is_active):

--- a/server/app/models/_base_model.py
+++ b/server/app/models/_base_model.py
@@ -114,17 +114,19 @@ class BaseModel(db.Model):
         return instance
 
     @classmethod
-    def delete_or_404(cls, _id, session: Session | None = None) -> Optional['BaseModel']:
+    def delete_or_404(cls, _id, session: Session | None = None) -> Optional[Dict]:
         session = session or db.session
         instance = cls.get_or_404(_id, session)
 
         if hasattr(instance, 'prepare_for_deletion'):
             instance.prepare_for_deletion()
 
+        instance_dict = instance.to_dict() if hasattr(instance, 'to_dict') else None
+
         try:
             session.delete(instance)
             session.commit()
-            return instance
+            return instance_dict
         except IntegrityError as e:
             session.rollback()
             raise ModelValidationError({"message": str(e)}) from e
@@ -173,7 +175,7 @@ class BaseModel(db.Model):
     @classmethod
     def delete(
         cls, _id, session: Session | None = None
-    ) -> Optional['BaseModel']:
+    ) -> Optional[Dict]:
         session = session or db.session
         return cls.delete_or_404(_id, session)
 


### PR DESCRIPTION
## Summary
- Capture model data before deletion to avoid DetachedInstanceError
- Simplify delete controller responses to use pre-serialized data

## Testing
- `set -a; source ../.example.env; export SERVER_TEST_DATABASE_URI="sqlite:///:memory:"; set +a; pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68924f5f2c5c832f975a3c7c95af57cc