### PR TITLE
Refactor booking forms and translations

### DIFF
--- a/client/src/components/booking/BookingProgress.js
+++ b/client/src/components/booking/BookingProgress.js
@@ -1,16 +1,55 @@
 import { Stepper, Step, StepLabel } from '@mui/material';
+import GroupIcon from '@mui/icons-material/Group';
+import FactCheckIcon from '@mui/icons-material/FactCheck';
+import PaymentIcon from '@mui/icons-material/Payment';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { useNavigate, useParams } from 'react-router-dom';
+
 import { UI_LABELS } from '../../constants';
 
-const steps = UI_LABELS.BOOKING.progress_steps;
+const icons = {
+        1: <GroupIcon />, // Passengers
+        2: <FactCheckIcon />, // Confirmation
+        3: <PaymentIcon />, // Payment
+        4: <CheckCircleIcon />, // Completion
+};
 
-const BookingProgress = ({ activeStep }) => (
-	<Stepper activeStep={activeStep} alternativeLabel sx={{ mb: 3 }}>
-		{steps.map((label) => (
-			<Step key={label}>
-				<StepLabel>{label}</StepLabel>
-			</Step>
-		))}
-	</Stepper>
-);
+const StepIcon = (props) => {
+        const { icon } = props;
+        return icons[icon];
+};
+
+const BookingProgress = ({ activeStep }) => {
+        const { publicId } = useParams();
+        const navigate = useNavigate();
+
+        const steps = UI_LABELS.BOOKING.progress_steps;
+        const routes = [
+                `/booking/${publicId}/passengers`,
+                `/booking/${publicId}/confirmation`,
+                `/booking/${publicId}/payment`,
+                `/booking/${publicId}/completion`,
+        ];
+
+        const handleClick = (index) => {
+                if (index < activeStep) {
+                        navigate(routes[index]);
+                }
+        };
+
+        return (
+                <Stepper activeStep={activeStep} alternativeLabel sx={{ mb: 3 }}>
+                        {steps.map((label, index) => (
+                                <Step
+                                        key={label}
+                                        onClick={() => handleClick(index)}
+                                        sx={{ cursor: index < activeStep ? 'pointer' : 'default' }}
+                                >
+                                        <StepLabel StepIconComponent={StepIcon}>{label}</StepLabel>
+                                </Step>
+                        ))}
+                </Stepper>
+        );
+};
 
 export default BookingProgress;

--- a/client/src/components/booking/PassengerForm.js
+++ b/client/src/components/booking/PassengerForm.js
@@ -1,14 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 
-import { Box, Grid, TextField, Select, MenuItem, FormControl, InputLabel, Typography, IconButton } from '@mui/material';
+import { Box, Grid, Typography, IconButton } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import DeleteIcon from '@mui/icons-material/Delete';
 import DescriptionIcon from '@mui/icons-material/Description';
-import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { differenceInYears } from 'date-fns';
 
-import { dateLocale, ENUM_LABELS, FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES } from '../../constants';
+import { ENUM_LABELS, FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES } from '../../constants';
+import { createFormFields, FIELD_TYPES } from '../utils';
 
 const typeLabels = UI_LABELS.BOOKING.passenger_form.type_labels;
 
@@ -37,34 +36,75 @@ const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument }) => {
 		documentNumber: passenger?.documentNumber || '',
 	});
 
-	const [errors, setErrors] = useState({});
+        const [errors, setErrors] = useState({});
 
-	useEffect(() => {
-		setData((prev) => ({ ...prev, ...passenger }));
-	}, [passenger]);
+        useEffect(() => {
+                setData((prev) => ({ ...prev, ...passenger }));
+        }, [passenger]);
 
