### PR TITLE
fix: restore passenger and buyer data

### DIFF
--- a/client/src/components/booking/PassengerForm.js
+++ b/client/src/components/booking/PassengerForm.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback, forwardRef, useImperativeHandle } from 'react';
+import React, { useState, useEffect, useMemo, forwardRef, useImperativeHandle } from 'react';
 
 import { Box, Grid, Typography, Tooltip } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -20,33 +20,35 @@ const typeLabels = UI_LABELS.BOOKING.passenger_form.type_labels;
 const genderOptions = getEnumOptions('GENDER');
 const docTypeOptions = getEnumOptions('DOCUMENT_TYPE');
 
+const normalizePassenger = (p = {}) => ({
+        id: p.id || '',
+        category: p.category || 'adult',
+        lastName: p.lastName || p.last_name || '',
+        firstName: p.firstName || p.first_name || '',
+        patronymicName: p.patronymicName || p.patronymic_name || '',
+        gender: p.gender || genderOptions[0]?.value || '',
+        birthDate: p.birthDate || p.birth_date || '',
+        documentType: p.documentType || p.document_type || docTypeOptions[0]?.value || '',
+        documentNumber: p.documentNumber || p.document_number || '',
+        documentExpiryDate: p.documentExpiryDate || p.document_expiry_date || '',
+        citizenshipId: p.citizenshipId || p.citizenship_id || '',
+});
+
 const PassengerForm = ({ passenger, onChange, citizenshipOptions = [], flights = [] }, ref) => {
-	const [data, setData] = useState({
-		id: passenger?.id || '',
-		category: passenger?.category || 'adult',
-		lastName: passenger?.lastName || '',
-		firstName: passenger?.firstName || '',
-		patronymicName: passenger?.patronymicName || '',
-		gender: passenger?.gender || genderOptions[0]?.value || '',
-		birthDate: passenger?.birthDate || '',
-		documentType: passenger?.documentType || docTypeOptions[0]?.value || '',
-		documentNumber: passenger?.documentNumber || '',
-		documentExpiryDate: passenger?.documentExpiryDate || '',
-		citizenshipId: passenger?.citizenshipId || '',
-	});
+        const [data, setData] = useState(normalizePassenger(passenger));
 
 	const [errors, setErrors] = useState({});
 	const [showErrors, setShowErrors] = useState(false);
 	const [focusedField, setFocusedField] = useState(null);
 
-	useEffect(() => {
-		if (!passenger) return;
-		const normalized = { ...passenger };
-		['lastName', 'firstName', 'patronymicName'].forEach((k) => {
-			if (normalized[k]) normalized[k] = String(normalized[k]).toUpperCase();
-		});
-		setData((prev) => ({ ...prev, ...normalized }));
-	}, [passenger]);
+        useEffect(() => {
+                if (!passenger) return;
+                const normalized = normalizePassenger(passenger);
+                ['lastName', 'firstName', 'patronymicName'].forEach((k) => {
+                        if (normalized[k]) normalized[k] = String(normalized[k]).toUpperCase();
+                });
+                setData((prev) => ({ ...prev, ...normalized }));
+        }, [passenger]);
 
 	const requiresCyrillic = isCyrillicDocument(data.documentType);
 	const formConfig = getPassengerFormConfig(data.documentType);

--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -51,10 +51,32 @@ const Passengers = () => {
 	} = useSelector((state) => state.bookingProcess);
 	const { countries } = useSelector((state) => state.countries);
 
-	const existingPassengerData = booking?.passengers;
-	const passengersExist = booking?.passengersExist;
-	const [passengerData, setPassengerData] = useState(null);
-	const [errors, setErrors] = useState({});
+        const existingPassengerData = booking?.passengers;
+        const passengersExist = booking?.passengersExist;
+        const [passengerData, setPassengerData] = useState(null);
+        const [errors, setErrors] = useState({});
+
+        const fromApiPassenger = (p = {}) => ({
+                id: p.id,
+                category: p.category,
+                firstName: p.first_name || '',
+                lastName: p.last_name || '',
+                patronymicName: p.patronymic_name || '',
+                gender: p.gender || '',
+                birthDate: p.birth_date || '',
+                documentType: p.document_type || '',
+                documentNumber: p.document_number || '',
+                documentExpiryDate: p.document_expiry_date || '',
+                citizenshipId: p.citizenship_id || '',
+        });
+
+        const fromApiBuyer = (b = {}) => ({
+                lastName: b.last_name || '',
+                firstName: b.first_name || '',
+                email: b.email || '',
+                phone: b.phone || '',
+                consent: b.consent ?? false,
+        });
 
 	useEffect(() => {
 		if (bookingErrors == null) return;
@@ -80,15 +102,12 @@ const Passengers = () => {
 		return [];
 	}, [errors]);
 
-	useEffect(() => {
-		if (Array.isArray(existingPassengerData)) {
-			const mapped = existingPassengerData.map((p) => ({
-				...p,
-				category: p.category,
-			}));
-			setPassengerData(mapped);
-		}
-	}, [existingPassengerData, passengersExist]);
+        useEffect(() => {
+                if (Array.isArray(existingPassengerData)) {
+                        const mapped = existingPassengerData.map(fromApiPassenger);
+                        setPassengerData(mapped);
+                }
+        }, [existingPassengerData, passengersExist]);
 
 	useEffect(() => {
 		dispatch(fetchBookingDetails(publicId));
@@ -110,9 +129,26 @@ const Passengers = () => {
 		return formConfig.required.every((f) => p[f]);
 	};
 
-	const [buyer, setBuyer] = useState(
-		booking?.buyer || { lastName: '', firstName: '', email: '', phone: '', consent: false }
-	);
+        const [buyer, setBuyer] = useState({
+                lastName: '',
+                firstName: '',
+                email: '',
+                phone: '',
+                consent: false,
+        });
+
+        useEffect(() => {
+                if (booking?.buyer || passengersExist) {
+                        const mapped = booking?.buyer ? fromApiBuyer(booking.buyer) : {};
+                        setBuyer({
+                                lastName: mapped.lastName || '',
+                                firstName: mapped.firstName || '',
+                                email: mapped.email || '',
+                                phone: mapped.phone || '',
+                                consent: passengersExist ? true : mapped.consent,
+                        });
+                }
+        }, [booking?.buyer, passengersExist]);
 
 	const buyerFormFields = useMemo(() => {
 		const fields = {


### PR DESCRIPTION
## Summary
- map API passenger and buyer fields to form fields
- preload consent when passenger data already exists
- allow PassengerForm to read both snake_case and camelCase data

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6899ee2a98dc832f801a8e2172a9e665