### PR TITLE
Handle creation and retrieval of booking payments

### DIFF
--- a/client/src/components/booking/Payment.js
+++ b/client/src/components/booking/Payment.js
@@ -19,9 +19,9 @@ const Payment = () => {
 	const [timeLeft, setTimeLeft] = useState(null);
 
 	useEffect(() => {
-		dispatch(fetchBookingDetails(publicId));
-		dispatch(createPayment({ public_id: publicId, return_url: window.location.href }));
-	}, [dispatch, publicId]);
+                dispatch(fetchBookingDetails(publicId));
+                dispatch(fetchPayment(publicId));
+        }, [dispatch, publicId]);
 
 	useEffect(() => {
 		if (!payment?.expires_at) return;
@@ -48,10 +48,10 @@ const Payment = () => {
 		dispatch(fetchPayment(publicId));
 	}, [dispatch, publicId]);
 
-	const handleError = useCallback(() => {
-		dispatch(fetchBookingDetails(publicId));
-		dispatch(fetchPayment(publicId));
-	}, [dispatch, publicId]);
+        const handleError = useCallback(() => {
+                dispatch(fetchBookingDetails(publicId));
+                dispatch(fetchPayment(publicId));
+        }, [dispatch, publicId]);
 
 	const getRouteInfo = (flight) => {
 		if (!flight?.route) return null;

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -9,7 +9,7 @@ from app.models.payment import Payment
 from app.middlewares.auth_middleware import admin_required, current_user
 from app.utils.business_logic import calculate_price_details
 from app.utils.payment import create_payment, handle_webhook
-from app.utils.enum import BOOKING_STATUS, PASSENGER_CATEGORY
+from app.utils.enum import BOOKING_STATUS, PASSENGER_CATEGORY, PAYMENT_STATUS
 
 
 @admin_required
@@ -270,11 +270,14 @@ def get_booking_payment(current_user, public_id):
     booking = Booking.get_by_public_id(public_id)
     payment = (
         Payment.query.filter_by(booking_id=booking.id)
+        .filter(
+            Payment.payment_status.notin_(
+                [PAYMENT_STATUS.succeeded, PAYMENT_STATUS.canceled]
+            )
+        )
         .order_by(Payment.id.desc())
-        .first()
+        .first_or_404()
     )
-    if not payment:
-        return jsonify({'message': 'payment not found'}), 404
     return jsonify(payment.to_dict()), 200
 
 


### PR DESCRIPTION
## Summary
- Create Yookassa payment when confirming booking and navigate after token received
- Fetch latest active payment on payment page instead of creating duplicate
- Avoid duplicate payment creation by checking for existing pending payment on server
- Return only active payments when requesting payment details
- Show loading spinner before redirect to payment page
- Use first_or_404 for retrieving payments
- Hide confirmation details until booking data has fully loaded using bookingProcess.isLoading selector

## Testing
- ✅ `cd client && CI=true npm test -- --passWithNoTests`
- ❌ `SERVER_JWT_EXP_HOURS=1 SERVER_DATABASE_URI=sqlite:// SERVER_TEST_DATABASE_URI=sqlite:// pytest` (ModuleNotFoundError: No module named 'tests.fixtures')


------
https://chatgpt.com/codex/tasks/task_e_68a14c22cecc832fb113132d034be704