### PR TITLE
Fix passenger form mapping and add booking confirmation

### DIFF
--- a/client/src/components/booking/Confirmation.js
+++ b/client/src/components/booking/Confirmation.js
@@ -15,9 +15,9 @@ import {
 } from '@mui/material';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
-import { fetchBookingDetails, fetchBookingDirectionsInfo } from '../../redux/actions/bookingProcess';
+import { fetchBookingDetails, fetchBookingDirectionsInfo, confirmBooking, fetchBookingAccess } from '../../redux/actions/bookingProcess';
 import { ENUM_LABELS, UI_LABELS } from '../../constants';
-import { formatNumber } from '../utils';
+import { formatNumber, formatDate, formatTime, formatDuration } from '../utils';
 
 const Confirmation = () => {
 	const { publicId } = useParams();
@@ -38,18 +38,93 @@ const Confirmation = () => {
 
 	const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
 
-	const handlePayment = () => {
-		navigate(`/booking/${publicId}/payment`);
-	};
+        const handlePayment = async () => {
+                try {
+                        await dispatch(confirmBooking(publicId)).unwrap();
+                        await dispatch(fetchBookingAccess(publicId)).unwrap();
+                        navigate(`/booking/${publicId}/payment`);
+                } catch (e) {
+                        // errors handled via redux state
+                }
+        };
 
 	return (
 		<Base maxWidth='lg'>
 			<BookingProgress activeStep='confirmation' />
-			<Box sx={{ mt: 2 }}>
-				{booking?.directions?.map((dir) => {
-					const info = directionsInfo[dir.direction] || {};
-					return (
-						<Card key={dir.direction} sx={{ mb: 2 }}>
+                        <Box sx={{ mt: 2 }}>
+                                {Array.isArray(booking?.flights) && booking.flights.length > 0 && (
+                                        <Card sx={{ mb: 2 }}>
+                                                <CardContent>
+                                                        <Typography variant='h6' sx={{ mb: 1 }}>
+                                                                {UI_LABELS.BOOKING.flight_details.title}
+                                                        </Typography>
+                                                        {booking.flights.map((f, idx) => {
+                                                                const origin = f.route?.origin_airport || {};
+                                                                const dest = f.route?.destination_airport || {};
+                                                                const depDate = formatDate(f.scheduled_departure);
+                                                                const depTime = formatTime(f.scheduled_departure_time);
+                                                                const arrDate = formatDate(f.scheduled_arrival);
+                                                                const arrTime = formatTime(f.scheduled_arrival_time);
+                                                                const duration = formatDuration(f.duration);
+                                                                const airline = f.airline?.name || '';
+                                                                const flightNo = f.airline_flight_number || f.flight_number || '';
+                                                                return (
+                                                                        <Box key={f.id || idx} sx={{ mb: idx < booking.flights.length - 1 ? 2 : 0 }}>
+                                                                                <Typography variant='subtitle2'>{UI_LABELS.BOOKING.flight_details.from_to(origin.iata_code, dest.iata_code)}</Typography>
+                                                                                <Typography variant='body2' color='text.secondary'>
+                                                                                        {airline} {flightNo}
+                                                                                </Typography>
+                                                                                <Typography variant='body2'>
+                                                                                        {depDate} {depTime} → {arrDate} {arrTime}
+                                                                                </Typography>
+                                                                                <Typography variant='body2'>
+                                                                                        {duration}
+                                                                                </Typography>
+                                                                        </Box>
+                                                                );
+                                                        })}
+                                                </CardContent>
+                                        </Card>
+                                )}
+
+                                {Array.isArray(booking?.passengers) && booking.passengers.length > 0 && (
+                                        <Card sx={{ mb: 2 }}>
+                                                <CardContent>
+                                                        <Typography variant='h6' sx={{ mb: 1 }}>
+                                                                {UI_LABELS.BOOKING.progress_steps.passengers}
+                                                        </Typography>
+                                                        <Table size='small'>
+                                                                <TableBody>
+                                                                        {booking.passengers.map((p, idx) => (
+                                                                                <TableRow key={p.id || idx}>
+                                                                                        <TableCell>{`${p.last_name || ''} ${p.first_name || ''}`}</TableCell>
+                                                                                        <TableCell>{ENUM_LABELS.PASSENGER_CATEGORY[p.category] || p.category}</TableCell>
+                                                                                        <TableCell>{p.document_number}</TableCell>
+                                                                                </TableRow>
+                                                                        ))}
+                                                                </TableBody>
+                                                        </Table>
+                                                </CardContent>
+                                        </Card>
+                                )}
+
+                                {booking && (
+                                        <Card sx={{ mb: 2 }}>
+                                                <CardContent>
+                                                        <Typography variant='h6' sx={{ mb: 1 }}>
+                                                                {UI_LABELS.BOOKING.buyer_form.title}
+                                                        </Typography>
+                                                        <Typography>{`${booking.buyer_last_name || ''} ${booking.buyer_first_name || ''}`}</Typography>
+                                                        <Typography>{booking.email_address}</Typography>
+                                                        <Typography>{booking.phone_number}</Typography>
+                                                </CardContent>
+                                        </Card>
+                                )}
+
+                                {booking?.directions?.map((dir) => {
+                                        const info = directionsInfo[dir.direction] || {};
+                                        return (
+                                                <Card key={dir.direction} sx={{ mb: 2 }}>
 							<CardContent>
 								<Typography variant='h6' sx={{ mb: 1 }}>
 									{UI_LABELS.SCHEDULE.from_to(info.from, info.to) || dir.direction}

--- a/client/src/components/booking/PassengerForm.js
+++ b/client/src/components/booking/PassengerForm.js
@@ -14,7 +14,8 @@ import {
 	getAgeError,
 	validateDate,
 } from '../utils';
-import { mapFromApi, mappingConfigs } from '../utils/mappers';
+// Passengers passed to this component are already in client-side camelCase.
+// No additional mapping from API format is required here.
 
 const typeLabels = UI_LABELS.BOOKING.passenger_form.type_labels;
 
@@ -22,12 +23,17 @@ const genderOptions = getEnumOptions('GENDER');
 const docTypeOptions = getEnumOptions('DOCUMENT_TYPE');
 
 const normalizePassenger = (p = {}) => ({
-	...mapFromApi(p, mappingConfigs.passenger, {
-		id: '',
-		category: 'adult',
-		gender: genderOptions[0]?.value || '',
-		documentType: docTypeOptions[0]?.value || '',
-	}),
+        id: p.id || '',
+        category: p.category || 'adult',
+        lastName: p.lastName || '',
+        firstName: p.firstName || '',
+        patronymicName: p.patronymicName || '',
+        gender: p.gender || genderOptions[0]?.value || '',
+        birthDate: p.birthDate || '',
+        documentType: p.documentType || docTypeOptions[0]?.value || '',
+        documentNumber: p.documentNumber || '',
+        documentExpiryDate: p.documentExpiryDate || '',
+        citizenshipId: p.citizenshipId || '',
 });
 
 const PassengerForm = ({ passenger, onChange, citizenshipOptions = [], flights = [] }, ref) => {

--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -232,9 +232,9 @@ const Passengers = () => {
 					passengers: apiPassengers,
 				})
 			).unwrap();
-			await dispatch(fetchBookingDetails(publicId)).unwrap();
-			// await dispatch(fetchBookingAccess(publicId)).unwrap();
-			navigate(`/booking/${publicId}/confirmation`);
+                        await dispatch(fetchBookingDetails(publicId)).unwrap();
+                        await dispatch(fetchBookingAccess(publicId)).unwrap();
+                        navigate(`/booking/${publicId}/confirmation`);
 		} catch (e) {
 			// errors handled via redux state
 		}

--- a/client/src/redux/actions/bookingProcess.js
+++ b/client/src/redux/actions/bookingProcess.js
@@ -48,8 +48,8 @@ export const fetchBookingAccess = createAsyncThunk(
 );
 
 export const fetchBookingDirectionsInfo = createAsyncThunk(
-	'bookingProcess/fetchDirectionsInfo',
-	async (directions, { rejectWithValue }) => {
+        'bookingProcess/fetchDirectionsInfo',
+        async (directions, { rejectWithValue }) => {
 		try {
 			const info = {};
 			await Promise.all(
@@ -68,5 +68,17 @@ export const fetchBookingDirectionsInfo = createAsyncThunk(
 		} catch (err) {
 			return rejectWithValue(getErrorData(err));
 		}
-	}
+        }
+);
+
+export const confirmBooking = createAsyncThunk(
+        'bookingProcess/confirm',
+        async (publicId, { rejectWithValue }) => {
+                try {
+                        const res = await serverApi.post('/bookings/process/confirm', { public_id: publicId });
+                        return res.data;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
 );

--- a/client/src/redux/reducers/bookingProcess.js
+++ b/client/src/redux/reducers/bookingProcess.js
@@ -1,10 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
 import {
-	processBookingCreate,
-	processBookingPassengers,
-	fetchBookingDetails,
-	fetchBookingAccess,
-	fetchBookingDirectionsInfo,
+        processBookingCreate,
+        processBookingPassengers,
+        fetchBookingDetails,
+        fetchBookingAccess,
+        fetchBookingDirectionsInfo,
+        confirmBooking,
 } from '../actions/bookingProcess';
 import { handlePending, handleRejected } from '../utils';
 
@@ -51,13 +52,18 @@ const bookingProcessSlice = createSlice({
 				state.current = { ...(state.current || {}), accessiblePages: action.payload.pages || [] };
 				state.isLoading = false;
 			})
-			.addCase(fetchBookingDirectionsInfo.pending, handlePending)
-			.addCase(fetchBookingDirectionsInfo.rejected, handleRejected)
-			.addCase(fetchBookingDirectionsInfo.fulfilled, (state, action) => {
-				state.current = { ...(state.current || {}), directionsInfo: action.payload };
-				state.isLoading = false;
-			});
-	},
+                        .addCase(fetchBookingDirectionsInfo.pending, handlePending)
+                        .addCase(fetchBookingDirectionsInfo.rejected, handleRejected)
+                        .addCase(fetchBookingDirectionsInfo.fulfilled, (state, action) => {
+                                state.current = { ...(state.current || {}), directionsInfo: action.payload };
+                                state.isLoading = false;
+                        })
+                        .addCase(confirmBooking.pending, handlePending)
+                        .addCase(confirmBooking.rejected, handleRejected)
+                        .addCase(confirmBooking.fulfilled, (state) => {
+                                state.isLoading = false;
+                        });
+        },
 });
 
 export default bookingProcessSlice.reducer;

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -215,6 +215,7 @@ def __create_app(_config_class, _db):
     app.route('/bookings/process/<public_id>/access', methods=['GET'])(get_process_booking_access)
     app.route('/bookings/process/create', methods=['POST'])(process_booking_create)
     app.route('/bookings/process/passengers', methods=['POST'])(process_booking_passengers)
+    app.route('/bookings/process/confirm', methods=['POST'])(process_booking_confirm)
     app.route('/bookings/process/payment', methods=['POST'])(process_booking_payment)
     app.route('/bookings/process/<public_id>/details', methods=['GET'])(get_process_booking_details)
 

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -142,6 +142,23 @@ def process_booking_passengers():
     return jsonify({'status': 'ok'}), 200
 
 
+def process_booking_confirm():
+    data = request.json or {}
+    public_id = data.get('public_id')
+    if not public_id:
+        return jsonify({'message': 'public_id_required'}), 400
+
+    session = db.session
+    booking = Booking.get_by_public_id(public_id)
+    Booking.transition_status(
+        id=booking.id,
+        session=session,
+        to_status='confirmed',
+    )
+
+    return jsonify({'status': 'ok'}), 200
+
+
 def process_booking_payment():
     return jsonify({'status': 'ok'}), 200
 


### PR DESCRIPTION
## Summary
- fix passenger form mapping so API values prefill correctly
- ensure passengers step fetches access before navigating to confirmation
- expand confirmation page with flight, passenger and buyer info and add booking confirmation flow
- add endpoint to transition booking to confirmed status

## Testing
- `npm test --prefix client`
- `set -o allexport; source .example.env; set +o allexport
pytest` *(fails: psycopg2.OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689a11ae48c0832fbc72275ff9c92a5f