### PR TITLE
feat: persist passenger counts and details

### DIFF
--- a/client/src/components/booking/BookingProgress.js
+++ b/client/src/components/booking/BookingProgress.js
@@ -17,12 +17,10 @@ const iconMap = {
 };
 
 const StepIcon = ({ icon, active, completed }) => {
-	const stepKey = stepKeys[icon - 1];
-	const Icon = iconMap[stepKey];
-
-	const color = completed ? 'text.disabled' : active ? 'primary.main' : 'text.disabled';
-
-	return Icon ? <Icon sx={{ color, fontSize: 24 }} /> : null;
+        const stepKey = stepKeys[icon - 1];
+        const Icon = iconMap[stepKey];
+        const color = completed || active ? 'primary.main' : 'text.disabled';
+        return Icon ? <Icon sx={{ color, fontSize: 24 }} /> : null;
 };
 
 const BookingProgress = ({ activeStep }) => {
@@ -38,37 +36,40 @@ const BookingProgress = ({ activeStep }) => {
 
 	const stepIndex = typeof activeStep === 'string' ? stepKeys.indexOf(activeStep) : activeStep;
 
-	const handleClick = (index) => {
-		if (index < stepIndex) navigate(routes[index]);
-	};
+        const handleClick = (index) => {
+                if (index <= stepIndex) navigate(routes[index]);
+        };
 
 	return (
 		<Stepper activeStep={stepIndex} alternativeLabel sx={{ mt: 2, mb: 3 }}>
 			{stepKeys.map((key, index) => {
 				const isCompleted = index < stepIndex;
 				const isActive = index === stepIndex;
-				const isDisabled = index > stepIndex;
-
-				return (
-					<Step
-						key={key}
-						disabled={isDisabled}
-						onClick={() => handleClick(index)}
-						sx={{
-							cursor: isCompleted ? 'pointer' : 'default',
-							'& .MuiStepLabel-label': {
-								color: isActive ? 'primary.main' : isCompleted ? 'text.primary' : 'text.disabled',
-								fontWeight: isActive ? 600 : 400,
-							},
-							'& .MuiStepLabel-labelContainer': { gap: 0.1 },
-						}}
-					>
-						<StepLabel StepIconComponent={StepIcon}>{UI_LABELS.BOOKING.progress_steps[key]}</StepLabel>
-					</Step>
-				);
-			})}
-		</Stepper>
-	);
+                                return (
+                                        <Step
+                                                key={key}
+                                                completed={isCompleted}
+                                                onClick={() => handleClick(index)}
+                                                sx={{
+                                                        cursor: index <= stepIndex ? 'pointer' : 'default',
+                                                        pointerEvents: index <= stepIndex ? 'auto' : 'none',
+                                                        '& .MuiStepLabel-label': {
+                                                                color: isActive
+                                                                        ? 'primary.main'
+                                                                        : isCompleted
+                                                                                ? 'text.primary'
+                                                                                : 'text.disabled',
+                                                                fontWeight: isActive ? 600 : 400,
+                                                        },
+                                                        '& .MuiStepLabel-labelContainer': { gap: 0.1 },
+                                                }}
+                                        >
+                                                <StepLabel StepIconComponent={StepIcon}>{UI_LABELS.BOOKING.progress_steps[key]}</StepLabel>
+                                        </Step>
+                                );
+                        })}
+                </Stepper>
+        );
 };
 
 export default BookingProgress;

--- a/client/src/components/booking/PassengerForm.js
+++ b/client/src/components/booking/PassengerForm.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { Box, Grid, Typography, IconButton } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -7,7 +8,8 @@ import DescriptionIcon from '@mui/icons-material/Description';
 import { differenceInYears } from 'date-fns';
 
 import { FIELD_LABELS, getEnumOptions, UI_LABELS, VALIDATION_MESSAGES } from '../../constants';
-import { createFormFields, FIELD_TYPES } from '../utils';
+import { fetchCountries } from '../../redux/actions/country';
+import { createFormFields, FIELD_TYPES, isCyrillicText, isLatinText, isCyrillicDocument, getDocumentFieldConfig } from '../utils';
 
 const typeLabels = UI_LABELS.BOOKING.passenger_form.type_labels;
 
@@ -23,17 +25,30 @@ const getAgeError = (type, birthDate) => {
 	return '';
 };
 
-const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument }) => {
-	const [data, setData] = useState({
-		id: passenger?.id || '',
-		type: passenger?.type || 'ADULT',
-		lastName: passenger?.lastName || '',
-		firstName: passenger?.firstName || '',
-		gender: passenger?.gender || 'MALE',
-		birthDate: passenger?.birthDate || '',
-		documentType: passenger?.documentType || 'passport',
-		documentNumber: passenger?.documentNumber || '',
-	});
+const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument, onValid }) => {
+        const dispatch = useDispatch();
+        const { countries } = useSelector((state) => state.countries);
+        useEffect(() => {
+                if (!countries || countries.length === 0) {
+                        dispatch(fetchCountries());
+                }
+        }, [countries, dispatch]);
+
+        const citizenshipOptions = (countries || []).map((c) => ({ value: c.id, label: c.name }));
+
+        const [data, setData] = useState({
+                id: passenger?.id || '',
+                type: passenger?.type || 'ADULT',
+                lastName: passenger?.lastName || '',
+                firstName: passenger?.firstName || '',
+                patronymicName: passenger?.patronymicName || '',
+                gender: passenger?.gender || genderOptions[0]?.value || '',
+                birthDate: passenger?.birthDate || '',
+                documentType: passenger?.documentType || docTypeOptions[0]?.value || '',
+                documentNumber: passenger?.documentNumber || '',
+                documentExpiryDate: passenger?.documentExpiryDate || '',
+                citizenshipId: passenger?.citizenshipId || '',
+        });
 
 	const [errors, setErrors] = useState({});
 
@@ -41,24 +56,56 @@ const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument }) => {
 		setData((prev) => ({ ...prev, ...passenger }));
 	}, [passenger]);
 
