### PR TITLE
Add application scope and term to fees

### DIFF
--- a/client/src/components/admin/FeeManagement.js
+++ b/client/src/components/admin/FeeManagement.js
@@ -6,7 +6,13 @@ import AdminDataTable from '../../components/admin/AdminDataTable';
 import { fetchFees, createFee, updateFee, deleteFee, deleteAllFees } from '../../redux/actions/fee';
 import { createAdminManager } from './utils';
 import { FIELD_TYPES, formatNumber } from '../utils';
-import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES } from '../../constants';
+import {
+       FIELD_LABELS,
+       UI_LABELS,
+       VALIDATION_MESSAGES,
+       ENUM_LABELS,
+       getEnumOptions,
+} from '../../constants';
 
 const FeeManagement = () => {
 	const dispatch = useDispatch();
@@ -25,15 +31,33 @@ const FeeManagement = () => {
 			type: FIELD_TYPES.TEXT,
 			validate: (value) => (!value ? VALIDATION_MESSAGES.FEE.name.REQUIRED : null),
 		},
-		amount: {
-			key: 'amount',
-			apiKey: 'amount',
-			label: FIELD_LABELS.FEE.amount,
-			type: FIELD_TYPES.NUMBER,
-			float: true,
-			formatter: (value) => (value != null ? formatNumber(value) : ''),
-			validate: (value) => (value == null ? VALIDATION_MESSAGES.FEE.amount.REQUIRED : null),
-		},
+                amount: {
+                        key: 'amount',
+                        apiKey: 'amount',
+                        label: FIELD_LABELS.FEE.amount,
+                        type: FIELD_TYPES.NUMBER,
+                        float: true,
+                        formatter: (value) => (value != null ? formatNumber(value) : ''),
+                        validate: (value) => (value == null ? VALIDATION_MESSAGES.FEE.amount.REQUIRED : null),
+                },
+                application: {
+                        key: 'application',
+                        apiKey: 'application',
+                        label: FIELD_LABELS.FEE.application,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('FEE_APPLICATION'),
+                        formatter: (value) => ENUM_LABELS.FEE_APPLICATION[value] || value,
+                        validate: (value) => (!value ? VALIDATION_MESSAGES.FEE.application.REQUIRED : null),
+                },
+                applicationTerm: {
+                        key: 'applicationTerm',
+                        apiKey: 'application_term',
+                        label: FIELD_LABELS.FEE.application_term,
+                        type: FIELD_TYPES.SELECT,
+                        options: getEnumOptions('FEE_TERM'),
+                        formatter: (value) => ENUM_LABELS.FEE_TERM[value] || value,
+                        validate: (value) => (!value ? VALIDATION_MESSAGES.FEE.application_term.REQUIRED : null),
+                },
 		description: {
 			key: 'description',
 			apiKey: 'description',

--- a/client/src/constants/enumLabels.js
+++ b/client/src/constants/enumLabels.js
@@ -8,12 +8,17 @@ export const ENUM_LABELS = {
 		infant: 'Младенец',
 		child: 'Ребенок',
 	},
-	BOOKING_STATUS: {
-		created: 'Создано',
-		pending_payment: 'Ожидает оплаты',
-		confirmed: 'Подтверждено',
-		cancelled: 'Отменено',
-	},
+        BOOKING_STATUS: {
+                created: 'Создано',
+                passengers_added: 'Пассажиры добавлены',
+                confirmed: 'Подтверждено',
+                payment_pending: 'Ожидает оплаты',
+                payment_confirmed: 'Оплата подтверждена',
+                payment_failed: 'Ошибка оплаты',
+                completed: 'Завершено',
+                expired: 'Истекло',
+                cancelled: 'Отменено',
+        },
 	USER_ROLE: {
 		admin: 'Администратор',
 		standard: 'Стандартный пользователь',
@@ -48,16 +53,25 @@ export const ENUM_LABELS = {
 		economy: 'Эконом',
 		business: 'Бизнес',
 	},
-	PAYMENT_STATUS: {
-		pending: 'В ожидании',
-		paid: 'Оплачено',
-		refunded: 'Возвращено',
-		failed: 'Ошибка',
-	},
-	PAYMENT_METHOD: {
-		card: 'Банковская карта',
-		cash: 'Наличные',
-	},
+        PAYMENT_STATUS: {
+                pending: 'Создан',
+                waiting_for_capture: 'Ожидает подтверждения',
+                succeeded: 'Оплачен',
+                canceled: 'Отменён',
+        },
+        PAYMENT_METHOD: {
+                yookassa: 'ЮKassa',
+        },
+        FEE_APPLICATION: {
+                booking: 'Бронирование',
+                cancellation: 'Отмена бронирования',
+        },
+        FEE_TERM: {
+                none: 'Не применяется',
+                before_24h: 'Более чем за 24 часа до рейса',
+                within_24h: 'Менее чем за 24 часа до рейса',
+                after_departure: 'После вылета рейса',
+        },
 };
 
 export const getEnumOptions = (enumType) => {

--- a/client/src/constants/fieldLabels.js
+++ b/client/src/constants/fieldLabels.js
@@ -4,11 +4,13 @@ export const FIELD_LABELS = {
 		discount_type: 'Тип скидки',
 		percentage_value: 'Процент скидки',
 	},
-	FEE: {
-		name: 'Наименование сбора',
-		description: 'Описание',
-		amount: 'Сумма',
-	},
+        FEE: {
+                name: 'Наименование сбора',
+                description: 'Описание',
+                amount: 'Сумма',
+                application: 'Применение сбора',
+                application_term: 'Срок применения сбора',
+        },
 	BOOKING: {
 		booking_number: 'Номер бронирования',
 		booking_date: 'Дата бронирования',

--- a/client/src/constants/validationMessages.js
+++ b/client/src/constants/validationMessages.js
@@ -17,14 +17,20 @@ export const VALIDATION_MESSAGES = {
 		},
 	},
 
-	FEE: {
-		name: {
-			REQUIRED: 'Наименование сбора обязательно',
-		},
-		amount: {
-			REQUIRED: 'Сумма обязательна',
-		},
-	},
+        FEE: {
+                name: {
+                        REQUIRED: 'Наименование сбора обязательно',
+                },
+                amount: {
+                        REQUIRED: 'Сумма обязательна',
+                },
+                application: {
+                        REQUIRED: 'Применение сбора обязательно',
+                },
+                application_term: {
+                        REQUIRED: 'Срок применения сбора обязателен',
+                },
+        },
 
 	AIRPORT: {
 		name: {

--- a/server/app/config.py
+++ b/server/app/config.py
@@ -94,6 +94,16 @@ class Config:
     class PAYMENT_METHOD(enum.Enum):
         yookassa = 'yookassa'
 
+    class FEE_APPLICATION(enum.Enum):
+        booking = 'booking'
+        cancellation = 'cancellation'
+
+    class FEE_TERM(enum.Enum):
+        none = 'none'
+        before_24h = 'before_24h'
+        within_24h = 'within_24h'
+        after_departure = 'after_departure'
+
     # Default variables
     DEFAULT_USER_ROLE = USER_ROLE.standard
     DEFAULT_BOOKING_STATUS = BOOKING_STATUS.created

--- a/server/app/models/fee.py
+++ b/server/app/models/fee.py
@@ -1,3 +1,4 @@
+from app.config import Config
 from app.database import db
 from app.models._base_model import BaseModel
 
@@ -8,6 +9,10 @@ class Fee(BaseModel):
     name = db.Column(db.String, unique=True, nullable=False)
     description = db.Column(db.String, nullable=True)
     amount = db.Column(db.Float, nullable=False)
+    application = db.Column(db.Enum(Config.FEE_APPLICATION), nullable=False)
+    application_term = db.Column(
+        db.Enum(Config.FEE_TERM), nullable=False, default=Config.FEE_TERM.none
+    )
 
     def to_dict(self, return_children=False):
         return {
@@ -15,8 +20,40 @@ class Fee(BaseModel):
             'name': self.name,
             'description': self.description,
             'amount': self.amount,
+            'application': self.application.value,
+            'application_term': self.application_term.value,
         }
 
     @classmethod
     def get_all(cls):
         return super().get_all(sort_by=['name'], descending=False)
+
+    @classmethod
+    def get_applicable(cls, application, hours_before_departure=None):
+        query = cls.query.filter_by(application=application)
+        if application == Config.FEE_APPLICATION.booking:
+            query = query.filter_by(application_term=Config.FEE_TERM.none)
+        else:
+            if hours_before_departure is None:
+                term = Config.FEE_TERM.after_departure
+            elif hours_before_departure > 24:
+                term = Config.FEE_TERM.before_24h
+            elif hours_before_departure >= 0:
+                term = Config.FEE_TERM.within_24h
+            else:
+                term = Config.FEE_TERM.after_departure
+            query = query.filter_by(application_term=term)
+        return query.all()
+
+    @classmethod
+    def calculate_fees(
+        cls, passengers_count, application, hours_before_departure=None
+    ):
+        fees = cls.get_applicable(application, hours_before_departure)
+        result = []
+        total = 0.0
+        for fee in fees:
+            fee_total = fee.amount * passengers_count
+            result.append({'name': fee.name, 'amount': fee.amount, 'total': fee_total})
+            total += fee_total
+        return result, total

--- a/server/app/utils/business_logic.py
+++ b/server/app/utils/business_logic.py
@@ -1,3 +1,4 @@
+from app.config import Config
 from app.models.tariff import Tariff
 from app.models.flight_tariff import FlightTariff
 from app.models.fee import Fee
@@ -110,13 +111,11 @@ def calculate_price_details(outbound_id, return_id, tariff_id, passengers):
         })
 
     total_passengers = sum(passengers.values())
-    fees = []
-    for fee in Fee.get_all():
-        fee_total = fee.amount * total_passengers
-        fees.append(
-            {'name': fee.name, 'amount': fee.amount, 'total': fee_total}
-        )
-        total_price += fee_total
+    fees, fees_total = Fee.calculate_fees(
+        passengers_count=total_passengers,
+        application=Config.FEE_APPLICATION.booking,
+    )
+    total_price += fees_total
 
     return {
         'tariff': tariff_info,


### PR DESCRIPTION
## Summary
- extend fee model with application type and term enums
- update booking price calculation to apply only relevant fees
- expose new fee fields in admin UI and constants
- align client enum labels with server configuration

## Testing
- `pytest` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType')*
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e24498f68832fbdbe9b53027ddd0b