### PR TITLE
Standardize session commits across models

### DIFF
--- a/server/app/models/airline.py
+++ b/server/app/models/airline.py
@@ -58,7 +58,11 @@ class Airline(BaseModel):
         return generate_xlsx_template(cls.upload_fields, text_fields=cls.upload_text_fields)
 
     @classmethod
-    def upload_from_file(cls, file, session: Session | None = None):
+    def upload_from_file(
+        cls,
+        file,
+        session: Session | None = None,
+    ):
         session = session or db.session
         rows = parse_xlsx(
             file,
@@ -83,7 +87,8 @@ class Airline(BaseModel):
                         iata_code=str(row.get('iata_code')),
                         icao_code=str(row.get('icao_code')),
                         name=str(row.get('name')),
-                        country_id=country.id
+                        country_id=country.id,
+                        commit=False,
                     )
                     airlines.append(airline)
                 except Exception as e:
@@ -91,5 +96,7 @@ class Airline(BaseModel):
 
             if row.get('error'):
                 error_rows.append(row)
+
+        session.commit()
 
         return airlines, error_rows

--- a/server/app/models/airport.py
+++ b/server/app/models/airport.py
@@ -81,7 +81,11 @@ class Airport(BaseModel):
         return generate_xlsx_template(cls.upload_fields, text_fields=cls.upload_text_fields)
 
     @classmethod
-    def upload_from_file(cls, file, session: Session | None = None):
+    def upload_from_file(
+        cls,
+        file,
+        session: Session | None = None,
+    ):
         session = session or db.session
         rows = parse_xlsx(
             file,
@@ -120,6 +124,7 @@ class Airport(BaseModel):
                         city_code=str(row.get('city_code')),
                         country_id=country.id,
                         timezone_id=tz.id if tz else None,
+                        commit=False,
                     )
                     airports.append(airport)
                 except Exception as e:
@@ -127,5 +132,7 @@ class Airport(BaseModel):
 
             if row.get('error'):
                 error_rows.append(row)
+
+        session.commit()
 
         return airports, error_rows

--- a/server/app/models/booking.py
+++ b/server/app/models/booking.py
@@ -122,7 +122,13 @@ class Booking(BaseModel):
         )
 
     @classmethod
-    def create(cls, session: Session | None = None, **kwargs):
+    def create(
+        cls,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
         kwargs = cls.convert_enums(kwargs)
         status = kwargs.get('status', DEFAULT_BOOKING_STATUS)
@@ -131,7 +137,7 @@ class Booking(BaseModel):
             'at': datetime.now().isoformat()
         }]
         kwargs['status_history'] = history
-        return super().create(session, **kwargs)
+        return super().create(session, commit=commit, **kwargs)
 
     @classmethod
     def update(

--- a/server/app/models/flight.py
+++ b/server/app/models/flight.py
@@ -178,7 +178,11 @@ class Flight(BaseModel):
         )
 
     @classmethod
-    def upload_from_file(cls, file, session: Session | None = None):
+    def upload_from_file(
+        cls,
+        file,
+        session: Session | None = None,
+    ):
         session = session or db.session
         rows = parse_xlsx(
             file,
@@ -237,6 +241,7 @@ class Flight(BaseModel):
                         scheduled_departure_time=parse_time(row.get('scheduled_departure_time')),
                         scheduled_arrival=parse_date(row.get('scheduled_arrival')),
                         scheduled_arrival_time=parse_time(row.get('scheduled_arrival_time')),
+                        commit=False,
                     )
 
                     used_tariffs = {}
@@ -262,6 +267,7 @@ class Flight(BaseModel):
                             flight_id=flight.id,
                             tariff_id=tariff.id,
                             seats_number=seats_number,
+                            commit=False,
                         )
 
                     flights.append(flight)
@@ -270,6 +276,8 @@ class Flight(BaseModel):
 
             if row.get('error'):
                 error_rows.append(row)
+
+        session.commit()
 
         return flights, error_rows
 
