### PR TITLE
feat: integrate yookassa payments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,3 +84,17 @@ services:
   #   ports:
   #     - 1025:1025
   #     - 8025:8025
+  yookassa-mock:
+    build: ./mock_yookassa
+    ports:
+      - 8050:8000
+    environment:
+      AUTHORIZE_OK: ${MOCK_AUTHORIZE_OK:-true}
+      CAPTURE_OK: ${MOCK_CAPTURE_OK:-true}
+      WEBHOOK_URL: ${MOCK_WEBHOOK_URL:-http://server-app:5000/api/payments/webhook}
+    volumes:
+      - ./mock_yookassa:/app
+    env_file:
+      - .env
+    depends_on:
+      - server-app

--- a/mock_yookassa/Dockerfile
+++ b/mock_yookassa/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["python", "app.py"]

--- a/mock_yookassa/app.py
+++ b/mock_yookassa/app.py
@@ -1,0 +1,57 @@
+import os
+import uuid
+import threading
+from flask import Flask, request, jsonify
+import requests
+
+app = Flask(__name__)
+
+payments = {}
+
+WEBHOOK_URL = os.getenv("WEBHOOK_URL")
+AUTHORIZE_OK = os.getenv("AUTHORIZE_OK", "true").lower() == "true"
+CAPTURE_OK = os.getenv("CAPTURE_OK", "true").lower() == "true"
+
+
+def send_webhook(event, payment):
+    if not WEBHOOK_URL:
+        return
+    payload = {"event": event, "object": payment}
+    try:
+        requests.post(WEBHOOK_URL, json=payload, timeout=5)
+    except Exception:
+        pass
+
+
+@app.post("/payments")
+def create_payment():
+    payment_id = str(uuid.uuid4())
+    payment = {
+        "id": payment_id,
+        "status": "pending",
+        "confirmation": {
+            "type": "embedded",
+            "confirmation_token": f"token-{payment_id}"
+        },
+    }
+    payments[payment_id] = payment
+    status = "waiting_for_capture" if AUTHORIZE_OK else "canceled"
+    payment = {**payment, "status": status}
+    payments[payment_id] = payment
+    threading.Thread(target=send_webhook, args=(f"payment.{status}", payment)).start()
+    return jsonify(payment)
+
+
+@app.post("/payments/<payment_id>/capture")
+def capture_payment(payment_id):
+    payment = payments.get(payment_id)
+    if not payment:
+        return jsonify({"message": "Not found"}), 404
+    status = "succeeded" if CAPTURE_OK else "canceled"
+    payment["status"] = status
+    threading.Thread(target=send_webhook, args=(f"payment.{status}", payment)).start()
+    return jsonify(payment)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/mock_yookassa/requirements.txt
+++ b/mock_yookassa/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -231,12 +231,11 @@ def get_booking_details(current_user, public_id):
 def create_booking_payment(current_user):
     data = request.json or {}
     public_id = data.get('public_id')
-    return_url = data.get('return_url')
     if not public_id:
         return jsonify({'message': 'public_id required'}), 400
 
     booking = Booking.get_by_public_id(public_id)
-    payment = create_payment(booking, return_url)
+    payment = create_payment(booking)
     return jsonify(payment.to_dict()), 201
 
 

--- a/server/app/models/payment.py
+++ b/server/app/models/payment.py
@@ -1,5 +1,8 @@
 from typing import TYPE_CHECKING
+from datetime import datetime
+
 from sqlalchemy.orm import Mapped
+from sqlalchemy.dialects.postgresql import JSONB
 
 from app.database import db
 from app.models._base_model import BaseModel
@@ -20,6 +23,12 @@ class Payment(BaseModel):
     provider_payment_id = db.Column(db.String, unique=True)
     confirmation_token = db.Column(db.String)
 
+    # Payment processing details
+    is_paid = db.Column(db.Boolean, default=False, nullable=False)
+    status_history = db.Column(JSONB, nullable=False, server_default='[]', default=list)
+    last_webhook = db.Column(JSONB)
+    meta = db.Column(JSONB)
+
     booking: Mapped['Booking'] = db.relationship('Booking', back_populates='payments')
 
     def to_dict(self, return_children=False):
@@ -33,4 +42,28 @@ class Payment(BaseModel):
             'currency': self.currency.value if self.currency else None,
             'provider_payment_id': self.provider_payment_id,
             'confirmation_token': self.confirmation_token,
+            'is_paid': self.is_paid,
+            'status_history': self.status_history,
+            'last_webhook': self.last_webhook,
+            'metadata': self.meta,
         }