-	const handleFieldChange = (field, value) => {
-		const next = { ...data, [field]: value };
-		setData(next);
-		if (onChange) onChange(field, value, next);
-		if (errors[field]) setErrors((e) => ({ ...e, [field]: '' }));
-	};
+        const formFields = useMemo(() => {
+                const fields = {
+                        lastName: {
+                                key: 'lastName',
+                                label: FIELD_LABELS.PASSENGER.last_name,
+                                validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED : ''),
+                        },
+                        firstName: {
+                                key: 'firstName',
+                                label: FIELD_LABELS.PASSENGER.first_name,
+                                validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED : ''),
+                        },
+                        gender: {
+                                key: 'gender',
+                                label: FIELD_LABELS.PASSENGER.gender,
+                                type: FIELD_TYPES.SELECT,
+                                options: genderOptions,
+                        },
+                        birthDate: {
+                                key: 'birthDate',
+                                label: FIELD_LABELS.PASSENGER.birth_date,
+                                type: FIELD_TYPES.DATE,
+                                validate: (v) => getAgeError(data.type, v),
+                        },
+                        documentType: {
+                                key: 'documentType',
+                                label: FIELD_LABELS.PASSENGER.document_type,
+                                type: FIELD_TYPES.SELECT,
+                                options: docTypeOptions,
+                                validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_type.REQUIRED : ''),
+                        },
+                        documentNumber: {
+                                key: 'documentNumber',
+                                label: FIELD_LABELS.PASSENGER.document_number,
+                                validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_number.REQUIRED : ''),
+                        },
+                };
+                const arr = createFormFields(fields);
+                return arr.reduce((acc, f) => ({ ...acc, [f.name]: f }), {});
+        }, [data.type]);
 
-	const validate = () => {
-		const errs = {};
-		if (!data.lastName) errs.lastName = VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED;
-		if (!data.firstName) errs.firstName = VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED;
-		const ageErr = getAgeError(data.type, data.birthDate);
-		if (ageErr) errs.birthDate = ageErr;
-		if (!data.documentType) errs.documentType = VALIDATION_MESSAGES.PASSENGER.document_type.REQUIRED;
-		if (!data.documentNumber) errs.documentNumber = VALIDATION_MESSAGES.PASSENGER.document_number.REQUIRED;
-		setErrors(errs);
-		return Object.keys(errs).length === 0;
-	};
+        const handleFieldChange = (field, value) => {
+                const next = { ...data, [field]: value };
+                setData(next);
+                if (onChange) onChange(field, value, next);
+                if (errors[field]) setErrors((e) => ({ ...e, [field]: '' }));
+        };
 
-	useEffect(() => {
-		validate();
-	}, [data.type, data.birthDate]);
+        const validate = useCallback(() => {
+                const errs = {};
+                Object.values(formFields).forEach((f) => {
+                        if (f.validate) {
+                                const err = f.validate(data[f.name]);
+                                if (err) errs[f.name] = err;
+                        }
+                });
+                setErrors(errs);
+                return Object.keys(errs).length === 0;
+        }, [formFields, data]);
+
+        useEffect(() => {
+                validate();
+        }, [data.type, data.birthDate, validate]);
 
 	const theme = useTheme();
 
@@ -92,90 +132,27 @@ const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument }) => {
 					)}
 				</Box>
 			</Box>