-	const formFields = useMemo(() => {
-		const fields = {
-			lastName: {
-				key: 'lastName',
-				label: FIELD_LABELS.PASSENGER.last_name,
-				validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED : ''),
-			},
-			firstName: {
-				key: 'firstName',
-				label: FIELD_LABELS.PASSENGER.first_name,
-				validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED : ''),
-			},
-			gender: {
-				key: 'gender',
-				label: FIELD_LABELS.PASSENGER.gender,
-				type: FIELD_TYPES.SELECT,
-				options: genderOptions,
-			},
+        const formFields = useMemo(() => {
+                const requiresCyrillic = isCyrillicDocument(data.documentType);
+                const { showExpiryDate, showCitizenship } = getDocumentFieldConfig(data.documentType);
+
+                const fields = {
+                        lastName: {
+                                key: 'lastName',
+                                label: FIELD_LABELS.PASSENGER.last_name,
+                                validate: (v) => {
+                                        if (!v) return VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED;
+                                        const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
+                                        return valid
+                                                ? ''
+                                                : requiresCyrillic
+                                                        ? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
+                                                        : VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
+                                },
+                        },
+                        firstName: {
+                                key: 'firstName',
+                                label: FIELD_LABELS.PASSENGER.first_name,
+                                validate: (v) => {
+                                        if (!v) return VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED;
+                                        const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
+                                        return valid
+                                                ? ''
+                                                : requiresCyrillic
+                                                        ? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
+                                                        : VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
+                                },
+                        },
+                        patronymicName: {
+                                key: 'patronymicName',
+                                label: FIELD_LABELS.PASSENGER.patronymic_name,
+                                validate: (v) => {
+                                        if (!v) return '';
+                                        const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
+                                        return valid
+                                                ? ''
+                                                : requiresCyrillic
+                                                        ? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
+                                                        : VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
+                                },
+                        },
+                        gender: {
+                                key: 'gender',
+                                label: FIELD_LABELS.PASSENGER.gender,
+                                type: FIELD_TYPES.SELECT,
+                                options: genderOptions,
+                        },
 			birthDate: {
 				key: 'birthDate',
 				label: FIELD_LABELS.PASSENGER.birth_date,
@@ -72,84 +119,149 @@ const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument }) => {
 				options: docTypeOptions,
 				validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_type.REQUIRED : ''),
 			},
-			documentNumber: {
-				key: 'documentNumber',
-				label: FIELD_LABELS.PASSENGER.document_number,
-				validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_number.REQUIRED : ''),
-			},
-		};
-		const arr = createFormFields(fields);
-		return arr.reduce((acc, f) => ({ ...acc, [f.name]: f }), {});
-	}, [data.type]);
+                        documentNumber: {
+                                key: 'documentNumber',
+                                label: FIELD_LABELS.PASSENGER.document_number,
+                                validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_number.REQUIRED : ''),
+                        },
+                        ...(showExpiryDate && {
+                                documentExpiryDate: {
+                                        key: 'documentExpiryDate',
+                                        label: FIELD_LABELS.PASSENGER.document_expiry_date,
+                                        type: FIELD_TYPES.DATE,
+                                },
+                        }),
+                        ...(showCitizenship && {
+                                citizenshipId: {
+                                        key: 'citizenshipId',
+                                        label: FIELD_LABELS.PASSENGER.citizenship_id,
+                                        type: FIELD_TYPES.SELECT,
+                                        options: citizenshipOptions,
+                                },
+                        }),
+                };
+                const arr = createFormFields(fields);
+                return arr.reduce((acc, f) => ({ ...acc, [f.name]: f }), {});
+        }, [data.type, data.documentType, citizenshipOptions]);
 
-	const handleFieldChange = (field, value) => {
-		const next = { ...data, [field]: value };
-		setData(next);
-		if (onChange) onChange(field, value, next);
-		if (errors[field]) setErrors((e) => ({ ...e, [field]: '' }));
-	};
+        const handleFieldChange = (field, value) => {
+                const next = { ...data, [field]: value };
+                setData(next);
+                if (onChange) onChange(field, value, next);
+                if (errors[field]) setErrors((e) => ({ ...e, [field]: '' }));
+                if (validate(next) && onValid) onValid(next);
+        };
 
-	const validate = useCallback(() => {
-		const errs = {};
-		Object.values(formFields).forEach((f) => {
-			if (f.validate) {
-				const err = f.validate(data[f.name]);
-				if (err) errs[f.name] = err;
-			}
-		});
-		setErrors(errs);
-		return Object.keys(errs).length === 0;
-	}, [formFields, data]);
+        const validate = useCallback(
+                (d = data) => {
+                        const errs = {};
+                        Object.values(formFields).forEach((f) => {
+                                if (f.validate) {
+                                        const err = f.validate(d[f.name]);
+                                        if (err) errs[f.name] = err;
+                                }
+                        });
+                        setErrors(errs);
+                        return Object.keys(errs).length === 0;
+                },
+                [formFields, data]
+        );
 
-	useEffect(() => {
-		validate();
-	}, [data.type, data.birthDate, validate]);
+        useEffect(() => {
+                validate();
+        }, [data.type, data.birthDate, data.documentType, validate]);
+
+        useEffect(() => {
+                if (formFields.citizenshipId && !data.citizenshipId && citizenshipOptions.length) {
+                        setData((prev) => ({ ...prev, citizenshipId: citizenshipOptions[0].value }));
+                }
+        }, [formFields.citizenshipId, citizenshipOptions, data.citizenshipId]);
 
 	const theme = useTheme();
 
