### PR TITLE
feat: restrict booking step access

### DIFF
--- a/client/src/redux/actions/bookingProcess.js
+++ b/client/src/redux/actions/bookingProcess.js
@@ -61,3 +61,39 @@ export const fetchBookingDetails = createAsyncThunk(
                 }
         }
 );
+
+export const fetchBookingAccess = createAsyncThunk(
+        'bookingProcess/fetchAccess',
+        async (publicId, { rejectWithValue }) => {
+                try {
+                        const res = await serverApi.get(`/bookings/${publicId}/access`);
+                        return res.data;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
+);
+
+export const fetchBookingDirectionsInfo = createAsyncThunk(
+        'bookingProcess/fetchDirectionsInfo',
+        async (directions, { rejectWithValue }) => {
+                try {
+                        const info = {};
+                        await Promise.all(
+                                directions.map(async (d) => {
+                                        const flight = (await serverApi.get(`/flights/${d.flight_id}`)).data;
+                                        const route = (await serverApi.get(`/routes/${flight.route_id}`)).data;
+                                        const origin = (await serverApi.get(`/airports/${route.origin_airport_id}`)).data;
+                                        const dest = (await serverApi.get(`/airports/${route.destination_airport_id}`)).data;
+                                        info[d.direction] = {
+                                                from: origin.city || origin.iata_code,
+                                                to: dest.city || dest.iata_code,
+                                        };
+                                })
+                        );
+                        return info;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
+);

--- a/client/src/redux/reducers/bookingProcess.js
+++ b/client/src/redux/reducers/bookingProcess.js
@@ -1,11 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { processBookingCreate, processBookingPassengers, fetchBookingPassengers, saveBookingPassenger, fetchBookingDetails } from '../actions/bookingProcess';
+import { processBookingCreate, processBookingPassengers, fetchBookingPassengers, saveBookingPassenger, fetchBookingDetails, fetchBookingAccess, fetchBookingDirectionsInfo } from '../actions/bookingProcess';
 import { handlePending, handleRejected } from '../utils';
 
 const initialState = {
-	current: null,
-	isLoading: false,
-	errors: null,
+        current: null,
+        isLoading: false,
+        errors: null,
 };
 
 const bookingProcessSlice = createSlice({
@@ -37,6 +37,18 @@ const bookingProcessSlice = createSlice({
                         .addCase(fetchBookingDetails.rejected, handleRejected)
                         .addCase(fetchBookingDetails.fulfilled, (state, action) => {
                                 state.current = { ...state.current, ...action.payload };
+                                state.isLoading = false;
+                        })
+                        .addCase(fetchBookingAccess.pending, handlePending)
+                        .addCase(fetchBookingAccess.rejected, handleRejected)
+                        .addCase(fetchBookingAccess.fulfilled, (state, action) => {
+                                state.current = { ...(state.current || {}), accessiblePages: action.payload.pages || [] };
+                                state.isLoading = false;
+                        })
+                        .addCase(fetchBookingDirectionsInfo.pending, handlePending)
+                        .addCase(fetchBookingDirectionsInfo.rejected, handleRejected)
+                        .addCase(fetchBookingDirectionsInfo.fulfilled, (state, action) => {
+                                state.current = { ...(state.current || {}), directionsInfo: action.payload };
                                 state.isLoading = false;
                         })
                         .addCase(saveBookingPassenger.pending, handlePending)

--- a/client/src/routes/BookingRoute.js
+++ b/client/src/routes/BookingRoute.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchBookingAccess } from '../redux/actions/bookingProcess';
+
+const BookingRoute = ({ page, children }) => {
+    const { publicId } = useParams();
+    const navigate = useNavigate();
+    const dispatch = useDispatch();
+    const pages = useSelector((state) => state.bookingProcess.current?.accessiblePages);
+    const [checked, setChecked] = useState(false);
+
+    useEffect(() => {
+        dispatch(fetchBookingAccess(publicId)).unwrap().catch(() => {
+            navigate('/', { replace: true });
+            setChecked(true);
+        });
+    }, [dispatch, publicId, navigate]);
+
+    useEffect(() => {
+        if (pages) {
+            if (!pages.includes(page)) {
+                const last = pages[pages.length - 1];
+                if (last) {
+                    navigate(`/booking/${publicId}/${last}`, { replace: true });
+                } else {
+                    navigate('/', { replace: true });
+                }
+            }
+            setChecked(true);
+        }
+    }, [pages, page, navigate, publicId]);
+
+    if (!checked) return null;
+
+    return children;
+};
+
+export default BookingRoute;

--- a/client/src/routes/PublicRoutes.js
+++ b/client/src/routes/PublicRoutes.js
@@ -9,6 +9,7 @@ import Passengers from '../components/booking/Passengers';
 import Confirmation from '../components/booking/Confirmation';
 import Payment from '../components/booking/Payment';
 import Completion from '../components/booking/Completion';
+import BookingRoute from './BookingRoute';
 
 const PublicRoutes = () => [
 	{ path: '/', element: <Home /> },
@@ -19,10 +20,10 @@ const PublicRoutes = () => [
 	{ path: '/search', element: <Search /> },
 	{ path: '/schedule', element: <Schedule /> },
 
-	{ path: '/booking/:publicId/passengers', element: <Passengers /> },
-        { path: '/booking/:publicId/confirmation', element: <Confirmation /> },
-        { path: '/booking/:publicId/payment', element: <Payment /> },
-        { path: '/booking/:publicId/completion', element: <Completion /> }
+        { path: '/booking/:publicId/passengers', element: <BookingRoute page='passengers'><Passengers /></BookingRoute> },
+        { path: '/booking/:publicId/confirmation', element: <BookingRoute page='confirmation'><Confirmation /></BookingRoute> },
+        { path: '/booking/:publicId/payment', element: <BookingRoute page='payment'><Payment /></BookingRoute> },
+        { path: '/booking/:publicId/completion', element: <BookingRoute page='completion'><Completion /></BookingRoute> }
 ];
 
 export default PublicRoutes;

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -180,6 +180,7 @@ def __create_app(_config_class, _db):
     app.route('/bookings/process/passengers', methods=['POST'])(process_booking_passengers)
     app.route('/bookings/process/payment', methods=['POST'])(process_booking_payment)
     app.route('/bookings/<public_id>/details', methods=['GET'])(get_booking_details)
+    app.route('/bookings/<public_id>/access', methods=['GET'])(get_booking_access)
     app.route('/bookings/<public_id>/passengers', methods=['GET'])(get_booking_passengers)
     app.route('/bookings/<public_id>/passengers', methods=['POST'])(save_booking_passenger)
 

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -1,6 +1,4 @@
 from flask import request, jsonify
-from uuid import UUID
-
 from app.database import db
 from app.models.booking import Booking
 from app.models.passenger import Passenger
@@ -55,7 +53,7 @@ def process_booking_passengers():
     buyer = data.get('buyer', {})
     if not public_id:
         return jsonify({'message': 'public_id_required'}), 400
-    booking = Booking.query.filter_by(public_id=UUID(public_id)).first_or_404()
+    booking = Booking.get_by_public_id(public_id)
     booking.email_address = buyer.get('email')
     booking.phone_number = buyer.get('phone')
     try:
@@ -71,7 +69,7 @@ def process_booking_payment():
 
 
 def get_booking_passengers(public_id):
-    booking = Booking.query.filter_by(public_id=UUID(public_id)).first_or_404()
+    booking = Booking.get_by_public_id(public_id)
     passengers = [bp.passenger.to_dict() for bp in booking.booking_passengers]
     counts = booking.passenger_counts or {}
     categories = []
@@ -86,7 +84,7 @@ def get_booking_passengers(public_id):
 
 
 def save_booking_passenger(public_id):
-    booking = Booking.query.filter_by(public_id=UUID(public_id)).first_or_404()
+    booking = Booking.get_by_public_id(public_id)
     data = request.json.get('passenger', {})
     passenger_id = data.get('id')
     if passenger_id:
@@ -98,7 +96,7 @@ def save_booking_passenger(public_id):
 
 
 def get_booking_details(public_id):
-    booking = Booking.query.filter_by(public_id=UUID(public_id)).first_or_404()
+    booking = Booking.get_by_public_id(public_id)
     result = booking.to_dict()
     passengers = [bp.passenger.to_dict() for bp in booking.booking_passengers]
     counts = booking.passenger_counts or {}
@@ -112,4 +110,9 @@ def get_booking_details(public_id):
             passengers.append({'category': category})
     result['passengers'] = passengers
     return jsonify(result), 200
+
+
+def get_booking_access(public_id):
+    booking = Booking.get_by_public_id(public_id)
+    return jsonify({'pages': booking.get_accessible_pages()}), 200
 


### PR DESCRIPTION
## Summary
- remove temporary booking access integration test
- centralize booking lookup by public id in model and use it across controller endpoints
- shift booking access and direction fetching to redux actions and reducers

## Testing
- `cd server && set -a && source ../.example.env && set +a && pytest` *(fails: could not translate host name "postgres" to address: Name or service not known)*
- `cd client && CI=true npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6897513ff338832f8a88779763866202