@@ -302,7 +310,13 @@ class Flight(BaseModel):
                 {'flight_number': 'Flight with this number already exists for the given airline and route.'})
 
     @classmethod
-    def create(cls, session=None, **kwargs):
+    def create(
+        cls,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
         flight_number = kwargs.get('flight_number')
         airline_id = kwargs.get('airline_id')
@@ -311,10 +325,17 @@ class Flight(BaseModel):
         cls._check_flight_uniqueness(
             session, flight_number, airline_id, route_id, scheduled_departure
         )
-        return super().create(session, **kwargs)
+        return super().create(session, commit=commit, **kwargs)
 
     @classmethod
-    def update(cls, _id, session=None, **kwargs):
+    def update(
+        cls,
+        _id,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
         flight_number = kwargs.get('flight_number')
         airline_id = kwargs.get('airline_id')
@@ -323,4 +344,4 @@ class Flight(BaseModel):
         cls._check_flight_uniqueness(
             session, flight_number, airline_id, route_id, scheduled_departure, exclude_id=_id
         )
-        return super().update(_id, session, **kwargs)
+        return super().update(_id, session, commit=commit, **kwargs)

--- a/server/app/models/flight_tariff.py
+++ b/server/app/models/flight_tariff.py
@@ -1,5 +1,5 @@
 from typing import List, TYPE_CHECKING
-from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapped, Session
 
 from app.database import db
 from app.models._base_model import BaseModel, ModelValidationError
@@ -47,23 +47,36 @@ class FlightTariff(BaseModel):
             raise ModelValidationError({'seat_class': 'flight tariff for this class already exists'})
 
     @classmethod
-    def create(cls, session=None, **kwargs):
+    def create(
+        cls,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
         # Deprecated
         # flight_id = kwargs.get('flight_id')
         # tariff_id = kwargs.get('tariff_id')
         # if flight_id is not None and tariff_id is not None:
         #     cls.__check_seat_class_unique(session, flight_id, tariff_id)
-        return super().create(session, **kwargs)
+        return super().create(session, commit=commit, **kwargs)
 
     @classmethod
-    def update(cls, _id, session=None, **kwargs):
+    def update(
+        cls,
+        _id,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
         instance = cls.get_or_404(_id, session)
         # Deprecated
         # flight_id = kwargs.get('flight_id', instance.flight_id)
         # tariff_id = kwargs.get('tariff_id', instance.tariff_id)
         # if flight_id is not None and tariff_id is not None:
-            # cls.__check_seat_class_unique(session, flight_id, tariff_id, instance_id=_id)
+        #     cls.__check_seat_class_unique(session, flight_id, tariff_id, instance_id=_id)
 
-        return super().update(_id, session, **kwargs)
+        return super().update(_id, session, commit=commit, **kwargs)

--- a/server/app/models/password_reset_token.py
+++ b/server/app/models/password_reset_token.py
@@ -18,13 +18,27 @@ class PasswordResetToken(BaseModel):
     user: Mapped['User'] = db.relationship('User', back_populates='reset_tokens')
 
     @classmethod
-    def create(cls, user: User, session: Session | None = None, expires_in_hours=1):
+    def create(
+        cls,
+        user: User,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        expires_in_hours=1,
+    ):
         session = session or db.session
-        
+
         token = secrets.token_urlsafe(32)
         expires_at = datetime.now() + timedelta(hours=expires_in_hours)
 
-        return super().create(session=db.session, token=token, user_id=user.id, expires_at=expires_at, used=False)
+        return super().create(
+            session=session,
+            commit=commit,
+            token=token,
+            user_id=user.id,
+            expires_at=expires_at,
+            used=False,
+        )
 
     @classmethod
     def verify_token(cls, token):

--- a/server/app/models/payment.py
+++ b/server/app/models/payment.py
@@ -55,17 +55,30 @@ class Payment(BaseModel):
         return cls.query.filter(cls.provider_payment_id == provider_payment_id).first_or_404()
 
     @classmethod
-    def create(cls, session: Session | None = None, **kwargs):
+    def create(
+        cls,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
         kwargs = cls.convert_enums(kwargs)
         status = kwargs.get('payment_status', DEFAULT_PAYMENT_STATUS)
         kwargs['status_history'] = [
             {'status': status.value, 'at': datetime.now().isoformat()}
         ]
-        return super().create(session, **kwargs)
+        return super().create(session, commit=commit, **kwargs)
 
     @classmethod
-    def update(cls, _id, session: Session | None = None, **kwargs):
+    def update(
+        cls,
+        _id,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
         payment = cls.get_or_404(_id, session)
         kwargs = cls.convert_enums(kwargs)
@@ -79,4 +92,4 @@ class Payment(BaseModel):
                 'at': datetime.now().isoformat()
             })
             kwargs['status_history'] = history
-        return super().update(_id, session=session, **kwargs)
+        return super().update(_id, session=session, commit=commit, **kwargs)

--- a/server/app/models/tariff.py
+++ b/server/app/models/tariff.py
@@ -43,7 +43,13 @@ class Tariff(BaseModel):
         return super().get_all(sort_by=['seat_class', 'order_number'], descending=False)
 
     @classmethod
-    def create(cls, session: Session | None = None, **kwargs):
+    def create(
+        cls,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
         seat_class = kwargs.get('seat_class')
 
@@ -53,4 +59,4 @@ class Tariff(BaseModel):
             next_order = (max_order.order_number + 1) if max_order else 1
             kwargs['order_number'] = next_order
 
-        return super().create(session, **kwargs)
+        return super().create(session, commit=commit, **kwargs)

--- a/server/app/models/timezone.py
+++ b/server/app/models/timezone.py
@@ -42,7 +42,11 @@ class Timezone(BaseModel):
         return generate_xlsx_template(cls.upload_fields, text_fields=cls.upload_text_fields)
 
     @classmethod
-    def upload_from_file(cls, file, session: Session | None = None):
+    def upload_from_file(
+        cls,
+        file,
+        session: Session | None = None,
+    ):
         session = session or db.session
         rows = parse_xlsx(
             file,
@@ -57,8 +61,9 @@ class Timezone(BaseModel):
             if not row.get('error'):
                 try:
                     tz = cls.create(
-                        session, 
+                        session,
                         name=str(row.get('name')),
+                        commit=False,
                     )
                     timezones.append(tz)
                 except Exception as e:
@@ -66,5 +71,7 @@ class Timezone(BaseModel):
 
             if row.get('error'):
                 error_rows.append(row)
+
+        session.commit()
 
         return timezones, error_rows

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -43,7 +43,13 @@ class User(BaseModel):
         return super().get_all(sort_by=['email'], descending=False)
 
     @classmethod
-    def create(cls, session: Session | None = None, **kwargs):
+    def create(
+        cls,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
 
         for key, value in kwargs.items():
@@ -52,7 +58,7 @@ class User(BaseModel):
             elif key == 'email' and isinstance(value, str):
                 kwargs['email'] = value.lower()
 
-        return super().create(session=session, **kwargs)
+        return super().create(session=session, commit=commit, **kwargs)
 
     @classmethod
     def get_by_email(cls, _email):
@@ -61,12 +67,19 @@ class User(BaseModel):
         return cls.query.filter(cls.email == _email.lower()).one_or_none()
 
     @classmethod
-    def update(cls, _id, session: Session | None = None, **kwargs):
+    def update(
+        cls,
+        _id,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
+        **kwargs,
+    ):
         session = session or db.session
 
         kwargs = {k: v for k, v in kwargs.items() if k in ['role', 'is_active']}
-        
-        return super().update(_id, session=session, **kwargs)
+
+        return super().update(_id, session=session, commit=commit, **kwargs)
 
     @classmethod
     def login(cls, _email, _password):


### PR DESCRIPTION
## Summary
- Remove commit flag from model `upload_from_file` helpers and commit session after parsing
- Pass `commit=False` to individual `create` calls during bulk uploads

## Testing
- `pytest` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType')*

------
https://chatgpt.com/codex/tasks/task_e_68a3590c3620832fafd08f7962d24736