### PR TITLE
Add booking payment expiry and client countdown

### DIFF
--- a/client/src/components/booking/Payment.js
+++ b/client/src/components/booking/Payment.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Box, Card, CardContent, Typography, Button, Alert } from '@mui/material';
@@ -14,13 +14,26 @@ const Payment = () => {
 	const { publicId } = useParams();
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
-	const booking = useSelector((state) => state.bookingProcess.current);
-	const payment = useSelector((state) => state.payment.current);
+        const booking = useSelector((state) => state.bookingProcess.current);
+        const payment = useSelector((state) => state.payment.current);
+        const [timeLeft, setTimeLeft] = useState(null);
 
-	useEffect(() => {
-		dispatch(fetchBookingDetails(publicId));
-		dispatch(createPayment({ public_id: publicId, return_url: window.location.href }));
-	}, [dispatch, publicId]);
+        useEffect(() => {
+                dispatch(fetchBookingDetails(publicId));
+                dispatch(createPayment({ public_id: publicId, return_url: window.location.href }));
+        }, [dispatch, publicId]);
+
+        useEffect(() => {
+                if (!payment?.expires_at) return;
+                const expiry = new Date(payment.expires_at).getTime();
+                const tick = () => {
+                        const diff = expiry - Date.now();
+                        setTimeLeft(diff > 0 ? diff : 0);
+                };
+                tick();
+                const interval = setInterval(tick, 1000);
+                return () => clearInterval(interval);
+        }, [payment?.expires_at]);
 
 	const status = booking?.status;
 
@@ -47,9 +60,19 @@ const Payment = () => {
 		return UI_LABELS.SCHEDULE.from_to(origin.city_name || origin.iata_code, dest.city_name || dest.iata_code);
 	};
 
-	const routeInfo = getRouteInfo(booking?.flights?.[0]);
+        const routeInfo = getRouteInfo(booking?.flights?.[0]);
 
-	const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
+        const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
+
+        const formatTime = (ms) => {
+                const total = Math.floor(ms / 1000);
+                const hours = Math.floor(total / 3600);
+                const minutes = Math.floor((total % 3600) / 60);
+                const seconds = total % 60;
+                return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds
+                        .toString()
+                        .padStart(2, '0')}`;
+        };
 
 	return (
 		<Base maxWidth='lg'>
@@ -62,10 +85,15 @@ const Payment = () => {
 								{routeInfo}
 							</Typography>
 						)}
-						<Typography variant='body1' sx={{ mb: 2 }}>
-							{UI_LABELS.BOOKING.buyer_form.summary.total}: {formatNumber(booking?.total_price || 0)}{' '}
-							{currencySymbol}
-						</Typography>
+                                                <Typography variant='body1' sx={{ mb: 2 }}>
+                                                        {UI_LABELS.BOOKING.buyer_form.summary.total}: {formatNumber(booking?.total_price || 0)}{' '}
+                                                        {currencySymbol}
+                                                </Typography>
+                                                {payment?.expires_at && timeLeft !== null && (
+                                                        <Typography variant='body2' sx={{ mb: 2 }}>
+                                                                {UI_LABELS.BOOKING.payment_time_left || 'Time left to pay'}: {formatTime(timeLeft)}
+                                                        </Typography>
+                                                )}
 						{status === 'payment_failed' && (
 							<Alert severity='error' sx={{ mb: 2 }}>
 								{UI_LABELS.BOOKING.payment_failed || 'Payment failed'}

--- a/server/app/models/payment.py
+++ b/server/app/models/payment.py
@@ -42,6 +42,7 @@ class Payment(BaseModel):
             'currency': self.currency.value if self.currency else None,
             'provider_payment_id': self.provider_payment_id,
             'confirmation_token': self.confirmation_token,
+            'expires_at': (self.meta or {}).get('expires_at'),
             'is_paid': self.is_paid,
             'status_history': self.status_history,
             'last_webhook': self.last_webhook,

--- a/server/app/utils/payment.py
+++ b/server/app/utils/payment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import uuid
 from typing import Any, Dict
+from datetime import datetime, timedelta
 
 from yookassa import Configuration, Payment as YooPayment
 
@@ -87,12 +88,13 @@ def create_payment(booking: Booking) -> Payment:
         'value': f'{booking.total_price:.2f}',
         'currency': booking.currency.value.upper(),
     }
+    expires_at = datetime.utcnow() + timedelta(hours=1)
     body: Dict[str, Any] = {
         'amount': amount,
         'confirmation': {'type': 'embedded'},
         'capture': False,
         'description': f'Booking {booking.booking_number or booking.id}',
-        'metadata': {'booking_id': booking.id},
+        'metadata': {'booking_id': booking.id, 'expires_at': expires_at.isoformat()},
     }
     yoo_payment: Any = YooPayment.create(body, uuid.uuid4())
 


### PR DESCRIPTION
## Summary
- return payment expiration timestamp from server
- show countdown timer on booking payment page

## Testing
- `pytest` *(fails: SERVER_JWT_EXP_HOURS env var missing)*
- `CI=true npm test` *(fails: No tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689eac93ab5c832fa1bb1233de009732