### PR TITLE
Parse date field bounds before rendering

### DIFF
--- a/client/src/components/utils/formField.js
+++ b/client/src/components/utils/formField.js
@@ -161,30 +161,31 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				);
 			}
 
-			case FIELD_TYPES.DATE: {
-				const { value, onChange, fullWidth, error, helperText, sx, minDate, textFieldProps, size } = allProps;
-				return (
-					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
-						<DatePicker
-							label={field.label}
-							value={value ? parseDate(value) : null}
-							onChange={(date) => onChange(formatDate(date, DATE_API_FORMAT))}
-							minDate={minDate}
-							format={field.dateFormat || DATE_FORMAT}
-							slotProps={{
-								textField: {
-									fullWidth,
-									error,
-									helperText: error ? helperText : '',
-									sx,
-									size,
-									...textFieldProps,
-								},
-							}}
-						/>
-					</LocalizationProvider>
-				);
-			}
+                        case FIELD_TYPES.DATE: {
+                                const { value, onChange, fullWidth, error, helperText, sx, minDate, maxDate, textFieldProps, size } = allProps;
+                                return (
+                                        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
+                                                <DatePicker
+                                                        label={field.label}
+                                                        value={value ? parseDate(value) : null}
+                                                        onChange={(date) => onChange(formatDate(date, DATE_API_FORMAT))}
+                                                        minDate={minDate ? parseDate(minDate) : undefined}
+                                                        maxDate={maxDate ? parseDate(maxDate) : undefined}
+                                                        format={field.dateFormat || DATE_FORMAT}
+                                                        slotProps={{
+                                                                textField: {
+                                                                        fullWidth,
+                                                                        error,
+                                                                        helperText: error ? helperText : '',
+                                                                        sx,
+                                                                        size,
+                                                                        ...textFieldProps,
+                                                                },
+                                                        }}
+                                                />
+                                        </LocalizationProvider>
+                                );
+                        }
 
 			case FIELD_TYPES.TIME: {
 				const { value, onChange, fullWidth, error, helperText, sx, textFieldProps, size } = allProps;


### PR DESCRIPTION
## Summary
- ensure date pickers parse `minDate`/`maxDate` values so props are always Date objects

## Testing
- `CI=true npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a026b7f16c832fa25142cb07d0376c