### PR TITLE
Fix payment session handling and commit control

### DIFF
--- a/server/app/utils/yookassa.py
+++ b/server/app/utils/yookassa.py
@@ -186,6 +186,7 @@ def create_payment(public_id: str) -> Payment:
         )
 
         session.flush()
+        session.commit()
         return payment
 
     except Exception as e:
@@ -251,3 +252,4 @@ def handle_webhook(payload: Dict[str, Any]) -> None:
         raise ValueError(f'Unknown event type: {event}')
 
     session.flush()
+    session.commit()


### PR DESCRIPTION
## Summary
- commit payment sessions in YooKassa helper and webhook to persist rows
- protect teardown session handler to commit/rollback only when a transaction is active

## Testing
- `python -m py_compile app/utils/yookassa.py app/middlewares/session_middleware.py app/models/_base_model.py app/models/payment.py app/controllers/booking_process_controller.py`
- `pytest` *(fails: int() argument must be a string, a bytes-like object or a real number, not 'NoneType')*


------
https://chatgpt.com/codex/tasks/task_e_68a351ccfb64832f8b9afb59d7b15e01