### PR TITLE
Fix booking confirmation data sources and access control

### DIFF
--- a/client/src/components/booking/Confirmation.js
+++ b/client/src/components/booking/Confirmation.js
@@ -22,10 +22,9 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
 import {
-	fetchBookingDetails,
-	fetchBookingDirectionsInfo,
-	confirmBooking,
-	fetchBookingAccess,
+        fetchBookingDetails,
+        confirmBooking,
+        fetchBookingAccess,
 } from '../../redux/actions/bookingProcess';
 import { ENUM_LABELS, UI_LABELS, FIELD_LABELS } from '../../constants';
 import { formatNumber, formatDate, formatTime, formatDuration } from '../utils';
@@ -34,18 +33,27 @@ const Confirmation = () => {
 	const { publicId } = useParams();
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
-	const booking = useSelector((state) => state.bookingProcess.current);
-	const directionsInfo = useSelector((state) => state.bookingProcess.current?.directionsInfo) || {};
+        const booking = useSelector((state) => state.bookingProcess.current);
 
 	useEffect(() => {
 		dispatch(fetchBookingDetails(publicId));
 	}, [dispatch, publicId]);
 
-	useEffect(() => {
-		if (booking?.price_details?.directions) {
-			dispatch(fetchBookingDirectionsInfo(booking.price_details.directions));
-		}
-	}, [dispatch, booking]);
+        const getRouteInfo = (flight) => {
+                if (!flight?.route) return null;
+                const origin = flight.route.origin_airport || {};
+                const dest = flight.route.destination_airport || {};
+                return {
+                        from: origin.city_name || origin.iata_code,
+                        to: dest.city_name || dest.iata_code,
+                };
+        };
+
+        const outboundFlight = booking?.flights?.[0];
+        const returnFlight = booking?.flights?.[1];
+        const outboundRouteInfo = getRouteInfo(outboundFlight);
+        const returnRouteInfo = getRouteInfo(returnFlight);
+        const flightMap = { outbound: outboundFlight, return: returnFlight };
 
 	const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
 
@@ -59,11 +67,8 @@ const Confirmation = () => {
 		}
 	};
 
