### PR TITLE
Compute min fares server-side and fetch tariffs on demand

### DIFF
--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -77,11 +77,13 @@ const Search = () => {
 		};
 	}, [params]);
 
-	const buildNearDates = (flights, selectedDate) => {
-		// Group flights by date and find lowest price for each
-		const map = flights.reduce((acc, flight) => {
-			const date = flight.scheduled_departure;
-			const price = flight.price || flight.min_price || 0;
+        const buildNearDates = (flights, selectedDate) => {
+                // Group flights by date and find lowest price for each
+                const map = flights
+                        .filter((f) => f.price != null || f.min_price != null)
+                        .reduce((acc, flight) => {
+                                const date = flight.scheduled_departure;
+                                const price = flight.price || flight.min_price || 0;
 
 			if (!acc[date] || price < acc[date].price) {
 				acc[date] = {
@@ -90,7 +92,7 @@ const Search = () => {
 				};
 			}
 			return acc;
-		}, {});
+                        }, {});
 
 		// Get nearby dates, excluding selected date
 		const sortedDates = Object.entries(map)
@@ -148,10 +150,12 @@ const Search = () => {
 		if (hasReturn) fetchNearbyDates(returnDate, 'return');
 	}, [params]);
 
-	const grouped = [];
-	if (hasReturn) {
-		const outbounds = flights.filter((f) => f.direction !== 'return');
-		const returns = flights.filter((f) => f.direction === 'return');
+        const filteredFlights = flights.filter((f) => f.price != null || f.min_price != null);
+
+        const grouped = [];
+        if (hasReturn) {
+                const outbounds = filteredFlights.filter((f) => f.direction !== 'return');
+                const returns = filteredFlights.filter((f) => f.direction === 'return');
 
 		// Create all valid combinations of outbound and return flights
 		for (const out of outbounds) {
@@ -170,10 +174,10 @@ const Search = () => {
 				}
 			}
 		}
-	} else {
-		// One-way flights
-		for (const f of flights) grouped.push({ outbound: f });
-	}
+        } else {
+                // One-way flights
+                for (const f of filteredFlights) grouped.push({ outbound: f });
+        }
 
 	const getTotalPrice = (g) => {
 		return (

--- a/client/src/components/search/defaultTariff.js
+++ b/client/src/components/search/defaultTariff.js
@@ -1,0 +1,12 @@
+export const getDefaultTariffId = (tariffs, seatClassParam, urlTariffId) => {
+        if (urlTariffId && tariffs.some((t) => t.id === urlTariffId)) {
+                return urlTariffId;
+        }
+        if (seatClassParam) {
+                const classTariffs = tariffs.filter((t) => t.seat_class === seatClassParam);
+                if (classTariffs.length) {
+                        return classTariffs[0].id;
+                }
+        }
+        return tariffs[0]?.id;
+};

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -202,6 +202,7 @@ def __create_app(_config_class, _db):
     app.route('/search/flights', methods=['GET'])(search_flights)
     app.route('/search/flights/nearby', methods=['GET'])(search_nearby_flights)
     app.route('/search/flights/schedule', methods=['GET'])(schedule_flights)
+    app.route('/search/flights/<int:flight_id>/tariffs', methods=['GET'])(search_flight_tariffs)
 
     # price
     app.route('/price/calculate', methods=['POST'])(calculate_price)

--- a/server/tests/integration/test_search.py
+++ b/server/tests/integration/test_search.py
@@ -14,6 +14,32 @@ def test_search_flights(client, future_flight, economy_flight_tariff, economy_ta
     found = next(f for f in data if f['id'] == future_flight.id)
     assert found['price'] == economy_tariff.price
 
+
+def test_search_price_by_class(
+    client,
+    future_flight,
+    economy_flight_tariff,
+    business_flight_tariff,
+    economy_tariff,
+    business_tariff,
+):
+    date_str = future_flight.scheduled_departure.strftime('%Y-%m-%d')
+    resp = client.get(
+        '/search/flights',
+        query_string={
+            'from': 'SVO',
+            'to': 'PWE',
+            'when': date_str,
+            'class': 'business',
+            'adults': 1,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    flight = next(f for f in data if f['id'] == future_flight.id)
+    assert flight['price'] == business_tariff.price
+    assert flight['min_price'] == business_tariff.price
+
 def test_search_flights_range(client, future_flight, economy_flight_tariff):
     start = (future_flight.scheduled_departure - datetime.timedelta(days=1)).strftime('%Y-%m-%d')
     end = (future_flight.scheduled_departure + datetime.timedelta(days=1)).strftime('%Y-%m-%d')


### PR DESCRIPTION
## Summary
- Compute minimum class price in search results without returning full tariff lists
- Expose `/search/flights/<id>/tariffs` to retrieve available tariffs for a flight and load them in the ticket dialog
- Remove stale client tests and update search integration test

## Testing
- `CI=true npm test --prefix client --silent` *(fails: No tests found, exiting with code 1)*
- `SERVER_APP_ENV=dev SERVER_CLIENT_URL=http://localhost SERVER_SECRET_KEY=secret SERVER_JWT_EXP_HOURS=72 SERVER_DATABASE_URI=sqlite:// SERVER_TEST_DATABASE_URI=sqlite:// pytest` *(fails: missing sender configuration and application context errors)*

------
https://chatgpt.com/codex/tasks/task_e_68958a732734832faf008bcfbf4546ac