+
+    @classmethod
+    def create(cls, session: db.Session | None = None, **kwargs):
+        session = session or db.session
+        status = kwargs.get('payment_status', Config.DEFAULT_PAYMENT_STATUS.value)
+        kwargs['status_history'] = [
+            {'status': status, 'at': datetime.now().isoformat()}
+        ]
+        return super().create(session, **kwargs)
+
+    @classmethod
+    def update(cls, _id, session: db.Session | None = None, **kwargs):
+        session = session or db.session
+        payment = cls.get_or_404(_id, session)
+        new_status = kwargs.get('payment_status')
+        if new_status and new_status != payment.payment_status.value:
+            history = list(payment.status_history or [])
+            history.append({'status': new_status, 'at': datetime.now().isoformat()})
+            kwargs['status_history'] = history
+        return super().update(_id, session=session, **kwargs)

--- a/server/app/utils/payment.py
+++ b/server/app/utils/payment.py
@@ -15,31 +15,77 @@ Configuration.account_id = Config.YOOKASSA_SHOP_ID or ''
 Configuration.secret_key = Config.YOOKASSA_SECRET_KEY or ''
 
 
-def create_payment(booking: Booking, return_url: str) -> Payment:
-    """Create a payment in YooKassa and persist Payment model."""
-    amount = {
-        'value': str(booking.total_price),
-        'currency': booking.currency.value,
+def generate_receipt(booking: Booking) -> Dict[str, Any]:
+    """Form receipt object with passenger categories, discounts and fees."""
+    currency = booking.currency.value.upper()
+    counts = booking.passenger_counts or {}
+    total_passengers = sum(counts.values()) or 1
+    base_per_passenger = booking.fare_price / total_passengers
+
+    items = []
+    for category, count in counts.items():
+        if count <= 0:
+            continue
+        items.append({
+            'description': f'Ticket {category}',
+            'quantity': count,
+            'amount': {'value': f'{base_per_passenger:.2f}', 'currency': currency},
+            'vat_code': 1,
+            'payment_mode': 'full_payment',
+            'payment_subject': 'service',
+        })
+
+    if booking.total_discounts:
+        items.append({
+            'description': 'Discount',
+            'quantity': 1,
+            'amount': {'value': f'-{booking.total_discounts:.2f}', 'currency': currency},
+            'vat_code': 1,
+            'payment_mode': 'full_payment',
+            'payment_subject': 'service',
+        })
+
+    if booking.fees:
+        items.append({
+            'description': 'Fees',
+            'quantity': 1,
+            'amount': {'value': f'{booking.fees:.2f}', 'currency': currency},
+            'vat_code': 1,
+            'payment_mode': 'full_payment',
+            'payment_subject': 'service',
+        })
+
+    return {
+        'customer': {'email': booking.email_address},
+        'items': items,
     }
-    yoo_payment: Any = YooPayment.create(
-        {
-            'amount': amount,
-            'confirmation': {'type': 'embedded', 'return_url': return_url},
-            'capture': True,
-            'description': f'Booking {booking.booking_number}',
-        },
-        uuid.uuid4(),
-    )
+
+
+def create_payment(booking: Booking) -> Payment:
+    """Create a two-stage payment in YooKassa and persist model."""
+    amount = {
+        'value': f'{booking.total_price:.2f}',
+        'currency': booking.currency.value.upper(),
+    }
+    body: Dict[str, Any] = {
+        'amount': amount,
+        'confirmation': {'type': 'embedded'},
+        'capture': False,
+        'description': f'Booking {booking.booking_number or booking.id}',
+        'metadata': {'booking_id': booking.id},
+    }
+    yoo_payment: Any = YooPayment.create(body, uuid.uuid4())
 
     payment = Payment.create(
         db.session,
         booking_id=booking.id,
-        payment_method=Config.PAYMENT_METHOD.card,
+        payment_method=Config.PAYMENT_METHOD.yookassa,
         payment_status=Config.PAYMENT_STATUS.pending,
         amount=booking.total_price,
         currency=booking.currency,
         provider_payment_id=yoo_payment.id,
         confirmation_token=(yoo_payment.confirmation or {}).get('confirmation_token'),
+        meta=body['metadata'],
     )
 
     Booking.transition_status(
@@ -49,8 +95,25 @@ def create_payment(booking: Booking, return_url: str) -> Payment:
     return payment
 
 
+def capture_payment(payment: Payment) -> None:
+    """Capture authorized payment with receipt and booking number."""
+    booking = payment.booking
+    receipt = generate_receipt(booking)
+    body: Dict[str, Any] = {
+        'amount': {
+            'value': f'{payment.amount:.2f}',
+            'currency': payment.currency.value.upper(),
+        },
+        'receipt': receipt,
+        'airline': {'booking_reference': booking.booking_number},
+        'metadata': {'booking_id': booking.id, 'booking_number': booking.booking_number},
+    }
+    YooPayment.capture(payment.provider_payment_id, body)
+
+
 def handle_webhook(payload: Dict[str, Any]) -> None:
     """Process YooKassa webhook notifications."""
+    event = payload.get('event')
     obj = payload.get('object') or {}
     provider_id = obj.get('id')
     status = obj.get('status')
@@ -62,20 +125,22 @@ def handle_webhook(payload: Dict[str, Any]) -> None:
     if not payment:
         return
 
-    try:
-        payment.payment_status = Config.PAYMENT_STATUS(status)
-    except ValueError:
-        pass
-
-    db.session.add(payment)
-
+    updates: Dict[str, Any] = {'payment_status': status, 'last_webhook': payload}
     if status == Config.PAYMENT_STATUS.succeeded.value:
-        Booking.transition_status(
-            id=payment.booking_id, session=db.session, to_status='payment_confirmed'
-        )
-    elif status == Config.PAYMENT_STATUS.canceled.value:
+        updates['is_paid'] = True
+    Payment.update(payment.id, session=db.session, **updates)
+
+    if event == 'payment.waiting_for_capture':
+        Booking.generate_booking_number(payment.booking_id, session=db.session)
+        api_payment = YooPayment.find_one(provider_id)
+        if api_payment.status == Config.PAYMENT_STATUS.waiting_for_capture.value:
+            capture_payment(payment)
+    elif event == 'payment.canceled':
         Booking.transition_status(
             id=payment.booking_id, session=db.session, to_status='payment_failed'
         )
+    elif event == 'payment.succeeded':
+        Booking.transition_status(
+            id=payment.booking_id, session=db.session, to_status='payment_confirmed'
+        )
 
-    db.session.commit()

--- a/server/migrations/versions/b21bf0d7b1c3_add_fields_to_payment.py
+++ b/server/migrations/versions/b21bf0d7b1c3_add_fields_to_payment.py
@@ -1,0 +1,31 @@
+"""add fields to payment
+
+Revision ID: b21bf0d7b1c3
+Revises: 06bfaade332a
+Create Date: 2025-10-08 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'b21bf0d7b1c3'
+down_revision = '06bfaade332a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('payments', sa.Column('is_paid', sa.Boolean(), nullable=False, server_default=sa.text('false')))
+    op.add_column('payments', sa.Column('status_history', postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default='[]'))
+    op.add_column('payments', sa.Column('last_webhook', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('payments', sa.Column('meta', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.alter_column('payments', 'is_paid', server_default=None)
+
+
+def downgrade():
+    op.drop_column('payments', 'meta')
+    op.drop_column('payments', 'last_webhook')
+    op.drop_column('payments', 'status_history')
+    op.drop_column('payments', 'is_paid')


### PR DESCRIPTION
## Summary
- add payment metadata and webhook tracking fields
- implement two-stage Yookassa payment flow with receipt generation
- handle webhooks and capture after PNR generation
- add configurable Flask service to mock Yookassa in docker-compose

## Testing
- `SERVER_JWT_EXP_HOURS=1 SERVER_SECRET_KEY=secret SERVER_DATABASE_URI=sqlite:///:memory: SERVER_MAIL_SERVER=localhost SERVER_MAIL_PORT=25 SERVER_MAIL_DEFAULT_SENDER=test@example.com SERVER_MAIL_USE_TLS=False SERVER_MAIL_USE_SSL=False pytest -q` *(fails: Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set)*

------
https://chatgpt.com/codex/tasks/task_e_689c3ee6c884832fa8a4dd8d167c82b9