### PR TITLE
Use config enums throughout server

### DIFF
--- a/server/app/utils/business_logic.py
+++ b/server/app/utils/business_logic.py
@@ -66,24 +66,27 @@ def calculate_price_details(outbound_id, outbound_tariff_id, return_id, return_t
             multiplier = 1.0
             applied_discounts = []
 
-            if tariff.seat_class.value == 'economy':
+            if tariff.seat_class == Config.SEAT_CLASS.economy:
                 if category == 'infants':
-                    pct = discount_pct.get('infant', 0.0)
+                    infant_key = Config.DISCOUNT_TYPE.infant.value
+                    pct = discount_pct.get(infant_key, 0.0)
                     multiplier *= (1.0 - pct)
-                    if 'infant' in discount_names_map:
-                        applied_discounts.append(discount_names_map['infant'])
+                    if infant_key in discount_names_map:
+                        applied_discounts.append(discount_names_map[infant_key])
                 elif category == 'children':
-                    pct = discount_pct.get('child', 0.0)
+                    child_key = Config.DISCOUNT_TYPE.child.value
+                    pct = discount_pct.get(child_key, 0.0)
                     multiplier *= (1.0 - pct)
-                    if 'child' in discount_names_map:
-                        applied_discounts.append(discount_names_map['child'])
+                    if child_key in discount_names_map:
+                        applied_discounts.append(discount_names_map[child_key])
 
                 if is_round_trip:
-                    pct_rt = discount_pct.get('round_trip', 0.0)
+                    rt_key = Config.DISCOUNT_TYPE.round_trip.value
+                    pct_rt = discount_pct.get(rt_key, 0.0)
                     multiplier *= (1.0 - pct_rt)
-                    if 'round_trip' in discount_names_map:
+                    if rt_key in discount_names_map:
                         applied_discounts.append(
-                            discount_names_map['round_trip']
+                            discount_names_map[rt_key]
                         )
 
             total_cost = fare_total * multiplier

--- a/server/tests/integration/test_process_booking_passengers.py
+++ b/server/tests/integration/test_process_booking_passengers.py
@@ -27,7 +27,7 @@ def test_process_booking_passengers_creates_and_updates(client, future_flight, c
         "buyer": {"email": "a@example.com", "phone": "+70000000000"},
         "passengers": [
             {
-                "category": "adult",
+                "category": Config.PASSENGER_CATEGORY.adult.value,
                 "first_name": "John",
                 "last_name": "Doe",
                 "gender": Config.GENDER.м.value,
@@ -64,7 +64,7 @@ def test_process_booking_passengers_validates_age(client, future_flight, country
         "buyer": {"email": "a@example.com", "phone": "+70000000000"},
         "passengers": [
             {
-                "category": "infant",
+                "category": Config.PASSENGER_CATEGORY.infant.value,
                 "first_name": "Baby",
                 "last_name": "Test",
                 "gender": Config.GENDER.м.value,
@@ -88,7 +88,7 @@ def test_process_booking_confirm(client, future_flight, country_ru):
         "buyer": {"email": "a@example.com", "phone": "+70000000000"},
         "passengers": [
             {
-                "category": "adult",
+                "category": Config.PASSENGER_CATEGORY.adult.value,
                 "first_name": "John",
                 "last_name": "Doe",
                 "gender": Config.GENDER.м.value,
@@ -105,4 +105,7 @@ def test_process_booking_confirm(client, future_flight, country_ru):
 
     res = client.post("/bookings/process/confirm", json={"public_id": str(booking.public_id)})
     assert res.status_code == 200
-    assert Booking.get_by_public_id(booking.public_id).status.value == "confirmed"
+    assert (
+        Booking.get_by_public_id(booking.public_id).status
+        == Config.BOOKING_STATUS.confirmed
+    )

--- a/server/tests/integration/test_search.py
+++ b/server/tests/integration/test_search.py
@@ -1,12 +1,14 @@
 import datetime
 
+from app.config import Config
+
 def test_search_flights(client, future_flight, economy_flight_tariff, economy_tariff):
     date_str = future_flight.scheduled_departure.strftime('%Y-%m-%d')
     resp = client.get('/search/flights', query_string={
         'from': 'SVO',
         'to': 'PWE',
         'when': date_str,
-        'class': 'economy',
+        'class': Config.SEAT_CLASS.economy.value,
     })
     assert resp.status_code == 200
     data = resp.get_json()
@@ -30,7 +32,7 @@ def test_search_price_by_class(
             'from': 'SVO',
             'to': 'PWE',
             'when': date_str,
-            'class': 'business',
+            'class': Config.SEAT_CLASS.business.value,
             'adults': 1,
         },
     )


### PR DESCRIPTION
## Summary
- replace hardcoded discount and seat class strings with Config enums
- update integration tests to derive values from Config enums

## Testing
- `pytest` *(fails: Compiler can't render element of type JSONB with SQLite)*

------
https://chatgpt.com/codex/tasks/task_e_68a044cee0d0832fb659154bdbda0fc6