-	return (
-		<Box sx={{ p: 2, border: `1px solid ${theme.palette.grey[200]}`, borderRadius: 2, mb: 3 }}>
-			<Box
-				sx={{
-					display: 'flex',
-					justifyContent: 'space-between',
-					alignItems: 'center',
-					mb: 2,
-				}}
-			>
-				<Typography variant='h6'>{typeLabels[data.type]}</Typography>
-				<Box>
-					{onSelectDocument && (
-						<IconButton onClick={onSelectDocument} size='small'>
-							<DescriptionIcon />
-						</IconButton>
-					)}
-					{onRemove && (
-						<IconButton onClick={onRemove} size='small'>
-							<DeleteIcon />
-						</IconButton>
-					)}
-				</Box>
-			</Box>
-			<Grid container spacing={2}>
-				{Object.values(formFields).map((field) => (
-					<Grid item xs={12} sm={6} key={field.name}>
-						{field.renderField({
-							value: data[field.name],
-							onChange: (value) =>
-								handleFieldChange(
-									field.name,
-									field.name === 'birthDate' && value ? value.toISOString().slice(0, 10) : value
-								),
-							fullWidth: true,
-							error: !!errors[field.name],
-							helperText: errors[field.name],
-						})}
-					</Grid>
-				))}
-			</Grid>
-		</Box>
-	);
+        const nameFields = ['lastName', 'firstName', 'patronymicName'];
+        const docConfig = getDocumentFieldConfig(data.documentType);
+        const docFieldNames = ['documentType', 'documentNumber'];
+        if (docConfig.showExpiryDate) docFieldNames.push('documentExpiryDate');
+        if (docConfig.showCitizenship) docFieldNames.push('citizenshipId');
+        const docGridSize = 12 / docFieldNames.length;
+
+        return (
+                <Box sx={{ p: 2, border: `1px solid ${theme.palette.grey[200]}`, borderRadius: 2, mb: 3 }}>
+                        <Box
+                                sx={{
+                                        display: 'flex',
+                                        justifyContent: 'space-between',
+                                        alignItems: 'center',
+                                        mb: 2,
+                                }}
+                        >
+                                <Typography variant='h6'>{typeLabels[data.type]}</Typography>
+                                <Box>
+                                        {onSelectDocument && (
+                                                <IconButton onClick={onSelectDocument} size='small'>
+                                                        <DescriptionIcon />
+                                                </IconButton>
+                                        )}
+                                        {onRemove && (
+                                                <IconButton onClick={onRemove} size='small'>
+                                                        <DeleteIcon />
+                                                </IconButton>
+                                        )}
+                                </Box>
+                        </Box>
+                        <Grid container spacing={1}>
+                                {nameFields.map((fieldName) => (
+                                        <Grid item xs={12} sm={4} key={fieldName}>
+                                                {formFields[fieldName].renderField({
+                                                        value: data[fieldName],
+                                                        onChange: (value) => handleFieldChange(fieldName, value),
+                                                        fullWidth: true,
+                                                        size: 'small',
+                                                        error: !!errors[fieldName],
+                                                        helperText: errors[fieldName],
+                                                })}
+                                        </Grid>
+                                ))}
+                                {['gender', 'birthDate'].map((fieldName) => (
+                                        <Grid item xs={12} sm={6} key={fieldName}>
+                                                {formFields[fieldName].renderField({
+                                                        value: data[fieldName],
+                                                        onChange: (value) =>
+                                                                handleFieldChange(
+                                                                        fieldName,
+                                                                        fieldName === 'birthDate' && value
+                                                                                ? value.toISOString().slice(0, 10)
+                                                                                : value
+                                                                ),
+                                                        fullWidth: true,
+                                                        size: 'small',
+                                                        error: !!errors[fieldName],
+                                                        helperText: errors[fieldName],
+                                                })}
+                                        </Grid>
+                                ))}
+                                {docFieldNames.map((fieldName) => (
+                                        <Grid item xs={12} sm={docGridSize} key={fieldName}>
+                                                {formFields[fieldName].renderField({
+                                                        value: data[fieldName],
+                                                        onChange: (value) =>
+                                                                handleFieldChange(
+                                                                        fieldName,
+                                                                        fieldName === 'documentExpiryDate' && value
+                                                                                ? value.toISOString().slice(0, 10)
+                                                                                : value
+                                                                ),
+                                                        fullWidth: true,
+                                                        size: 'small',
+                                                        error: !!errors[fieldName],
+                                                        helperText: errors[fieldName],
+                                                })}
+                                        </Grid>
+                                ))}
+                        </Grid>
+                </Box>
+        );
 };
 
 export default PassengerForm;

--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -2,22 +2,23 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-	Box,
-	Grid,
-	Typography,
-	Card,
-	CardContent,
-	Checkbox,
-	FormControlLabel,
-	Button,
-	FormControl,
-	FormHelperText,
-	Divider,
+        Box,
+        Grid,
+        Typography,
+        Card,
+        CardContent,
+        Checkbox,
+        FormControlLabel,
+        Button,
+        FormControl,
+        FormHelperText,
+        Divider,
+        Chip,
 } from '@mui/material';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
 import PassengerForm from './PassengerForm';
-import { processBookingPassengers } from '../../redux/actions/bookingProcess';
+import { processBookingPassengers, fetchBookingPassengers, saveBookingPassenger } from '../../redux/actions/bookingProcess';
 import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES, ENUM_LABELS } from '../../constants';
 import { createFormFields, FIELD_TYPES, formatNumber } from '../utils';
 
