### PR TITLE
feat: allow switching to yookassa mock

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -10,6 +10,8 @@ SERVER_JWT_EXP_HOURS='72'
 # YooKassa configuration
 YOOKASSA_SHOP_ID='123456789'
 YOOKASSA_SECRET_KEY='123456789'
+YOOKASSA_USE_MOCK='False'
+YOOKASSA_MOCK_URL='http://yookassa-mock:8000'
 
 # Client configuration
 REACT_APP_APP_ENV='dev'

--- a/mock_yookassa/app.py
+++ b/mock_yookassa/app.py
@@ -42,6 +42,14 @@ def create_payment():
     return jsonify(payment)
 
 
+@app.get("/payments/<payment_id>")
+def get_payment(payment_id):
+    payment = payments.get(payment_id)
+    if not payment:
+        return jsonify({"message": "Not found"}), 404
+    return jsonify(payment)
+
+
 @app.post("/payments/<payment_id>/capture")
 def capture_payment(payment_id):
     payment = payments.get(payment_id)

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -34,6 +34,14 @@ class Config:
     # Yookassa settings
     YOOKASSA_SHOP_ID = os.environ.get('YOOKASSA_SHOP_ID')
     YOOKASSA_SECRET_KEY = os.environ.get('YOOKASSA_SECRET_KEY')
+    YOOKASSA_USE_MOCK = os.environ.get('YOOKASSA_USE_MOCK', 'False').lower() == 'true'
+    _DEFAULT_API_URL = 'https://api.yookassa.ru/v3'
+    _DEFAULT_MOCK_URL = 'http://yookassa-mock:8000'
+    YOOKASSA_API_URL = (
+        os.environ.get('YOOKASSA_MOCK_URL', _DEFAULT_MOCK_URL)
+        if YOOKASSA_USE_MOCK
+        else os.environ.get('YOOKASSA_API_URL', _DEFAULT_API_URL)
+    )
 
     # Enum classes
     class USER_ROLE(enum.Enum):

--- a/server/app/utils/payment.py
+++ b/server/app/utils/payment.py
@@ -15,6 +15,7 @@ from app.utils.business_logic import calculate_price_details
 # Configure YooKassa SDK
 Configuration.account_id = Config.YOOKASSA_SHOP_ID or ''
 Configuration.secret_key = Config.YOOKASSA_SECRET_KEY or ''
+Configuration.api_url = Config.YOOKASSA_API_URL
 
 
 def generate_receipt(booking: Booking) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add toggle to config for using yookassa mock service
- support custom API url and example env vars
- extend mock service with endpoint to retrieve payment info

## Testing
- `cd server && pytest` *(fails: OperationalError: connection to server at "postgres" failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c50cfdc4c832fb572614278a710e9