-			<Grid container spacing={2}>
-				<Grid item xs={12} sm={6}>
-					<TextField
-						label={FIELD_LABELS.PASSENGER.last_name}
-						value={data.lastName}
-						onChange={(e) => handleFieldChange('lastName', e.target.value)}
-						fullWidth
-						error={!!errors.lastName}
-						helperText={errors.lastName}
-					/>
-				</Grid>
-				<Grid item xs={12} sm={6}>
-					<TextField
-						label={FIELD_LABELS.PASSENGER.first_name}
-						value={data.firstName}
-						onChange={(e) => handleFieldChange('firstName', e.target.value)}
-						fullWidth
-						error={!!errors.firstName}
-						helperText={errors.firstName}
-					/>
-				</Grid>
-				<Grid item xs={12} sm={6}>
-					<FormControl fullWidth error={!!errors.gender}>
-						<InputLabel>{FIELD_LABELS.PASSENGER.gender}</InputLabel>
-						<Select
-							value={data.gender}
-							label={FIELD_LABELS.PASSENGER.gender}
-							onChange={(e) => handleFieldChange('gender', e.target.value)}
-						>
-							{genderOptions.map((o) => (
-								<MenuItem key={o.value} value={o.value}>
-									{o.label}
-								</MenuItem>
-							))}
-						</Select>
-					</FormControl>
-				</Grid>
-				<Grid item xs={12} sm={6}>
-					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
-						<DatePicker
-							label={FIELD_LABELS.PASSENGER.birth_date}
-							value={data.birthDate ? new Date(data.birthDate) : null}
-							onChange={(date) =>
-								handleFieldChange('birthDate', date ? date.toISOString().slice(0, 10) : '')
-							}
-							slotProps={{
-								textField: {
-									fullWidth: true,
-									error: !!errors.birthDate,
-									helperText: errors.birthDate,
-								},
-							}}
-						/>
-					</LocalizationProvider>
-				</Grid>
-				<Grid item xs={12} sm={6}>
-					<FormControl fullWidth error={!!errors.documentType}>
-						<InputLabel>{FIELD_LABELS.PASSENGER.document_type}</InputLabel>
-						<Select
-							value={data.documentType}
-							label={FIELD_LABELS.PASSENGER.document_type}
-							onChange={(e) => handleFieldChange('documentType', e.target.value)}
-						>
-							{docTypeOptions.map((o) => (
-								<MenuItem key={o.value} value={o.value}>
-									{o.label}
-								</MenuItem>
-							))}
-						</Select>
-					</FormControl>
-				</Grid>
-				<Grid item xs={12} sm={6}>
-					<TextField
-						label={FIELD_LABELS.PASSENGER.document_number}
-						value={data.documentNumber}
-						onChange={(e) => handleFieldChange('documentNumber', e.target.value)}
-						fullWidth
-						error={!!errors.documentNumber}
-						helperText={errors.documentNumber}
-					/>
-				</Grid>
-			</Grid>
-		</Box>
-	);
+                        <Grid container spacing={2}>
+                                {Object.values(formFields).map((field) => (
+                                        <Grid item xs={12} sm={6} key={field.name}>
+                                                {field.renderField({
+                                                        value: data[field.name],
+                                                        onChange: (value) =>
+                                                                handleFieldChange(
+                                                                        field.name,
+                                                                        field.name === 'birthDate' && value
+                                                                                ? value.toISOString().slice(0, 10)
+                                                                                : value,
+                                                                ),
+                                                        fullWidth: true,
+                                                        error: !!errors[field.name],
+                                                        helperText: errors[field.name],
+                                                })}
+                                        </Grid>
+                                ))}
+                        </Grid>
+                </Box>
+        );
 };
 
 export default PassengerForm;

--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -1,121 +1,203 @@
-import React, { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
-import { Box, Grid, Typography, Card, CardContent, TextField, Checkbox, FormControlLabel, Button } from '@mui/material';
+import React, { useState, useMemo, useEffect } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Box,
+  Grid,
+  Typography,
+  Card,
+  CardContent,
+  Checkbox,
+  FormControlLabel,
+  Button,
+  FormControl,
+  FormHelperText,
+} from '@mui/material';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
 import PassengerForm from './PassengerForm';
 import { processBookingPassengers } from '../../redux/actions/bookingProcess';
