### PR TITLE
Refactor booking session management

### DIFF
--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -22,7 +22,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
 import PassengerForm from './PassengerForm';
-import { processBookingPassengers, fetchBookingDetails } from '../../redux/actions/bookingProcess';
+import { processBookingPassengers, fetchBookingDetails, fetchBookingAccess } from '../../redux/actions/bookingProcess';
 import { fetchCountries } from '../../redux/actions/country';
 import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES, ENUM_LABELS } from '../../constants';
 import {
@@ -181,21 +181,23 @@ const Passengers = () => {
 			.every(Boolean);
 		const buyerValid = validateBuyer();
 		if (!passengerValid || !buyerValid) return;
-		try {
-			const apiPassengers = (passengerData || []).map(toApiPassenger);
-			const apiBuyer = toApiBuyer(buyer);
-			await dispatch(
-				processBookingPassengers({
-					public_id: publicId,
-					buyer: apiBuyer,
-					passengers: apiPassengers,
-				})
-			).unwrap();
-			navigate(`/booking/${publicId}/confirmation`);
-		} catch (e) {
-			// errors handled via redux state
-		}
-	};
+                try {
+                        const apiPassengers = (passengerData || []).map(toApiPassenger);
+                        const apiBuyer = toApiBuyer(buyer);
+                        await dispatch(
+                                processBookingPassengers({
+                                        public_id: publicId,
+                                        buyer: apiBuyer,
+                                        passengers: apiPassengers,
+                                })
+                        ).unwrap();
+                        await dispatch(fetchBookingDetails(publicId)).unwrap();
+                        await dispatch(fetchBookingAccess(publicId)).unwrap();
+                        navigate(`/booking/${publicId}/confirmation`);
+                } catch (e) {
+                        // errors handled via redux state
+                }
+        };
 
 	const [outboundFlight = null, returnFlight = null] = (booking?.flights ?? [])
 		.slice()


### PR DESCRIPTION
## Summary
- centralize booking creation logic in controller and manage sessions per request
- refresh booking details and access before navigating to confirmation
- streamline booking helpers

## Testing
- `pytest` *(fails: could not translate host name "postgres")*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68990ea7b194832f981e7379a4d58a1f