### PR TITLE
Add booking confirmation and payment pages

### DIFF
--- a/client/src/components/booking/Confirmation.js
+++ b/client/src/components/booking/Confirmation.js
@@ -1,12 +1,145 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+    Box,
+    Card,
+    CardContent,
+    Typography,
+    Button,
+    Divider,
+    Table,
+    TableBody,
+    TableRow,
+    TableCell,
+} from '@mui/material';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
-import { UI_LABELS } from '../../constants';
+import { fetchBookingDetails } from '../../redux/actions/bookingProcess';
+import { ENUM_LABELS, UI_LABELS } from '../../constants';
+import { formatNumber } from '../utils';
+import { serverApi } from '../../api';
 
-const Confirmation = () => (
-	<Base maxWidth='lg'>
-		<BookingProgress activeStep='confirmation' />
-		<div>{UI_LABELS.BOOKING.step_placeholders.confirmation}</div>
-	</Base>
-);
+const Confirmation = () => {
+    const { publicId } = useParams();
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const booking = useSelector((state) => state.bookingProcess.current);
+    const [directionsInfo, setDirectionsInfo] = useState({});
+
+    useEffect(() => {
+        dispatch(fetchBookingDetails(publicId));
+    }, [dispatch, publicId]);
+
+    useEffect(() => {
+        const loadInfo = async () => {
+            if (!booking?.directions) return;
+            const info = {};
+            await Promise.all(
+                booking.directions.map(async (d) => {
+                    try {
+                        const flight = (await serverApi.get(`/flights/${d.flight_id}`)).data;
+                        const route = (await serverApi.get(`/routes/${flight.route_id}`)).data;
+                        const origin = (await serverApi.get(`/airports/${route.origin_airport_id}`)).data;
+                        const dest = (await serverApi.get(`/airports/${route.destination_airport_id}`)).data;
+                        info[d.direction] = {
+                            from: origin.city || origin.iata_code,
+                            to: dest.city || dest.iata_code,
+                        };
+                    } catch (e) {
+                        // ignore fetching errors
+                    }
+                })
+            );
+            setDirectionsInfo(info);
+        };
+        loadInfo();
+    }, [booking]);
+
+    const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
+
+    const handlePayment = () => {
+        navigate(`/booking/${publicId}/payment`);
+    };
+
+    return (
+        <Base maxWidth='lg'>
+            <BookingProgress activeStep='confirmation' />
+            <Box sx={{ mt: 2 }}>
+                {booking?.directions?.map((dir) => {
+                    const info = directionsInfo[dir.direction] || {};
+                    return (
+                        <Card key={dir.direction} sx={{ mb: 2 }}>
+                            <CardContent>
+                                <Typography variant='h6' sx={{ mb: 1 }}>
+                                    {UI_LABELS.SCHEDULE.from_to(info.from, info.to) || dir.direction}
+                                </Typography>
+                                <Table size='small'>
+                                    <TableBody>
+                                        {dir.passengers.map((p) => (
+                                            <TableRow key={p.category}>
+                                                <TableCell>{`${ENUM_LABELS.PASSENGER_CATEGORY[p.category] || p.category} x${p.count}`}</TableCell>
+                                                <TableCell align='right'>{`${formatNumber(p.fare_price)} ${currencySymbol}`}</TableCell>
+                                                {p.discount > 0 && (
+                                                    <TableCell align='right'>{`- ${formatNumber(p.discount)} ${currencySymbol}`}</TableCell>
+                                                )}
+                                                <TableCell align='right'>{`${formatNumber(p.total_price)} ${currencySymbol}`}</TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
+
+                {booking?.fees && booking.fees.length > 0 && (
+                    <Card sx={{ mb: 2 }}>
+                        <CardContent>
+                            {booking.fees.map((f) => (
+                                <Box key={f.name} sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                                    <Typography>{f.name}</Typography>
+                                    <Typography>{`${formatNumber(f.total)} ${currencySymbol}`}</Typography>
+                                </Box>
+                            ))}
+                        </CardContent>
+                    </Card>
+                )}
+
+                <Card sx={{ mb: 2 }}>
+                    <CardContent>
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                            <Typography>{UI_LABELS.BOOKING.buyer_form.summary.tickets}</Typography>
+                            <Typography>{`${formatNumber(booking?.fare_price || 0)} ${currencySymbol}`}</Typography>
+                        </Box>
+                        {booking?.total_discounts > 0 && (
+                            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                                <Typography>{UI_LABELS.BOOKING.buyer_form.summary.discount}</Typography>
+                                <Typography>{`- ${formatNumber(booking.total_discounts)} ${currencySymbol}`}</Typography>
+                            </Box>
+                        )}
+                        {booking?.fees > 0 && (
+                            <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                                <Typography>{UI_LABELS.BOOKING.buyer_form.summary.service_fee}</Typography>
+                                <Typography>{`${formatNumber(booking.fees)} ${currencySymbol}`}</Typography>
+                            </Box>
+                        )}
+                        <Divider sx={{ my: 1 }} />
+                        <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                            <Typography variant='h6'>
+                                {UI_LABELS.BOOKING.buyer_form.summary.total}
+                            </Typography>
+                            <Typography variant='h6'>{`${formatNumber(booking?.total_price || 0)} ${currencySymbol}`}</Typography>
+                        </Box>
+                    </CardContent>
+                </Card>
+
+                <Button variant='contained' color='orange' onClick={handlePayment}>
+                    Перейти к оплате
+                </Button>
+            </Box>
+        </Base>
+    );
+};
 
 export default Confirmation;

--- a/client/src/components/booking/Payment.js
+++ b/client/src/components/booking/Payment.js
@@ -1,12 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { Box, Card, CardContent, Typography, Button } from '@mui/material';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
-import { UI_LABELS } from '../../constants';
+import { fetchBookingDetails } from '../../redux/actions/bookingProcess';
+import { ENUM_LABELS, UI_LABELS } from '../../constants';
+import { formatNumber } from '../utils';
+import { serverApi } from '../../api';
 
-const Payment = () => (
-    <Base maxWidth='lg'>
-        <BookingProgress activeStep='payment' />
-        <div>{UI_LABELS.BOOKING.step_placeholders.payment}</div>
-    </Base>
-);
+const Payment = () => {
+    const { publicId } = useParams();
+    const dispatch = useDispatch();
+    const booking = useSelector((state) => state.bookingProcess.current);
+    const [routeInfo, setRouteInfo] = useState(null);
+
+    useEffect(() => {
+        dispatch(fetchBookingDetails(publicId));
+    }, [dispatch, publicId]);
+
+    useEffect(() => {
+        const loadRoute = async () => {
+            if (!booking?.directions || booking.directions.length === 0) return;
+            const d = booking.directions[0];
+            try {
+                const flight = (await serverApi.get(`/flights/${d.flight_id}`)).data;
+                const route = (await serverApi.get(`/routes/${flight.route_id}`)).data;
+                const origin = (await serverApi.get(`/airports/${route.origin_airport_id}`)).data;
+                const dest = (await serverApi.get(`/airports/${route.destination_airport_id}`)).data;
+                setRouteInfo(UI_LABELS.SCHEDULE.from_to(origin.city || origin.iata_code, dest.city || dest.iata_code));
+            } catch (e) {
+                setRouteInfo(null);
+            }
+        };
+        loadRoute();
+    }, [booking]);
+
+    const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
+
+    return (
+        <Base maxWidth='lg'>
+            <BookingProgress activeStep='payment' />
+            <Box sx={{ mt: 2 }}>
+                <Card>
+                    <CardContent>
+                        {routeInfo && (
+                            <Typography variant='h6' sx={{ mb: 2 }}>
+                                {routeInfo}
+                            </Typography>
+                        )}
+                        <Typography variant='body1' sx={{ mb: 2 }}>
+                            {UI_LABELS.BOOKING.buyer_form.summary.total}: {formatNumber(booking?.total_price || 0)} {currencySymbol}
+                        </Typography>
+                        <Button
+                            variant='contained'
+                            color='orange'
+                            href='https://yoomoney.ru/'
+                            target='_blank'
+                        >
+                            Оплатить через YooMoney
+                        </Button>
+                    </CardContent>
+                </Card>
+            </Box>
+        </Base>
+    );
+};
 
 export default Payment;

--- a/client/src/redux/actions/bookingProcess.js
+++ b/client/src/redux/actions/bookingProcess.js
@@ -2,14 +2,17 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { serverApi } from '../../api';
 import { getErrorData } from '../utils';
 
-export const processBookingCreate = createAsyncThunk('bookingProcess/create', async (data, { rejectWithValue }) => {
-	try {
-		const res = await serverApi.post('/bookings/process/create', data);
-		return res.data;
-	} catch (err) {
-		return rejectWithValue(getErrorData(err));
-	}
-});
+export const processBookingCreate = createAsyncThunk(
+        'bookingProcess/create',
+        async (data, { rejectWithValue }) => {
+                try {
+                        const res = await serverApi.post('/bookings/process/create', data);
+                        return { ...data, ...res.data };
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
+);
 
 export const processBookingPassengers = createAsyncThunk(
         'bookingProcess/passengers',
@@ -40,6 +43,18 @@ export const saveBookingPassenger = createAsyncThunk(
         async ({ public_id, passenger }, { rejectWithValue }) => {
                 try {
                         const res = await serverApi.post(`/bookings/${public_id}/passengers`, { passenger });
+                        return res.data;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
+);
+
+export const fetchBookingDetails = createAsyncThunk(
+        'bookingProcess/fetchDetails',
+        async (publicId, { rejectWithValue }) => {
+                try {
+                        const res = await serverApi.get(`/bookings/${publicId}/details`);
                         return res.data;
                 } catch (err) {
                         return rejectWithValue(getErrorData(err));

--- a/client/src/redux/reducers/bookingProcess.js
+++ b/client/src/redux/reducers/bookingProcess.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { processBookingCreate, processBookingPassengers, fetchBookingPassengers, saveBookingPassenger } from '../actions/bookingProcess';
+import { processBookingCreate, processBookingPassengers, fetchBookingPassengers, saveBookingPassenger, fetchBookingDetails } from '../actions/bookingProcess';
 import { handlePending, handleRejected } from '../utils';
 
 const initialState = {
@@ -14,12 +14,12 @@ const bookingProcessSlice = createSlice({
 	reducers: {},
 	extraReducers: (builder) => {
 		builder
-			.addCase(processBookingCreate.pending, handlePending)
-			.addCase(processBookingCreate.rejected, handleRejected)
-			.addCase(processBookingCreate.fulfilled, (state, action) => {
-				state.current = action.payload;
-				state.isLoading = false;
-			})
+                        .addCase(processBookingCreate.pending, handlePending)
+                        .addCase(processBookingCreate.rejected, handleRejected)
+                        .addCase(processBookingCreate.fulfilled, (state, action) => {
+                                state.current = action.payload;
+                                state.isLoading = false;
+                        })
                         .addCase(processBookingPassengers.pending, handlePending)
                         .addCase(processBookingPassengers.rejected, handleRejected)
                         .addCase(processBookingPassengers.fulfilled, (state, action) => {
@@ -31,6 +31,12 @@ const bookingProcessSlice = createSlice({
                         .addCase(fetchBookingPassengers.rejected, handleRejected)
                         .addCase(fetchBookingPassengers.fulfilled, (state, action) => {
                                 state.current = { ...state.current, passengers: action.payload };
+                                state.isLoading = false;
+                        })
+                        .addCase(fetchBookingDetails.pending, handlePending)
+                        .addCase(fetchBookingDetails.rejected, handleRejected)
+                        .addCase(fetchBookingDetails.fulfilled, (state, action) => {
+                                state.current = { ...state.current, ...action.payload };
                                 state.isLoading = false;
                         })
                         .addCase(saveBookingPassenger.pending, handlePending)

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -179,6 +179,7 @@ def __create_app(_config_class, _db):
     app.route('/bookings/process/create', methods=['POST'])(process_booking_create)
     app.route('/bookings/process/passengers', methods=['POST'])(process_booking_passengers)
     app.route('/bookings/process/payment', methods=['POST'])(process_booking_payment)
+    app.route('/bookings/<public_id>/details', methods=['GET'])(get_booking_details)
     app.route('/bookings/<public_id>/passengers', methods=['GET'])(get_booking_passengers)
     app.route('/bookings/<public_id>/passengers', methods=['POST'])(save_booking_passenger)
 

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -1,6 +1,7 @@
 from flask import request, jsonify
 from uuid import UUID
 
+from app.database import db
 from app.models.booking import Booking
 from app.models.passenger import Passenger
 from app.models.booking_passenger import BookingPassenger
@@ -42,11 +43,26 @@ def delete_booking(current_user, booking_id):
 
 def process_booking_create():
     data = request.json or {}
-    booking = process_booking_create_logic(data)
-    return jsonify({'public_id': str(booking.public_id)}), 201
+    booking, price = process_booking_create_logic(data)
+    result = {'public_id': str(booking.public_id)}
+    result.update(price)
+    return jsonify(result), 201
 
 
 def process_booking_passengers():
+    data = request.json or {}
+    public_id = data.get('public_id')
+    buyer = data.get('buyer', {})
+    if not public_id:
+        return jsonify({'message': 'public_id_required'}), 400
+    booking = Booking.query.filter_by(public_id=UUID(public_id)).first_or_404()
+    booking.email_address = buyer.get('email')
+    booking.phone_number = buyer.get('phone')
+    try:
+        booking.transition_status('passengers_added')
+    except ValueError:
+        pass
+    db.session.commit()
     return jsonify({'status': 'ok'}), 200
 
 
@@ -79,4 +95,21 @@ def save_booking_passenger(public_id):
         passenger = Passenger.create(**data)
         BookingPassenger.create(booking_id=booking.id, passenger_id=passenger.id, is_contact=data.get('is_contact', False))
     return jsonify(passenger.to_dict()), 201
+
+
+def get_booking_details(public_id):
+    booking = Booking.query.filter_by(public_id=UUID(public_id)).first_or_404()
+    result = booking.to_dict()
+    passengers = [bp.passenger.to_dict() for bp in booking.booking_passengers]
+    counts = booking.passenger_counts or {}
+    categories = []
+    for key, count in counts.items():
+        categories.extend([key] * count)
+    for idx, category in enumerate(categories):
+        if idx < len(passengers):
+            passengers[idx]['category'] = category
+        else:
+            passengers.append({'category': category})
+    result['passengers'] = passengers
+    return jsonify(result), 200
 

--- a/server/app/utils/business_logic.py
+++ b/server/app/utils/business_logic.py
@@ -156,4 +156,4 @@ def process_booking_create(data):
     )
 
     db.session.refresh(booking)
-    return booking
+    return booking, price


### PR DESCRIPTION
## Summary
- Expand booking creation logic to return detailed price info and store buyer data
- Provide API for booking details and integrate into confirmation and payment steps
- Build confirmation and payment pages with cost breakdown and YooMoney link

## Testing
- `npm test`
- `pytest` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType')*


------
https://chatgpt.com/codex/tasks/task_e_68973919cf34832fba95cbe422f610d8