-import { FIELD_LABELS, UI_LABELS } from '../../constants';
+import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES, ENUM_LABELS } from '../../constants';
+import { createFormFields, FIELD_TYPES, formatNumber } from '../utils';
 
 const Passengers = () => {
-	const { publicId } = useParams();
-	const navigate = useNavigate();
-	const dispatch = useDispatch();
-	const passengers = [{ id: 1, type: 'ADULT' }];
-	const [passengerData, setPassengerData] = useState(passengers);
-	const [buyer, setBuyer] = useState({ lastName: '', firstName: '', email: '', phone: '', consent: false });
+  const { publicId } = useParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const booking = useSelector((state) => state.bookingProcess.current);
 
-	const handlePassengerChange = (id) => (field, value, data) => {
-		setPassengerData((prev) => prev.map((p) => (p.id === id ? { ...p, ...data } : p)));
-	};
+  const initialPassengers = booking?.passengers || [{ id: 1, type: 'ADULT' }];
+  const [passengerData, setPassengerData] = useState(initialPassengers);
+  const [buyer, setBuyer] = useState(
+    booking?.buyer || { lastName: '', firstName: '', email: '', phone: '', consent: false }
+  );
 
-	const handleContinue = async () => {
-		await dispatch(processBookingPassengers({ public_id: publicId, passengers: passengerData, buyer }));
-		navigate(`/booking/${publicId}/confirmation`);
-	};
+  const buyerFormFields = useMemo(() => {
+    const fields = {
+      lastName: {
+        key: 'lastName',
+        label: FIELD_LABELS.PASSENGER.last_name,
+        validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED : ''),
+      },
+      firstName: {
+        key: 'firstName',
+        label: FIELD_LABELS.PASSENGER.first_name,
+        validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED : ''),
+      },
+      email: {
+        key: 'email',
+        label: FIELD_LABELS.BOOKING.email_address,
+        type: FIELD_TYPES.EMAIL,
+        validate: (v) => (!v ? VALIDATION_MESSAGES.BOOKING.email_address.REQUIRED : ''),
+      },
+      phone: {
+        key: 'phone',
+        label: FIELD_LABELS.BOOKING.phone_number,
+        type: FIELD_TYPES.PHONE,
+        validate: (v) => (!v ? VALIDATION_MESSAGES.BOOKING.phone_number.REQUIRED : ''),
+      },
+    };
+    const arr = createFormFields(fields);
+    return arr.reduce((acc, f) => ({ ...acc, [f.name]: f }), {});
+  }, []);
 
