### PR TITLE
Fix flight duration calculation with time zone handling

### DIFF
--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -14,7 +14,7 @@ import { fetchNearbyOutboundFlights, fetchNearbyReturnFlights, fetchSearchFlight
 import { fetchAirports } from '../../redux/actions/airport';
 import { fetchAirlines } from '../../redux/actions/airline';
 import { fetchRoutes } from '../../redux/actions/route';
-import { formatDate, formatNumber, getFlightDurationMinutes, parseTime } from '../utils';
+import { formatDate, formatNumber, parseTime } from '../utils';
 
 const Search = () => {
 	const dispatch = useDispatch();
@@ -221,9 +221,9 @@ const Search = () => {
 				case 'arrival_time':
 					res = parseTime(a.outbound.scheduled_arrival_time) - parseTime(b.outbound.scheduled_arrival_time);
 					break;
-				case 'duration':
-					res = getFlightDurationMinutes(a.outbound) - getFlightDurationMinutes(b.outbound);
-					break;
+                                case 'duration':
+                                        res = (a.outbound.duration ?? 0) - (b.outbound.duration ?? 0);
+                                        break;
 				default:
 					res = 0;
 			}

--- a/server/app/models/flight.py
+++ b/server/app/models/flight.py
@@ -65,6 +65,9 @@ class Flight(BaseModel):
         depart_dt = get_datetime(self.scheduled_departure, self.scheduled_departure_time)
         arrive_dt = get_datetime(self.scheduled_arrival, self.scheduled_arrival_time)
 
+        if depart_dt is None or arrive_dt is None:
+            return None
+
         route = self.route
         origin = route.origin_airport
         dest = route.destination_airport
@@ -72,15 +75,13 @@ class Flight(BaseModel):
         origin_tz = origin.timezone.get_tz() if origin.timezone else None
         dest_tz = dest.timezone.get_tz() if dest.timezone else None
 
-        if origin_tz is not None and dest_tz is not None:
-            depart_dt = depart_dt.astimezone(origin_tz)
-            arrive_dt = arrive_dt.astimezone(dest_tz)
+        if origin_tz:
+            depart_dt = depart_dt.replace(tzinfo=origin_tz)
+        if dest_tz:
+            arrive_dt = arrive_dt.replace(tzinfo=dest_tz)
 
-            delta = arrive_dt - depart_dt
-
-            return int(delta.total_seconds() // 60)
-
-        return 0
+        delta = arrive_dt - depart_dt
+        return int(delta.total_seconds() // 60)
 
     MAX_TARIFFS = 4
 


### PR DESCRIPTION
## Summary
- handle origin and destination time zones when computing `Flight.flight_duration`
- sort search results using server-provided flight duration

## Testing
- `pytest` *(fails: RuntimeError: Working outside of application context)*
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689665021920832f99ff47aa8ca155eb