@@ -25,10 +26,17 @@ const Passengers = () => {
 	const { publicId } = useParams();
 	const navigate = useNavigate();
 	const dispatch = useDispatch();
-	const booking = useSelector((state) => state.bookingProcess.current);
+        const booking = useSelector((state) => state.bookingProcess.current);
 
-	const initialPassengers = booking?.passengers || [{ id: 1, type: 'ADULT' }];
-	const [passengerData, setPassengerData] = useState(initialPassengers);
+        const passengersFromStore = booking?.passengers || [{ id: 1, type: 'ADULT' }];
+        const [passengerData, setPassengerData] = useState(passengersFromStore);
+        useEffect(() => {
+                setPassengerData(passengersFromStore);
+        }, [passengersFromStore]);
+
+        useEffect(() => {
+                dispatch(fetchBookingPassengers(publicId));
+        }, [dispatch, publicId]);
 	const [buyer, setBuyer] = useState(
 		booking?.buyer || { lastName: '', firstName: '', email: '', phone: '', consent: false }
 	);
@@ -64,9 +72,13 @@ const Passengers = () => {
 
 	const [buyerErrors, setBuyerErrors] = useState({});
 
-	const handlePassengerChange = (id) => (field, value, data) => {
-		setPassengerData((prev) => prev.map((p) => (p.id === id ? { ...p, ...data } : p)));
-	};
+        const handlePassengerChange = (id) => (field, value, data) => {
+                setPassengerData((prev) => prev.map((p) => (p.id === id ? { ...p, ...data } : p)));
+        };
+
+        const handlePassengerValid = (id) => (data) => {
+                dispatch(saveBookingPassenger({ public_id: publicId, passenger: data }));
+        };
 
 	const handleBuyerChange = (field, value) => {
 		setBuyer((prev) => ({ ...prev, [field]: value }));
@@ -88,9 +100,9 @@ const Passengers = () => {
 
 	const handleContinue = async () => {
 		if (!validateBuyer()) return;
-		await dispatch(processBookingPassengers({ public_id: publicId, passengers: passengerData, buyer }));
-		navigate(`/booking/${publicId}/confirmation`);
-	};
+                await dispatch(processBookingPassengers({ public_id: publicId, buyer }));
+                navigate(`/booking/${publicId}/confirmation`);
+        };
 
 	const routeInfo = UI_LABELS.SCHEDULE.from_to(booking?.from, booking?.to);
 
@@ -111,25 +123,47 @@ const Passengers = () => {
 			<BookingProgress activeStep='passengers' />
 			<Grid container spacing={2}>
 				<Grid item xs={12} md={8} sx={{ maxHeight: 'calc(100vh - 200px)', overflowY: 'auto', pr: { md: 2 } }}>
-					{passengerData.map((p) => (
-						<PassengerForm key={p.id} passenger={p} onChange={handlePassengerChange(p.id)} />
-					))}
+                                        {passengerData.map((p) => (
+                                                <PassengerForm
+                                                        key={p.id}
+                                                        passenger={p}
+                                                        onChange={handlePassengerChange(p.id)}
+                                                        onValid={handlePassengerValid(p.id)}
+                                                />
+                                        ))}
 					<Box sx={{ p: 2, border: '1px solid #eee', borderRadius: 2, mb: 2 }}>
-						<Typography variant='h6' sx={{ mb: 2 }}>
-							{UI_LABELS.BOOKING.buyer_form.title}
-						</Typography>
-						<Grid container spacing={2}>
-							{Object.values(buyerFormFields).map((field) => (
-								<Grid item xs={12} sm={6} key={field.name}>
-									{field.renderField({
-										value: buyer[field.name],
-										onChange: (value) => handleBuyerChange(field.name, value),
-										fullWidth: true,
-										error: !!buyerErrors[field.name],
-										helperText: buyerErrors[field.name],
-									})}
-								</Grid>
-							))}
+                                                <Typography variant='h6' sx={{ mb: 1 }}>
+                                                        {UI_LABELS.BOOKING.buyer_form.title}
+                                                </Typography>
+                                                <Box sx={{ mb: 2, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                                                        {passengerData.map((p) => (
+                                                                <Chip
+                                                                        key={p.id}
+                                                                        label={`${p.lastName || ''} ${p.firstName || ''}`}
+                                                                        size='small'
+                                                                        onClick={() =>
+                                                                                setBuyer((prev) => ({
+                                                                                        ...prev,
+                                                                                        lastName: p.lastName || '',
+                                                                                        firstName: p.firstName || '',
+                                                                                }))
+                                                                        }
+                                                                />
+                                                        ))}
+                                                </Box>
+                                                <Grid container spacing={2}>
+                                                        {Object.values(buyerFormFields).map((field) => (
+                                                                <Grid item xs={12} sm={6} key={field.name}>
+                                                                        {field.renderField({
+                                                                                value: buyer[field.name],
+                                                                                onChange: (value) => handleBuyerChange(field.name, value),
+                                                                                fullWidth: true,
+                                                                                size: 'small',
+                                                                                error: !!buyerErrors[field.name],
+                                                                                helperText: buyerErrors[field.name],
+                                                                        })}
+                                                                </Grid>
+                                                        ))}
 						</Grid>
 					</Box>
 				</Grid>

--- a/client/src/components/utils/businessLogic.js
+++ b/client/src/components/utils/businessLogic.js
@@ -78,26 +78,38 @@ export const getExistingPassenger = (passengers, passengerData) => {
 };
 
 export const isDuplicateInBooking = (
-	allBookingPassengers,
-	passengers,
-	bookingId,
-	firstName,
-	lastName,
-	birthDate,
-	ignoreId = null
+        allBookingPassengers,
+        passengers,
+        bookingId,
+        firstName,
+        lastName,
+        birthDate,
+        ignoreId = null
 ) => {
 	const bookingPassengers = allBookingPassengers.filter((bp) => {
 		if (bp.booking_id !== bookingId || bp.id === ignoreId) return false;
 		return true;
 	});
 
-	return bookingPassengers.some((bp) => {
-		const passenger = passengers.find((pass) => pass.id === bp.passenger_id);
-		return (
-			passenger &&
-			passenger.first_name === firstName &&
-			passenger.last_name === lastName &&
-			passenger.birth_date === formatDate(birthDate, DATE_API_FORMAT)
-		);
-	});
+        return bookingPassengers.some((bp) => {
+                const passenger = passengers.find((pass) => pass.id === bp.passenger_id);
+                return (
+                        passenger &&
+                        passenger.first_name === firstName &&
+                        passenger.last_name === lastName &&
+                        passenger.birth_date === formatDate(birthDate, DATE_API_FORMAT)
+                );
+        });
+};
+
+export const isCyrillicDocument = (documentType) => {
+        return ['passport', 'birth_certificate'].includes(documentType);
+};
+
+export const getDocumentFieldConfig = (documentType) => {
+        const isForeign = ['international_passport', 'foreign_passport'].includes(documentType);
+        return {
+                showExpiryDate: isForeign,
+                showCitizenship: isForeign,
+        };
 };

--- a/client/src/components/utils/formField.js
+++ b/client/src/components/utils/formField.js
@@ -44,89 +44,93 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 		const allProps = { ...defaultProps, ...props };
 
 		switch (type) {
-			case FIELD_TYPES.EMAIL: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx } = allProps;
-				return (
-					<TextField
-						label={field.label}
-						value={value}
-						onChange={(e) => onChange(e.target.value)}
-						fullWidth={fullWidth}
-						error={error}
-						helperText={error ? helperText : ''}
-						inputProps={{
-							placeholder: DEFAULT_EMAIL,
-							type: 'email',
-							autoComplete: 'email',
-							...field.inputProps,
-							...inputProps,
-						}}
-						sx={{ ...sx }}
-					/>
-				);
-			}
+                        case FIELD_TYPES.EMAIL: {
+                                const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+                                return (
+                                        <TextField
+                                                label={field.label}
+                                                value={value}
+                                                onChange={(e) => onChange(e.target.value)}
+                                                fullWidth={fullWidth}
+                                                error={error}
+                                                helperText={error ? helperText : ''}
+                                                inputProps={{
+                                                        placeholder: DEFAULT_EMAIL,
+                                                        type: 'email',
+                                                        autoComplete: 'email',
+                                                        ...field.inputProps,
+                                                        ...inputProps,
+                                                }}
+                                                size={size}
+                                                sx={{ ...sx }}
+                                        />
+                                );
+                        }
 
-			case FIELD_TYPES.PHONE: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx } = allProps;
-				return (
-					<TextField
-						label={field.label}
-						value={value}
-						onChange={(e) => onChange(e.target.value)}
-						fullWidth={fullWidth}
-						error={error}
-						helperText={error ? helperText : ''}
-						inputProps={{
-							placeholder: DEFAULT_PHONE_NUMBER,
-							type: 'tel',
-							autoComplete: 'tel',
-							...field.inputProps,
-							...inputProps,
-						}}
-						sx={{ ...sx }}
-					/>
-				);
-			}
+                        case FIELD_TYPES.PHONE: {
+                                const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+                                return (
+                                        <TextField
+                                                label={field.label}
+                                                value={value}
+                                                onChange={(e) => onChange(e.target.value)}
+                                                fullWidth={fullWidth}
+                                                error={error}
+                                                helperText={error ? helperText : ''}
+                                                inputProps={{
+                                                        placeholder: DEFAULT_PHONE_NUMBER,
+                                                        type: 'tel',
+                                                        autoComplete: 'tel',
+                                                        ...field.inputProps,
+                                                        ...inputProps,
+                                                }}
+                                                size={size}
+                                                sx={{ ...sx }}
+                                        />
+                                );
+                        }
 
-			case FIELD_TYPES.TEXT: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx } = allProps;
-				return (
-					<TextField
-						label={field.label}
-						value={value}
-						onChange={(e) => onChange(e.target.value)}
-						fullWidth={fullWidth}
-						error={error}
-						helperText={error ? helperText : ''}
-						inputProps={{ ...field.inputProps, ...inputProps }}
-						sx={{ ...sx }}
-					/>
-				);
-			}
+                        case FIELD_TYPES.TEXT: {
+                                const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+                                return (
+                                        <TextField
+                                                label={field.label}
+                                                value={value}
+                                                onChange={(e) => onChange(e.target.value)}
+                                                fullWidth={fullWidth}
+                                                error={error}
+                                                helperText={error ? helperText : ''}
+                                                inputProps={{ ...field.inputProps, ...inputProps }}
+                                                size={size}
+                                                sx={{ ...sx }}
+                                        />
+                                );
+                        }
 
-			case FIELD_TYPES.TEXT_AREA: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx } = allProps;
-				return (
-					<TextField
-						label={field.label}
-						value={value}
-						onChange={(e) => onChange(e.target.value)}
-						fullWidth={fullWidth}
-						error={error}
-						helperText={error ? helperText : ''}
-						multiline
-						rows={field.rows || 5}
-						inputProps={{ ...field.inputProps, ...inputProps }}
-						sx={{
-							'& .MuiInputBase-root': { padding: '4px' },
-							...sx,
-						}}
-					/>
-				);
-			}
+                        case FIELD_TYPES.TEXT_AREA: {
+                                const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+                                return (
+                                        <TextField
+                                                label={field.label}
+                                                value={value}
+                                                onChange={(e) => onChange(e.target.value)}
+                                                fullWidth={fullWidth}
+                                                error={error}
+                                                helperText={error ? helperText : ''}
+                                                multiline
+                                                rows={field.rows || 5}
+                                                inputProps={{ ...field.inputProps, ...inputProps }}
+                                                size={size}
+                                                sx={{
+                                                        '& .MuiInputBase-root': { padding: '4px' },
+                                                        ...sx,
+                                                }}
+                                        />
+                                );
+                        }
 