-	return (
-		<Base maxWidth='lg'>
-			<BookingProgress activeStep={0} />
-			<Grid container spacing={2}>
-				<Grid item xs={12} md={8}>
-					{passengers.map((p) => (
-						<PassengerForm key={p.id} passenger={p} onChange={handlePassengerChange(p.id)} />
-					))}
-					<Box sx={{ p: 2, border: '1px solid #eee', borderRadius: 2, mb: 2 }}>
-						<Typography variant='h6' sx={{ mb: 2 }}>
-							{UI_LABELS.BOOKING.buyer_form.title}
-						</Typography>
-						<Grid container spacing={2}>
-							<Grid item xs={12} sm={6}>
-								<TextField
-									label={FIELD_LABELS.PASSENGER.last_name}
-									value={buyer.lastName}
-									onChange={(e) => setBuyer({ ...buyer, lastName: e.target.value })}
-									fullWidth
-								/>
-							</Grid>
-							<Grid item xs={12} sm={6}>
-								<TextField
-									label={FIELD_LABELS.PASSENGER.first_name}
-									value={buyer.firstName}
-									onChange={(e) => setBuyer({ ...buyer, firstName: e.target.value })}
-									fullWidth
-								/>
-							</Grid>
-							<Grid item xs={12} sm={6}>
-								<TextField
-									label={FIELD_LABELS.BOOKING.email_address}
-									value={buyer.email}
-									onChange={(e) => setBuyer({ ...buyer, email: e.target.value })}
-									fullWidth
-								/>
-							</Grid>
-							<Grid item xs={12} sm={6}>
-								<TextField
-									label={FIELD_LABELS.BOOKING.phone_number}
-									value={buyer.phone}
-									onChange={(e) => setBuyer({ ...buyer, phone: e.target.value })}
-									fullWidth
-								/>
-							</Grid>
-						</Grid>
-						<FormControlLabel
-							sx={{ mt: 2 }}
-							control={
-								<Checkbox
-									checked={buyer.consent}
-									onChange={(e) => setBuyer({ ...buyer, consent: e.target.checked })}
-								/>
-							}
-							label={UI_LABELS.BOOKING.buyer_form.consent}
-						/>
-					</Box>
-				</Grid>
-				<Grid item xs={12} md={4}>
-					<Card>
-						<CardContent>
-							<Typography variant='h6' gutterBottom>
-								{UI_LABELS.BOOKING.buyer_form.summary.total_for(passengers.length)}
-							</Typography>
-							<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-								<Typography>{UI_LABELS.BOOKING.buyer_form.summary.tickets}</Typography>
-								<Typography>0 ₽</Typography>
-							</Box>
-							<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-								<Typography>{UI_LABELS.BOOKING.buyer_form.summary.service_fee}</Typography>
-								<Typography>0 ₽</Typography>
-							</Box>
-							<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
-								<Typography>{UI_LABELS.BOOKING.buyer_form.summary.discount}</Typography>
-								<Typography>0 ₽</Typography>
-							</Box>
-							<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
-								<Typography variant='subtitle1'>
-									{UI_LABELS.BOOKING.buyer_form.summary.total}
-								</Typography>
-								<Typography variant='subtitle1'>0 ₽</Typography>
-							</Box>
-							<Button variant='contained' color='orange' fullWidth onClick={handleContinue}>
-								{UI_LABELS.BUTTONS.continue}
-							</Button>
-						</CardContent>
-					</Card>
-				</Grid>
-			</Grid>
-		</Base>
-	);
+  const [buyerErrors, setBuyerErrors] = useState({});
+
+  const handlePassengerChange = (id) => (field, value, data) => {
+    setPassengerData((prev) => prev.map((p) => (p.id === id ? { ...p, ...data } : p)));
+  };
+
+  const handleBuyerChange = (field, value) => {
+    setBuyer((prev) => ({ ...prev, [field]: value }));
+    if (buyerErrors[field]) setBuyerErrors((e) => ({ ...e, [field]: '' }));
+  };
+
+  const validateBuyer = () => {
+    const errs = {};
+    Object.values(buyerFormFields).forEach((f) => {
+      if (f.validate) {
+        const err = f.validate(buyer[f.name]);
+        if (err) errs[f.name] = err;
+      }
+    });
+    if (!buyer.consent) errs.consent = VALIDATION_MESSAGES.BOOKING.consent.REQUIRED;
+    setBuyerErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleContinue = async () => {
+    if (!validateBuyer()) return;
+    await dispatch(processBookingPassengers({ public_id: publicId, passengers: passengerData, buyer }));
+    navigate(`/booking/${publicId}/confirmation`);
+  };
+
+  const routeInfo = UI_LABELS.SCHEDULE.from_to(booking?.from, booking?.to);
+
+  const farePrice = booking?.fare_price || 0;
+  const serviceFee = booking?.fees || 0;
+  const discount = booking?.total_discounts || 0;
+  const totalPrice = booking?.total_price || 0;
+  const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
+
+  useEffect(() => {
+    if (routeInfo) {
+      document.title = routeInfo;
+    }
+  }, [routeInfo]);
+
+  return (
+    <Base maxWidth='lg'>
+      <BookingProgress activeStep={0} />
+      <Grid container spacing={2}>
+        <Grid
+          item
+          xs={12}
+          md={8}
+          sx={{ maxHeight: 'calc(100vh - 200px)', overflowY: 'auto', pr: { md: 2 } }}
+        >
+          {passengerData.map((p) => (
+            <PassengerForm key={p.id} passenger={p} onChange={handlePassengerChange(p.id)} />
+          ))}
+          <Box sx={{ p: 2, border: '1px solid #eee', borderRadius: 2, mb: 2 }}>
+            <Typography variant='h6' sx={{ mb: 2 }}>
+              {UI_LABELS.BOOKING.buyer_form.title}
+            </Typography>
+            <Grid container spacing={2}>
+              {Object.values(buyerFormFields).map((field) => (
+                <Grid item xs={12} sm={6} key={field.name}>
+                  {field.renderField({
+                    value: buyer[field.name],
+                    onChange: (value) => handleBuyerChange(field.name, value),
+                    fullWidth: true,
+                    error: !!buyerErrors[field.name],
+                    helperText: buyerErrors[field.name],
+                  })}
+                </Grid>
+              ))}
+            </Grid>
+          </Box>
+        </Grid>
+        <Grid item xs={12} md={4} sx={{ position: 'sticky', top: 16 }}>
+          {routeInfo && (
+            <Typography variant='h6' sx={{ mb: 2 }}>
+              {routeInfo}
+            </Typography>
+          )}
+          <Card>
+            <CardContent>
+              <Typography variant='h6' gutterBottom>
+                {UI_LABELS.BOOKING.buyer_form.summary.total_for(passengerData.length)}
+              </Typography>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Typography>{UI_LABELS.BOOKING.buyer_form.summary.tickets}</Typography>
+                <Typography>{`${formatNumber(farePrice)} ${currencySymbol}`}</Typography>
+              </Box>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Typography>{UI_LABELS.BOOKING.buyer_form.summary.service_fee}</Typography>
+                <Typography>{`${formatNumber(serviceFee)} ${currencySymbol}`}</Typography>
+              </Box>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+                <Typography>{UI_LABELS.BOOKING.buyer_form.summary.discount}</Typography>
+                <Typography>{`-${formatNumber(discount)} ${currencySymbol}`}</Typography>
+              </Box>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
+                <Typography variant='subtitle1'>
+                  {UI_LABELS.BOOKING.buyer_form.summary.total}
+                </Typography>
+                <Typography variant='subtitle1'>
+                  {`${formatNumber(totalPrice)} ${currencySymbol}`}
+                </Typography>
+              </Box>
+              <FormControl required error={!!buyerErrors.consent} sx={{ mb: 2 }}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={buyer.consent}
+                      onChange={(e) => handleBuyerChange('consent', e.target.checked)}
+                    />
+                  }
+                  label={
+                    <Typography>
+                      {UI_LABELS.BOOKING.buyer_form.consent}{' '}
+                      <Link to='/privacy_policy'>
+                        {UI_LABELS.BOOKING.buyer_form.privacy_policy}
+                      </Link>
+                    </Typography>
+                  }
+                />
+                {buyerErrors.consent && (
+                  <FormHelperText>{buyerErrors.consent}</FormHelperText>
+                )}
+              </FormControl>
+              <Button variant='contained' color='orange' fullWidth onClick={handleContinue}>
+                {UI_LABELS.BUTTONS.continue}
+              </Button>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Base>
+  );
 };
 
 export default Passengers;

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -249,38 +249,39 @@ export const UI_LABELS = {
 		passwords_dont_match: 'Пароли не совпадают',
 	},
 	HOME: {},