-	const outboundRouteInfo = directionsInfo.outbound;
-	const returnRouteInfo = directionsInfo.return;
-
-	return (
-		<Base maxWidth='lg'>
+        return (
+                <Base maxWidth='lg'>
 			<BookingProgress activeStep='confirmation' />
 			<Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', rowGap: 2 }}>
 				{Array.isArray(booking?.flights) && booking.flights.length > 0 && (
@@ -212,8 +217,8 @@ const Confirmation = () => {
 				{booking && (
 					<Card>
 						<CardContent>
-							{(booking.price_details?.directions || []).map((dir, idx) => {
-								const info = directionsInfo[dir.direction] || {};
+                                                       {(booking.price_details?.directions || []).map((dir, idx) => {
+                                                                const info = getRouteInfo(flightMap[dir.direction]) || {};
 								return (
 									<Box key={dir.direction} sx={{ mb: 2 }}>
 										<Typography variant='subtitle1' sx={{ fontWeight: 500, mb: 0.5 }}>

--- a/client/src/components/booking/Payment.js
+++ b/client/src/components/booking/Payment.js
@@ -4,30 +4,32 @@ import { useParams } from 'react-router-dom';
 import { Box, Card, CardContent, Typography, Button } from '@mui/material';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
-import { fetchBookingDetails, fetchBookingDirectionsInfo } from '../../redux/actions/bookingProcess';
+import { fetchBookingDetails } from '../../redux/actions/bookingProcess';
 import { ENUM_LABELS, UI_LABELS } from '../../constants';
 import { formatNumber } from '../utils';
 
 const Payment = () => {
 	const { publicId } = useParams();
 	const dispatch = useDispatch();
-	const booking = useSelector((state) => state.bookingProcess.current);
-	const directionsInfo = useSelector((state) => state.bookingProcess.current?.directionsInfo || {});
+        const booking = useSelector((state) => state.bookingProcess.current);
 
 	useEffect(() => {
 		dispatch(fetchBookingDetails(publicId));
 	}, [dispatch, publicId]);
 
-	useEffect(() => {
-		if (booking?.directions) {
-			dispatch(fetchBookingDirectionsInfo(booking.directions));
-		}
-	}, [dispatch, booking]);
+        const getRouteInfo = (flight) => {
+                if (!flight?.route) return null;
+                const origin = flight.route.origin_airport || {};
+                const dest = flight.route.destination_airport || {};
+                return UI_LABELS.SCHEDULE.from_to(
+                        origin.city_name || origin.iata_code,
+                        dest.city_name || dest.iata_code
+                );
+        };
 
-	const firstDir = booking?.directions ? booking.directions[0]?.direction : null;
-	const info = firstDir ? directionsInfo[firstDir] : null;
-	const routeInfo = info ? UI_LABELS.SCHEDULE.from_to(info.from, info.to) : null;
-	const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
+        const routeInfo = getRouteInfo(booking?.flights?.[0]);
+
+        const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
 
 	return (
 		<Base maxWidth='lg'>

--- a/client/src/redux/actions/bookingProcess.js
+++ b/client/src/redux/actions/bookingProcess.js
@@ -47,30 +47,6 @@ export const fetchBookingAccess = createAsyncThunk(
 	}
 );
 
-export const fetchBookingDirectionsInfo = createAsyncThunk(
-        'bookingProcess/fetchDirectionsInfo',
-        async (directions, { rejectWithValue }) => {
-		try {
-			const info = {};
-			await Promise.all(
-				directions.map(async (d) => {
-					const flight = (await serverApi.get(`/flights/${d.flight_id}`)).data;
-					const route = (await serverApi.get(`/routes/${flight.route_id}`)).data;
-					const origin = (await serverApi.get(`/airports/${route.origin_airport_id}`)).data;
-					const dest = (await serverApi.get(`/airports/${route.destination_airport_id}`)).data;
-					info[d.direction] = {
-						from: origin.city || origin.iata_code,
-						to: dest.city || dest.iata_code,
-					};
-				})
-			);
-			return info;
-		} catch (err) {
-			return rejectWithValue(getErrorData(err));
-		}
-        }
-);
-
 export const confirmBooking = createAsyncThunk(
         'bookingProcess/confirm',
         async (publicId, { rejectWithValue }) => {

--- a/client/src/redux/reducers/bookingProcess.js
+++ b/client/src/redux/reducers/bookingProcess.js
@@ -4,7 +4,6 @@ import {
         processBookingPassengers,
         fetchBookingDetails,
         fetchBookingAccess,
-        fetchBookingDirectionsInfo,
         confirmBooking,
 } from '../actions/bookingProcess';
 import { handlePending, handleRejected } from '../utils';
@@ -46,16 +45,10 @@ const bookingProcessSlice = createSlice({
 				};
 				state.isLoading = false;
 			})
-			.addCase(fetchBookingAccess.pending, handlePending)
-			.addCase(fetchBookingAccess.rejected, handleRejected)
-			.addCase(fetchBookingAccess.fulfilled, (state, action) => {
-				state.current = { ...(state.current || {}), accessiblePages: action.payload.pages || [] };
-				state.isLoading = false;
-			})
-                        .addCase(fetchBookingDirectionsInfo.pending, handlePending)
-                        .addCase(fetchBookingDirectionsInfo.rejected, handleRejected)
-                        .addCase(fetchBookingDirectionsInfo.fulfilled, (state, action) => {
-                                state.current = { ...(state.current || {}), directionsInfo: action.payload };
+                        .addCase(fetchBookingAccess.pending, handlePending)
+                        .addCase(fetchBookingAccess.rejected, handleRejected)
+                        .addCase(fetchBookingAccess.fulfilled, (state, action) => {
+                                state.current = { ...(state.current || {}), accessiblePages: action.payload.pages || [] };
                                 state.isLoading = false;
                         })
                         .addCase(confirmBooking.pending, handlePending)

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -78,6 +78,7 @@ def process_booking_create(current_user):
         total_discounts=price['total_discounts'],
         total_price=price['total_price'],
         passenger_counts=passengers,
+        user_id=current_user.id if current_user else None,
     )
 
     if outbound_id:

--- a/server/app/models/booking.py
+++ b/server/app/models/booking.py
@@ -177,7 +177,7 @@ class Booking(BaseModel):
     def get_accessible_pages(cls, current_user, public_id):
         booking = cls.get_by_public_id(public_id)
 
-        if booking.user_id and booking.user_id != current_user.id:
+        if booking.user_id and current_user and booking.user_id != current_user.id:
             return []
 
         return cls.PAGE_FLOW.get(booking.status.value, [])


### PR DESCRIPTION
## Summary
- link created bookings to current user
- restrict booking access when user mismatch
- remove airport lookups from confirmation and payment pages and related redux logic

## Testing
- `npm test`
- `pytest` *(fails: Server JWT exp hours not set)*

------
https://chatgpt.com/codex/tasks/task_e_689ada8cacc8832f8ef4b94f609aa14b