### PR TITLE
feat: add transactional booking payments with detailed receipts

### DIFF
--- a/server/app/app.py
+++ b/server/app/app.py
@@ -57,6 +57,19 @@ def __create_app(_config_class, _db):
     init_mail(app)
     register_error_handlers(app)
 
+    @app.teardown_request
+    def teardown_transaction(exception=None):
+        session = db.session
+        if exception:
+            session.rollback()
+        else:
+            try:
+                session.commit()
+            except Exception:
+                session.rollback()
+                raise
+        session.remove()
+
     # auth
     app.route('/register', methods=['POST'])(register)
     app.route('/login', methods=['POST'])(login)

--- a/server/app/controllers/auth_controller.py
+++ b/server/app/controllers/auth_controller.py
@@ -80,7 +80,6 @@ def reset_password():
 
     user = User.change_password(token.user_id, password)
     token.used = True
-    db.session.commit()
     if user:
         token_jwt = signJWT(user.email)
         return jsonify({'token': token_jwt, 'user': user.to_dict()}), 200

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -80,34 +80,37 @@ def create_booking_process(current_user):
         passengers,
     )
 
-    booking = Booking.create(
-        session,
-        currency=price['currency'],
-        fare_price=price['fare_price'],
-        fees=sum(f['total'] for f in price['fees']),
-        total_discounts=price['total_discounts'],
-        total_price=price['total_price'],
-        passenger_counts=passengers,
-        user_id=current_user.id if current_user else None,
-    )
+    with session.begin():
+        booking = Booking.create(
+            session,
+            commit=False,
+            currency=price['currency'],
+            fare_price=price['fare_price'],
+            fees=sum(f['total'] for f in price['fees']),
+            total_discounts=price['total_discounts'],
+            total_price=price['total_price'],
+            passenger_counts=passengers,
+            user_id=current_user.id if current_user else None,
+        )
 
-    if outbound_id:
-        BookingFlight.create(
-            session,
-            booking_id=booking.id,
-            flight_id=outbound_id,
-            tariff_id=outbound_tariff_id,
-        )
-    if return_id:
-        BookingFlight.create(
-            session,
-            booking_id=booking.id,
-            flight_id=return_id,
-            tariff_id=return_tariff_id,
-        )
+        if outbound_id:
+            BookingFlight.create(
+                session,
+                commit=False,
+                booking_id=booking.id,
+                flight_id=outbound_id,
+                tariff_id=outbound_tariff_id,
+            )
+        if return_id:
+            BookingFlight.create(
+                session,
+                commit=False,
+                booking_id=booking.id,
+                flight_id=return_id,
+                tariff_id=return_tariff_id,
+            )
 
     session.refresh(booking)
-
     result = {'public_id': str(booking.public_id)}
     return jsonify(result), 201
 
@@ -123,46 +126,70 @@ def create_booking_passengers(current_user):
 
     session = db.session
 
-    booking = Booking.update_by_public_id(
-        public_id,
-        session=session,
-        **buyer
-    )
+    with session.begin():
+        booking = Booking.update_by_public_id(
+            public_id,
+            session=session,
+            commit=False,
+            **buyer
+        )
 
-    existing = {bp.passenger_id: bp for bp in booking.booking_passengers}
-    processed_ids = set()
-    for pdata in passengers:
-        pid = pdata.get('id')
-        category = pdata.get('category')
+        existing = {bp.passenger_id: bp for bp in booking.booking_passengers}
+        processed_ids = set()
+        for pdata in passengers:
+            pid = pdata.get('id')
+            category = pdata.get('category')
 