-			case FIELD_TYPES.NUMBER: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx } = allProps;
+                        case FIELD_TYPES.NUMBER: {
+                                const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
 
 				const step = field.inputProps?.step ?? (field.float ? 0.01 : 1);
 				const min = field.inputProps?.min ?? 0;
@@ -149,14 +153,15 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 								onChange(rounded);
 							}
 						}}
-						inputProps={{ min, step, ...field.inputProps, ...inputProps }}
-						sx={{ ...sx }}
-					/>
-				);
-			}
+                                                inputProps={{ min, step, ...field.inputProps, ...inputProps }}
+                                                size={size}
+                                                sx={{ ...sx }}
+                                        />
+                                );
+                        }
 
-			case FIELD_TYPES.DATE: {
-				const { value, onChange, fullWidth, error, helperText, sx, minDate, textFieldProps } = allProps;
+                        case FIELD_TYPES.DATE: {
+                                const { value, onChange, fullWidth, error, helperText, sx, minDate, textFieldProps, size } = allProps;
 				return (
 					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
 						<DatePicker
@@ -170,17 +175,18 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 									fullWidth,
 									error,
 									helperText: error ? helperText : '',
-									sx,
-									...textFieldProps,
-								},
-							}}
-						/>
-					</LocalizationProvider>
-				);
-			}
+                                                                        sx,
+                                                                        size,
+                                                                        ...textFieldProps,
+                                                                },
+                                                        }}
+                                                />
+                                        </LocalizationProvider>
+                                );
+                        }
 