-	BOOKING: {
-		progress_steps: ['Passengers', 'Confirmation', 'Payment', 'Completion'],
-		step_placeholders: {
-			confirmation: 'Confirmation step',
-			payment: 'Payment step',
-			completion: 'Completion step',
-		},
-		buyer_form: {
-			title: 'Покупатель',
-			consent: 'Даю согласие на обработку персональных данных',
-			summary: {
-				total_for: (count) => `Итого за ${count} пассажира(ов)`,
-				tickets: 'Билеты',
-				service_fee: 'Сервисный сбор',
-				discount: 'Скидка',
-				total: 'Итого',
-			},
-		},
-		passenger_form: {
-			type_labels: {
-				ADULT: 'Взрослый, старше 12 лет',
-				CHILD: 'Ребёнок, от 2 до 12 лет',
-				INFANT: 'Малыш, до 2 лет',
-			},
-			genders: [
-				{ value: 'MALE', label: 'Мужской' },
-				{ value: 'FEMALE', label: 'Женский' },
-				{ value: 'OTHER', label: 'Другой' },
-			],
-			add_passenger: 'Добавить пассажира',
-		},
-	},
+        BOOKING: {
+                progress_steps: ['Пассажиры', 'Подтверждение', 'Оплата', 'Завершение'],
+                step_placeholders: {
+                        confirmation: 'Шаг подтверждения',
+                        payment: 'Шаг оплаты',
+                        completion: 'Шаг завершения',
+                },
+                buyer_form: {
+                        title: 'Покупатель',
+                        consent: 'Даю согласие на обработку персональных данных и соглашаюсь с',
+                        privacy_policy: 'политикой обработки персональных данных',
+                        summary: {
+                                total_for: (count) => `Итого за ${count} ${UI_LABELS.SEARCH.form.passenger_word(count)}`,
+                                tickets: 'Билеты',
+                                service_fee: 'Сервисный сбор',
+                                discount: 'Скидка',
+                                total: 'Итого',
+                        },
+                },
+                passenger_form: {
+                        type_labels: {
+                                ADULT: 'Взрослый, старше 12 лет',
+                                CHILD: 'Ребёнок, от 2 до 12 лет',
+                                INFANT: 'Малыш, до 2 лет',
+                        },
+                        genders: [
+                                { value: 'MALE', label: 'Мужской' },
+                                { value: 'FEMALE', label: 'Женский' },
+                                { value: 'OTHER', label: 'Другой' },
+                        ],
+                        add_passenger: 'Добавить пассажира',
+                },
+        },
 	SCHEDULE: {
 		title: 'Расписание рейсов',
 		results: 'Результаты поиска',

--- a/client/src/constants/validationMessages.js
+++ b/client/src/constants/validationMessages.js
@@ -99,19 +99,22 @@ export const VALIDATION_MESSAGES = {
 		},
 	},
 