-        passenger_fields = {k: v for k, v in {
-            'first_name': pdata.get('first_name'),
-            'last_name': pdata.get('last_name'),
-            'patronymic_name': pdata.get('patronymic_name'),
-            'gender': pdata.get('gender'),
-            'birth_date': pdata.get('birth_date'),
-            'document_type': pdata.get('document_type'),
-            'document_number': pdata.get('document_number'),
-            'document_expiry_date': pdata.get('document_expiry_date'),
-            'citizenship_id': pdata.get('citizenship_id'),
-        }.items() if v is not None and v != ''}
-        if pid:
-            passenger = Passenger.update(pid, session=session, **passenger_fields)
-        else:
-            passenger = Passenger.create(session, **passenger_fields)
+            passenger_fields = {k: v for k, v in {
+                'first_name': pdata.get('first_name'),
+                'last_name': pdata.get('last_name'),
+                'patronymic_name': pdata.get('patronymic_name'),
+                'gender': pdata.get('gender'),
+                'birth_date': pdata.get('birth_date'),
+                'document_type': pdata.get('document_type'),
+                'document_number': pdata.get('document_number'),
+                'document_expiry_date': pdata.get('document_expiry_date'),
+                'citizenship_id': pdata.get('citizenship_id'),
+            }.items() if v is not None and v != ''}
+            if pid:
+                passenger = Passenger.update(
+                    pid,
+                    session=session,
+                    commit=False,
+                    **passenger_fields,
+                )
+            else:
+                passenger = Passenger.create(
+                    session,
+                    commit=False,
+                    **passenger_fields,
+                )
 
-        processed_ids.add(passenger.id)
-        bp = existing.get(passenger.id)
-        if bp:
-            BookingPassenger.update(bp.id, session=session, passenger_id=passenger.id, category=category)
-        else:
-            BookingPassenger.create(session, booking_id=booking.id, passenger_id=passenger.id, category=category)
+            processed_ids.add(passenger.id)
+            bp = existing.get(passenger.id)
+            if bp:
+                BookingPassenger.update(
+                    bp.id,
+                    session=session,
+                    commit=False,
+                    passenger_id=passenger.id,
+                    category=category,
+                )
+            else:
+                BookingPassenger.create(
+                    session,
+                    commit=False,
+                    booking_id=booking.id,
+                    passenger_id=passenger.id,
+                    category=category,
+                )
 
-    booking = Booking.transition_status(
-        id=booking.id,
-        session=session,
-        to_status=BOOKING_STATUS.passengers_added,
-    )
+        booking = Booking.transition_status(
+            id=booking.id,
+            session=session,
+            commit=False,
+            to_status=BOOKING_STATUS.passengers_added,
+        )
 
     return jsonify({'status': 'ok'}), 200
 
@@ -176,11 +203,13 @@ def confirm_booking(current_user):
 
     session = db.session
     booking = Booking.get_by_public_id(public_id)
-    Booking.transition_status(
-        id=booking.id,
-        session=session,
-        to_status=BOOKING_STATUS.confirmed,
-    )
+    with session.begin():
+        Booking.transition_status(
+            id=booking.id,
+            session=session,
+            commit=False,
+            to_status=BOOKING_STATUS.confirmed,
+        )
 
     return jsonify({'status': 'ok'}), 200
 

--- a/server/app/middlewares/error_handler.py
+++ b/server/app/middlewares/error_handler.py
@@ -5,6 +5,7 @@ from flask import jsonify, current_app
 from werkzeug.exceptions import HTTPException
 
 from app.models._base_model import ModelValidationError, NotFoundError
+from app.database import db
 
 
 def handle_exceptions(f: Callable[..., Any]) -> Callable[..., Any]:
@@ -34,16 +35,19 @@ def register_error_handlers(app):
 
     @app.errorhandler(ModelValidationError)
     def _handle_model_validation_error(e):
+        db.session.rollback()
         return jsonify({'errors': e.errors}), 400
 
     @app.errorhandler(NotFoundError)
     def _handle_not_found_error(e):
+        db.session.rollback()
         return jsonify({'message': str(e)}), 404
 
     @app.errorhandler(Exception)
     def _handle_unexpected_error(e):
         if isinstance(e, HTTPException):
             return e
+        db.session.rollback()
         app.logger.exception("Unhandled exception", exc_info=e)
         return jsonify({'message': 'Internal server error'}), 500
 


### PR DESCRIPTION
## Summary
- add Russian flight route info to payment receipt using price details
- ensure booking and payment operations run in DB transactions
- allow BaseModel operations to skip auto commit for atomic workflows
- commit or rollback DB session after each request to keep controllers atomic
- rollback sessions in error handlers and rely on request-level commit in auth flow
- default model CRUD helpers to flush so all controller calls participate in request transactions

## Testing
- `pytest` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType')*


------
https://chatgpt.com/codex/tasks/task_e_68a2a2075f24832fad4a071ca579046c