-			case FIELD_TYPES.TIME: {
-				const { value, onChange, fullWidth, error, helperText, sx, textFieldProps } = allProps;
+                        case FIELD_TYPES.TIME: {
+                                const { value, onChange, fullWidth, error, helperText, sx, textFieldProps, size } = allProps;
 
 				return (
 					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
@@ -196,17 +202,18 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 									fullWidth,
 									error,
 									helperText: error ? helperText : '',
-									sx,
-									...textFieldProps,
-								},
-							}}
-						/>
-					</LocalizationProvider>
-				);
-			}
+                                                                        sx,
+                                                                        size,
+                                                                        ...textFieldProps,
+                                                                },
+                                                        }}
+                                                />
+                                        </LocalizationProvider>
+                                );
+                        }
 
-			case FIELD_TYPES.DATETIME: {
-				const { value, onChange, fullWidth, error, helperText, sx, textFieldProps } = allProps;
+                        case FIELD_TYPES.DATETIME: {
+                                const { value, onChange, fullWidth, error, helperText, sx, textFieldProps, size } = allProps;
 				return (
 					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
 						<DateTimePicker
@@ -219,29 +226,31 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 									fullWidth,
 									error,
 									helperText: error ? helperText : '',
-									sx,
-									...textFieldProps,
-								},
-							}}
-						/>
-					</LocalizationProvider>
-				);
-			}
+                                                                        sx,
+                                                                        size,
+                                                                        ...textFieldProps,
+                                                                },
+                                                        }}
+                                                />
+                                        </LocalizationProvider>
+                                );
+                        }
 
