### PR TITLE
Require passenger form fields and map API keys

### DIFF
--- a/client/src/components/booking/PassengerForm.js
+++ b/client/src/components/booking/PassengerForm.js
@@ -43,93 +43,98 @@ const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument, citize
 		setData((prev) => ({ ...prev, ...passenger }));
 	}, [passenger]);
 
-	const formFields = useMemo(() => {
-		const requiresCyrillic = isCyrillicDocument(data.documentType);
-		const { showExpiryDate, showCitizenship } = getDocumentFieldConfig(data.documentType);
+        const requiresCyrillic = isCyrillicDocument(data.documentType);
+        const docConfig = getDocumentFieldConfig(data.documentType);
+        const { showExpiryDate, showCitizenship } = docConfig;
 
-		const fields = {
-			lastName: {
-				key: 'lastName',
-				label: FIELD_LABELS.PASSENGER.last_name,
-				validate: (v) => {
-					if (!v) return VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED;
-					const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
-					return valid
-						? ''
-						: requiresCyrillic
-						? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
-						: VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
-				},
-			},
-			firstName: {
-				key: 'firstName',
-				label: FIELD_LABELS.PASSENGER.first_name,
-				validate: (v) => {
-					if (!v) return VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED;
-					const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
-					return valid
-						? ''
-						: requiresCyrillic
-						? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
-						: VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
-				},
-			},
-			patronymicName: {
-				key: 'patronymicName',
-				label: FIELD_LABELS.PASSENGER.patronymic_name,
-				validate: (v) => {
-					if (!v) return '';
-					const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
-					return valid
-						? ''
-						: requiresCyrillic
-						? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
-						: VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
-				},
-			},
-			gender: {
-				key: 'gender',
-				label: FIELD_LABELS.PASSENGER.gender,
-				type: FIELD_TYPES.SELECT,
-				options: genderOptions,
-			},
-			birthDate: {
-				key: 'birthDate',
-				label: FIELD_LABELS.PASSENGER.birth_date,
-				type: FIELD_TYPES.DATE,
-				validate: (v) => getAgeError(data.type, v),
-			},
-			documentType: {
-				key: 'documentType',
-				label: FIELD_LABELS.PASSENGER.document_type,
-				type: FIELD_TYPES.SELECT,
-				options: docTypeOptions,
-				validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_type.REQUIRED : ''),
-			},
-			documentNumber: {
-				key: 'documentNumber',
-				label: FIELD_LABELS.PASSENGER.document_number,
-				validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_number.REQUIRED : ''),
-			},
-			...(showExpiryDate && {
-				documentExpiryDate: {
-					key: 'documentExpiryDate',
-					label: FIELD_LABELS.PASSENGER.document_expiry_date,
-					type: FIELD_TYPES.DATE,
-				},
-			}),
-			...(showCitizenship && {
-				citizenshipId: {
-					key: 'citizenshipId',
-					label: FIELD_LABELS.PASSENGER.citizenship_id,
-					type: FIELD_TYPES.SELECT,
-					options: citizenshipOptions,
-				},
-			}),
-		};
-		const arr = createFormFields(fields);
-		return arr.reduce((acc, f) => ({ ...acc, [f.name]: f }), {});
-	}, [data.type, data.documentType, citizenshipOptions]);
+        const formFields = useMemo(() => {
+                const fields = {
+                        lastName: {
+                                key: 'lastName',
+                                label: UI_LABELS.BOOKING.passenger_form.last_name(requiresCyrillic),
+                                validate: (v) => {
+                                        if (!v) return VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED;
+                                        const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
+                                        return valid
+                                                ? ''
+                                                : requiresCyrillic
+                                                ? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
+                                                : VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
+                                },
+                        },
+                        firstName: {
+                                key: 'firstName',
+                                label: UI_LABELS.BOOKING.passenger_form.first_name(requiresCyrillic),
+                                validate: (v) => {
+                                        if (!v) return VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED;
+                                        const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
+                                        return valid
+                                                ? ''
+                                                : requiresCyrillic
+                                                ? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
+                                                : VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
+                                },
+                        },
+                        patronymicName: {
+                                key: 'patronymicName',
+                                label: UI_LABELS.BOOKING.passenger_form.patronymic_name(requiresCyrillic),
+                                validate: (v) => {
+                                        if (!v) return '';
+                                        const valid = requiresCyrillic ? isCyrillicText(v) : isLatinText(v);
+                                        return valid
+                                                ? ''
+                                                : requiresCyrillic
+                                                ? VALIDATION_MESSAGES.PASSENGER.name_language.CYRILLIC
+                                                : VALIDATION_MESSAGES.PASSENGER.name_language.LATIN;
+                                },
+                        },
+                        gender: {
+                                key: 'gender',
+                                label: FIELD_LABELS.PASSENGER.gender,
+                                type: FIELD_TYPES.SELECT,
+                                options: genderOptions,
+                        },
+                        birthDate: {
+                                key: 'birthDate',
+                                label: FIELD_LABELS.PASSENGER.birth_date,
+                                type: FIELD_TYPES.DATE,
+                                validate: (v) => getAgeError(data.type, v),
+                        },
+                        documentType: {
+                                key: 'documentType',
+                                label: FIELD_LABELS.PASSENGER.document_type,
+                                type: FIELD_TYPES.SELECT,
+                                options: docTypeOptions,
+                                validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_type.REQUIRED : ''),
+                        },
+                        documentNumber: {
+                                key: 'documentNumber',
+                                label: FIELD_LABELS.PASSENGER.document_number,
+                                validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.document_number.REQUIRED : ''),
+                        },
+                        ...(showExpiryDate && {
+                                documentExpiryDate: {
+                                        key: 'documentExpiryDate',
+                                        label: FIELD_LABELS.PASSENGER.document_expiry_date,
+                                        type: FIELD_TYPES.DATE,
+                                        validate: (v) =>
+                                                !v ? VALIDATION_MESSAGES.PASSENGER.document_expiry_date.REQUIRED : '',
+                                },
+                        }),
+                        ...(showCitizenship && {
+                                citizenshipId: {
+                                        key: 'citizenshipId',
+                                        label: FIELD_LABELS.PASSENGER.citizenship_id,
+                                        type: FIELD_TYPES.SELECT,
+                                        options: citizenshipOptions,
+                                        validate: (v) =>
+                                                !v ? VALIDATION_MESSAGES.PASSENGER.citizenship_id.REQUIRED : '',
+                                },
+                        }),
+                };
+                const arr = createFormFields(fields);
+                return arr.reduce((acc, f) => ({ ...acc, [f.name]: f }), {});
+        }, [data.type, requiresCyrillic, showExpiryDate, showCitizenship, citizenshipOptions]);
 
 	const handleFieldChange = (field, value) => {
 		const next = { ...data, [field]: value };
@@ -156,15 +161,7 @@ const PassengerForm = ({ passenger, onChange, onRemove, onSelectDocument, citize
 
 	useImperativeHandle(ref, () => ({ validate }));
 
-	useEffect(() => {
-		if (formFields.citizenshipId && !data.citizenshipId && citizenshipOptions.length) {
-			setData((prev) => ({ ...prev, citizenshipId: citizenshipOptions[0].value }));
-		}
-	}, [formFields.citizenshipId, citizenshipOptions, data.citizenshipId]);
-
-	const theme = useTheme();
-
-	const docConfig = getDocumentFieldConfig(data.documentType);
+        const theme = useTheme();
 
 	const nameFields = [
 		'lastName',

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -1,4 +1,5 @@
 import { formatDate } from '../components/utils';
+import { FIELD_LABELS } from './fieldLabels';
 
 export const UI_LABELS = {
 	APP_TITLE: 'АВЕКСМАР - Авиаперевозки',
@@ -279,17 +280,23 @@ export const UI_LABELS = {
 				discount: 'Скидка',
 			},
 		},
-		passenger_form: {
-			type_labels: {
-				adult: 'Взрослый, старше 12 лет',
-				child: 'Ребёнок, от 2 до 12 лет',
-				infant: 'Младенец, до 2 лет',
-				infant_seat: 'Младенец с местом, до 2 лет',
-			},
-			add_passenger: 'Добавить пассажира',
-		},
-	},
-	SCHEDULE: {
+                passenger_form: {
+                        type_labels: {
+                                adult: 'Взрослый, старше 12 лет',
+                                child: 'Ребёнок, от 2 до 12 лет',
+                                infant: 'Младенец, до 2 лет',
+                                infant_seat: 'Младенец с местом, до 2 лет',
+                        },
+                        add_passenger: 'Добавить пассажира',
+                        last_name: (isCyrillic) =>
+                                `${FIELD_LABELS.PASSENGER.last_name} ${isCyrillic ? '(кириллица)' : '(латиница)'}`,
+                        first_name: (isCyrillic) =>
+                                `${FIELD_LABELS.PASSENGER.first_name} ${isCyrillic ? '(кириллица)' : '(латиница)'}`,
+                        patronymic_name: (isCyrillic) =>
+                                `${FIELD_LABELS.PASSENGER.patronymic_name} ${isCyrillic ? '(кириллица)' : '(латиница)'}`,
+                },
+        },
+        SCHEDULE: {
 		title: 'Расписание рейсов',
 		results: 'Результаты поиска',
 		no_results: 'Рейсы не найдены',

--- a/client/src/constants/validationMessages.js
+++ b/client/src/constants/validationMessages.js
@@ -78,31 +78,37 @@ export const VALIDATION_MESSAGES = {
 		},
 	},
 
-	PASSENGER: {
-		first_name: {
-			REQUIRED: 'Имя обязательно',
-		},
-		last_name: {
-			REQUIRED: 'Фамилия обязательна',
-		},
-		birth_date: {
-			REQUIRED: 'Укажите дату рождения',
-			adult: 'Пассажир должен быть старше 12 лет',
-			child: 'Возраст ребёнка 2–12 лет',
-			infant: 'Возраст младенца должен быть менее 2 лет',
-			infant_seat: 'Возраст младенца должен быть менее 2 лет',
-		},
-		document_type: {
-			REQUIRED: 'Тип документа обязателен',
-		},
-		document_number: {
-			REQUIRED: 'Номер документа обязателен',
-		},
-		name_language: {
-			CYRILLIC: 'Используйте кириллицу',
-			LATIN: 'Используйте латиницу',
-		},
-	},
+        PASSENGER: {
+                first_name: {
+                        REQUIRED: 'Имя обязательно',
+                },
+                last_name: {
+                        REQUIRED: 'Фамилия обязательна',
+                },
+                birth_date: {
+                        REQUIRED: 'Укажите дату рождения',
+                        adult: 'Пассажир должен быть старше 12 лет',
+                        child: 'Возраст ребёнка 2–12 лет',
+                        infant: 'Возраст младенца должен быть менее 2 лет',
+                        infant_seat: 'Возраст младенца должен быть менее 2 лет',
+                },
+                document_type: {
+                        REQUIRED: 'Тип документа обязателен',
+                },
+                document_number: {
+                        REQUIRED: 'Номер документа обязателен',
+                },
+                document_expiry_date: {
+                        REQUIRED: 'Срок действия обязателен',
+                },
+                citizenship_id: {
+                        REQUIRED: 'Гражданство обязательно',
+                },
+                name_language: {
+                        CYRILLIC: 'Используйте кириллицу',
+                        LATIN: 'Используйте латиницу',
+                },
+        },
 
 	BOOKING: {
 		email_address: {


### PR DESCRIPTION
## Summary
- enforce mandatory inputs for passenger names, documents, expiry date and citizenship with language hints
- remove default citizenship selection and validate dynamically shown fields
- map booking forms to API snake_case keys before submission
- centralize name field labels with script indicators while keeping patronymic optional

## Testing
- `CI=true npm test -- --passWithNoTests`
- `pytest` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType')*


------
https://chatgpt.com/codex/tasks/task_e_68985c4ca324832f8ded0d4b31bfb7f5