### PR TITLE
Fix passenger form state and layout

### DIFF
--- a/client/src/redux/reducers/bookingProcess.js
+++ b/client/src/redux/reducers/bookingProcess.js
@@ -47,15 +47,16 @@ const bookingProcessSlice = createSlice({
 			})
 			.addCase(fetchBookingDetails.pending, handlePending)
 			.addCase(fetchBookingDetails.rejected, handleRejected)
-			.addCase(fetchBookingDetails.fulfilled, (state, action) => {
-				const { passengers_exist, ...rest } = action.payload;
-				state.current = {
-					...state.current,
-					...rest,
-					passengersExist: passengers_exist,
-				};
-				state.isLoading = false;
-			})
+                        .addCase(fetchBookingDetails.fulfilled, (state, action) => {
+                                const { passengers_exist, passengers, ...rest } = action.payload;
+                                state.current = {
+                                        ...state.current,
+                                        ...rest,
+                                        passengers,
+                                        passengersExist: passengers_exist,
+                                };
+                                state.isLoading = false;
+                        })
 			.addCase(fetchBookingAccess.pending, handlePending)
 			.addCase(fetchBookingAccess.rejected, handleRejected)
 			.addCase(fetchBookingAccess.fulfilled, (state, action) => {


### PR DESCRIPTION
## Summary
- Load country options once and pass to passenger forms
- Validate passengers only on continue and improve form layout
- Fetch booking details with passenger data and store in reducer

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`
- `SERVER_JWT_EXP_HOURS=1 SERVER_SECRET_KEY=1 SERVER_DATABASE_URI=sqlite:///:memory: pytest` *(fails: RuntimeError: Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set)*

------
https://chatgpt.com/codex/tasks/task_e_689850f98c58832f939a47050c2a27ac