-			case FIELD_TYPES.SELECT: {
-				const {
-					value = '',
-					onChange,
-					fullWidth,
-					error,
-					helperText,
-					options = field.options || [],
-					MenuProps,
-					MenuItemProps,
-					displayEmpty,
-					simpleSelect,
-					sx,
-				} = allProps;
+                        case FIELD_TYPES.SELECT: {
+                                const {
+                                        value = '',
+                                        onChange,
+                                        fullWidth,
+                                        error,
+                                        helperText,
+                                        options = field.options || [],
+                                        MenuProps,
+                                        MenuItemProps,
+                                        displayEmpty,
+                                        simpleSelect,
+                                        sx,
+                                        size,
+                                } = allProps;
 
 				const resolvedValue = value !== undefined && value !== null ? value : field.defaultValue;
 				const isValidValue = options.some((o) => o.value === resolvedValue);
@@ -266,24 +275,26 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 									label={field.label}
 									error={error}
 									helperText={error ? helperText : ''}
-									fullWidth={fullWidth}
-									sx={{ ...sx }}
-								/>
-							)}
-						/>
-					);
-				}
+                                                                        fullWidth={fullWidth}
+                                                                        size={size}
+                                                                        sx={{ ...sx }}
+                                                                />
+                                                        )}
+                                                />
+                                        );
+                                }
 
 				if (simpleSelect) {
 					return (
-						<Select
-							value={safeValue}
-							onChange={(e) => onChange(e.target.value)}
-							fullWidth={fullWidth}
-							MenuProps={MenuProps}
-							displayEmpty={displayEmpty}
-							sx={{ ...sx }}
-						>
+                                                <Select
+                                                        value={safeValue}
+                                                        onChange={(e) => onChange(e.target.value)}
+                                                        fullWidth={fullWidth}
+                                                        MenuProps={MenuProps}
+                                                        displayEmpty={displayEmpty}
+                                                        size={size}
+                                                        sx={{ ...sx }}
+                                                >
 							{options.map((option) => (
 								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
 									{option.label}
@@ -293,17 +304,18 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 					);
 				}
 
-				return (
-					<FormControl fullWidth={fullWidth} error={!!error}>
-						<InputLabel>{field.label}</InputLabel>
-						<Select
-							value={safeValue}
-							onChange={(e) => onChange(e.target.value)}
-							label={field.label}
-							MenuProps={MenuProps}
-							displayEmpty={displayEmpty}
-							sx={{ ...sx }}
-						>
+                                return (
+                                        <FormControl fullWidth={fullWidth} error={!!error} size={size}>
+                                                <InputLabel>{field.label}</InputLabel>
+                                                <Select
+                                                        value={safeValue}
+                                                        onChange={(e) => onChange(e.target.value)}
+                                                        label={field.label}
+                                                        MenuProps={MenuProps}
+                                                        displayEmpty={displayEmpty}
+                                                        size={size}
+                                                        sx={{ ...sx }}
+                                                >
 							{options.map((option) => (
 								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
 									{option.label}
@@ -332,18 +344,19 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				return (customProps) => field.renderField({ ...allProps, ...customProps });
 
 			default: {
-				const { value = '', onChange, fullWidth, inputProps, sx } = allProps;
+                                const { value = '', onChange, fullWidth, inputProps, sx, size } = allProps;
 				return (
 					<TextField
 						label={field.label}
 						value={value}
 						onChange={(e) => onChange(e.target.value)}
 						fullWidth={fullWidth}
-						inputProps={{ ...field.inputProps, ...inputProps }}
-						sx={{ ...sx }}
-					/>
-				);
-			}
+                                                inputProps={{ ...field.inputProps, ...inputProps }}
+                                                size={size}
+                                                sx={{ ...sx }}
+                                        />
+                                );
+                        }
 		}
 	};
 };

--- a/client/src/components/utils/validation.js
+++ b/client/src/components/utils/validation.js
@@ -41,8 +41,18 @@ export const validateEmail = (value) => {
 };
 
 export const validatePhoneNumber = (value) => {
-	// E.164 format: +1234567890
-	if (!value) return false;
-	const phoneRegex = /^\+[1-9]\d{9,14}$/;
-	return phoneRegex.test(value);
+        // E.164 format: +1234567890
+        if (!value) return false;
+        const phoneRegex = /^\+[1-9]\d{9,14}$/;
+        return phoneRegex.test(value);
+};
+
+export const isCyrillicText = (value) => {
+        if (!value) return false;
+        return /^[А-ЯЁа-яё\s-]+$/.test(value);
+};
+
+export const isLatinText = (value) => {
+        if (!value) return false;
+        return /^[A-Za-z\s-]+$/.test(value);
 };

--- a/client/src/constants/validationMessages.js
+++ b/client/src/constants/validationMessages.js
@@ -78,13 +78,13 @@ export const VALIDATION_MESSAGES = {
 		},
 	},
 
-	PASSENGER: {
-		first_name: {
-			REQUIRED: 'Имя обязательно',
-		},
-		last_name: {
-			REQUIRED: 'Фамилия обязательна',
-		},
+        PASSENGER: {
+                first_name: {
+                        REQUIRED: 'Имя обязательно',
+                },
+                last_name: {
+                        REQUIRED: 'Фамилия обязательна',
+                },
 		birth_date: {
 			REQUIRED: 'Укажите дату рождения',
 			ADULT: 'Пассажир должен быть старше 12 лет',
@@ -94,10 +94,14 @@ export const VALIDATION_MESSAGES = {
 		document_type: {
 			REQUIRED: 'Тип документа обязателен',
 		},
-		document_number: {
-			REQUIRED: 'Номер документа обязателен',
-		},
-	},
+                document_number: {
+                        REQUIRED: 'Номер документа обязателен',
+                },
+                name_language: {
+                        CYRILLIC: 'Используйте кириллицу',
+                        LATIN: 'Используйте латиницу',
+                },
+        },
 
         BOOKING: {
                 email_address: {

--- a/client/src/redux/actions/bookingProcess.js
+++ b/client/src/redux/actions/bookingProcess.js
@@ -12,13 +12,37 @@ export const processBookingCreate = createAsyncThunk('bookingProcess/create', as
 });
 
 export const processBookingPassengers = createAsyncThunk(
-	'bookingProcess/passengers',
-	async (data, { rejectWithValue }) => {
-		try {
-			const res = await serverApi.post('/bookings/process/passengers', data);
-			return res.data;
-		} catch (err) {
-			return rejectWithValue(getErrorData(err));
-		}
-	}
+        'bookingProcess/passengers',
+        async (data, { rejectWithValue }) => {
+                try {
+                        const res = await serverApi.post('/bookings/process/passengers', data);
+                        return res.data;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
+);
+
+export const fetchBookingPassengers = createAsyncThunk(
+        'bookingProcess/fetchPassengers',
+        async (publicId, { rejectWithValue }) => {
+                try {
+                        const res = await serverApi.get(`/bookings/${publicId}/passengers`);
+                        return res.data;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
+);
+
+export const saveBookingPassenger = createAsyncThunk(
+        'bookingProcess/savePassenger',
+        async ({ public_id, passenger }, { rejectWithValue }) => {
+                try {
+                        const res = await serverApi.post(`/bookings/${public_id}/passengers`, { passenger });
+                        return res.data;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
 );

--- a/client/src/redux/reducers/bookingProcess.js
+++ b/client/src/redux/reducers/bookingProcess.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { processBookingCreate, processBookingPassengers } from '../actions/bookingProcess';
+import { processBookingCreate, processBookingPassengers, fetchBookingPassengers, saveBookingPassenger } from '../actions/bookingProcess';
 import { handlePending, handleRejected } from '../utils';
 
 const initialState = {
@@ -23,8 +23,26 @@ const bookingProcessSlice = createSlice({
                         .addCase(processBookingPassengers.pending, handlePending)
                         .addCase(processBookingPassengers.rejected, handleRejected)
                         .addCase(processBookingPassengers.fulfilled, (state, action) => {
-                                const { passengers, buyer } = action.meta.arg || {};
-                                state.current = { ...state.current, passengers, buyer };
+                                const { buyer } = action.meta.arg || {};
+                                state.current = { ...state.current, buyer };
+                                state.isLoading = false;
+                        })
+                        .addCase(fetchBookingPassengers.pending, handlePending)
+                        .addCase(fetchBookingPassengers.rejected, handleRejected)
+                        .addCase(fetchBookingPassengers.fulfilled, (state, action) => {
+                                state.current = { ...state.current, passengers: action.payload };
+                                state.isLoading = false;
+                        })
+                        .addCase(saveBookingPassenger.pending, handlePending)
+                        .addCase(saveBookingPassenger.rejected, handleRejected)
+                        .addCase(saveBookingPassenger.fulfilled, (state, action) => {
+                                const p = action.payload;
+                                if (state.current) {
+                                        const list = state.current.passengers || [];
+                                        const idx = list.findIndex((x) => x.id === p.id);
+                                        if (idx >= 0) list[idx] = p; else list.push(p);
+                                        state.current.passengers = list;
+                                }
                                 state.isLoading = false;
                         });
         },

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -179,6 +179,8 @@ def __create_app(_config_class, _db):
     app.route('/bookings/process/create', methods=['POST'])(process_booking_create)
     app.route('/bookings/process/passengers', methods=['POST'])(process_booking_passengers)
     app.route('/bookings/process/payment', methods=['POST'])(process_booking_payment)
+    app.route('/bookings/<public_id>/passengers', methods=['GET'])(get_booking_passengers)
+    app.route('/bookings/<public_id>/passengers', methods=['POST'])(save_booking_passenger)
 
     # booking passengers
     app.route('/booking_passengers', methods=['GET'])(get_booking_passengers)

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -1,6 +1,9 @@
 from flask import request, jsonify
+from uuid import UUID
 
 from app.models.booking import Booking
+from app.models.passenger import Passenger
+from app.models.booking_passenger import BookingPassenger
 from app.middlewares.auth_middleware import admin_required
 from app.utils.business_logic import process_booking_create as process_booking_create_logic
 
@@ -49,4 +52,31 @@ def process_booking_passengers():
 
 def process_booking_payment():
     return jsonify({'status': 'ok'}), 200
+
+
+def get_booking_passengers(public_id):
+    booking = Booking.query.filter_by(public_id=UUID(public_id)).first_or_404()
+    passengers = [bp.passenger.to_dict() for bp in booking.booking_passengers]
+    counts = booking.passenger_counts or {}
+    categories = []
+    for key, count in counts.items():
+        categories.extend([key] * count)
+    for idx, category in enumerate(categories):
+        if idx < len(passengers):
+            passengers[idx]['category'] = category
+        else:
+            passengers.append({'category': category})
+    return jsonify(passengers), 200
+
+
+def save_booking_passenger(public_id):
+    booking = Booking.query.filter_by(public_id=UUID(public_id)).first_or_404()
+    data = request.json.get('passenger', {})
+    passenger_id = data.get('id')
+    if passenger_id:
+        passenger = Passenger.update(passenger_id, **data)
+    else:
+        passenger = Passenger.create(**data)
+        BookingPassenger.create(booking_id=booking.id, passenger_id=passenger.id, is_contact=data.get('is_contact', False))
+    return jsonify(passenger.to_dict()), 201
 

--- a/server/app/models/booking.py
+++ b/server/app/models/booking.py
@@ -37,6 +37,7 @@ class Booking(BaseModel):
     fees = db.Column(db.Float, nullable=False, default=0.0)
     total_discounts = db.Column(db.Float, nullable=False, default=0.0)
     total_price = db.Column(db.Float, nullable=False)
+    passenger_counts = db.Column(JSONB, nullable=False, server_default='{}', default=dict)
 
     # Relationships
     payments: Mapped[List['Payment']] = db.relationship(
@@ -66,6 +67,7 @@ class Booking(BaseModel):
             'total_discounts': self.total_discounts,
             'fees': self.fees,
             'total_price': self.total_price,
+            'passenger_counts': self.passenger_counts,
         }
 
     @classmethod

--- a/server/app/utils/business_logic.py
+++ b/server/app/utils/business_logic.py
@@ -143,6 +143,8 @@ def process_booking_create(data):
         'at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
     }]
 
+    passenger_counts = {k: v for k, v in passengers.items() if v}
+
     booking = Booking.create(
         currency=Config.CURRENCY[price['currency']],
         fare_price=price['fare_price'],
@@ -150,6 +152,7 @@ def process_booking_create(data):
         total_discounts=price['total_discounts'],
         total_price=price['total_price'],
         status_history=history,
+        passenger_counts=passenger_counts,
     )
 
     db.session.refresh(booking)

--- a/server/migrations/versions/1b2b3c4d5e67_passenger_counts.py
+++ b/server/migrations/versions/1b2b3c4d5e67_passenger_counts.py
@@ -1,0 +1,24 @@
+"""Add passenger_counts to bookings
+
+Revision ID: 1b2b3c4d5e67
+Revises: 0ade5bdb146c
+Create Date: 2025-08-10 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '1b2b3c4d5e67'
+down_revision = '0ade5bdb146c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('bookings', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('passenger_counts', postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default='{}'))
+
+
+def downgrade():
+    with op.batch_alter_table('bookings', schema=None) as batch_op:
+        batch_op.drop_column('passenger_counts')


### PR DESCRIPTION
## Summary
- fetch countries for citizenship selector and default select options
- store passenger counts in bookings with endpoints to fetch/save passengers
- auto-save passenger form data when valid during booking

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `pytest` *(fails: CompileError in bookings column status)*

------
https://chatgpt.com/codex/tasks/task_e_6897203fd670832f9b7ac4ae2f274623