-	BOOKING: {
-		email_address: {
-			REQUIRED: 'Email обязателен',
-			INVALID: 'Введите корректный email',
-		},
-		phone_number: {
-			REQUIRED: 'Телефон обязателен',
-			INVALID: 'Введите корректный номер телефона',
-		},
-		passenger: {
-			EXISTS: 'Пассажир с таким именем и датой рождения уже есть в бронировании',
-		},
-	},
+        BOOKING: {
+                email_address: {
+                        REQUIRED: 'Email обязателен',
+                        INVALID: 'Введите корректный email',
+                },
+                phone_number: {
+                        REQUIRED: 'Телефон обязателен',
+                        INVALID: 'Введите корректный номер телефона',
+                },
+                passenger: {
+                        EXISTS: 'Пассажир с таким именем и датой рождения уже есть в бронировании',
+                },
+                consent: {
+                        REQUIRED: 'Необходимо согласие на обработку персональных данных',
+                },
+        },
 
 	AIRLINE: {
 		iata_code: {

--- a/client/src/redux/reducers/bookingProcess.js
+++ b/client/src/redux/reducers/bookingProcess.js
@@ -20,12 +20,14 @@ const bookingProcessSlice = createSlice({
 				state.current = action.payload;
 				state.isLoading = false;
 			})
-			.addCase(processBookingPassengers.pending, handlePending)
-			.addCase(processBookingPassengers.rejected, handleRejected)
-			.addCase(processBookingPassengers.fulfilled, (state) => {
-				state.isLoading = false;
-			});
-	},
+                        .addCase(processBookingPassengers.pending, handlePending)
+                        .addCase(processBookingPassengers.rejected, handleRejected)
+                        .addCase(processBookingPassengers.fulfilled, (state, action) => {
+                                const { passengers, buyer } = action.meta.arg || {};
+                                state.current = { ...state.current, passengers, buyer };
+                                state.isLoading = false;
+                        });
+        },
 });
 
 export default bookingProcessSlice.reducer;


### PR DESCRIPTION
## Summary
- translate booking labels to Russian and add passenger count declension
- refactor passenger and buyer forms to reuse shared form field helpers
- enhance booking progress with icons and back navigation, persist passenger data and enforce consent

## Testing
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6897050f252c832fb1253dad5c34e611