### PR TITLE
Refactor consent document page and improve rich text editor

### DIFF
--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -164,3 +164,7 @@ Minor inconsistencies and recommendations:
 - `removeAll` thunk is generated but not handled in reducers via `addCrudCases`. Add a helper (e.g., `addRemoveAllCase`) or include it in `addCrudCases` when needed.
 - Store configuration uses legacy `createStore` + `redux-thunk`. Consider migrating to RTK’s `configureStore` for simpler setup and better devtools integration.
 - Enforce single quotes via `.prettierrc` (above) and ESLint `quotes` rules to avoid drift.
+
+## Code Style
+
+- JavaScript files within this directory must use tabs for indentation with a tab width of four spaces.

--- a/client/src/components/ConsentDocPage.js
+++ b/client/src/components/ConsentDocPage.js
@@ -1,31 +1,22 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Box, Button, Chip, Container, Divider, Grid, Paper, Stack, Typography } from '@mui/material';
-import { DescriptionOutlined, PrintOutlined, DownloadOutlined } from '@mui/icons-material';
+import React, { useEffect, useMemo, useRef } from 'react';
+import {
+	Box,
+	Button,
+	Chip,
+	Container,
+	Divider,
+	Paper,
+	Stack,
+	Typography,
+} from '@mui/material';
+import { DescriptionOutlined, DownloadOutlined } from '@mui/icons-material';
 import DOMPurify from 'dompurify';
 import { useDispatch, useSelector } from 'react-redux';
 import Base from './Base';
 import { fetchLatestConsentDoc } from '../redux/actions/consentDoc';
-
-// утилита: добавляет id к h2/h3 для оглавления
-function addHeadingIds(html) {
-	const doc = new DOMParser().parseFromString(html, 'text/html');
-	const headings = Array.from(doc.querySelectorAll('h2, h3'));
-	headings.forEach((h) => {
-		if (!h.id) {
-			const slug = h.textContent
-				.trim()
-				.toLowerCase()
-				.replace(/[^\p{L}\p{N}\s-]/gu, '')
-				.replace(/\s+/g, '-')
-				.slice(0, 80);
-			h.id = slug || `h-${Math.random().toString(36).slice(2, 7)}`;
-		}
-	});
-	return doc.body.innerHTML;
-}
+import { UI_LABELS } from '../constants';
 
 const proseSx = {
-	// «прозовый» стиль для юридического текста
 	typography: 'body1',
 	lineHeight: 1.7,
 	'& h1, & h2, & h3': { fontWeight: 600, mt: 3, mb: 1.5, lineHeight: 1.25 },
@@ -63,158 +54,122 @@ const proseSx = {
 	},
 };
 
-const tocBoxSx = {
-	position: { md: 'sticky' },
-	top: { md: 24 },
-	borderLeft: { md: (t) => `1px dashed ${t.palette.divider}` },
-	pl: { md: 2 },
-	ml: { md: 2 },
-	mt: { xs: 2, md: 0 },
-	'& a': {
-		display: 'block',
-		py: 0.5,
-		color: 'text.secondary',
-		fontSize: '0.9rem',
-		textDecoration: 'none',
-		'&:hover': { color: 'text.primary', textDecoration: 'underline' },
-	},
-};
-
 const ConsentDocPage = ({ type, title }) => {
 	const dispatch = useDispatch();
 	const { consentDoc } = useSelector((s) => s.consentDocs) || {};
 	const contentRaw = consentDoc?.content || '';
-	const effectiveDate = consentDoc?.effective_date || consentDoc?.updated_at || null;
+	const effectiveDate =
+		consentDoc?.effective_date || consentDoc?.updated_at || null;
 	const version = consentDoc?.version || null;
 
 	const containerRef = useRef(null);
-	const [toc, setToc] = useState([]);
 
-	// грузим последний документ
 	useEffect(() => {
 		dispatch(fetchLatestConsentDoc(type));
 	}, [dispatch, type]);
 
-	// санитизируем + добавляем id заголовкам
-	const contentHtml = useMemo(() => {
-		const withIds = addHeadingIds(contentRaw);
-		return DOMPurify.sanitize(withIds, { USE_PROFILES: { html: true } });
-	}, [contentRaw]);
+	const contentHtml = useMemo(
+		() => DOMPurify.sanitize(contentRaw, { USE_PROFILES: { html: true } }),
+		[contentRaw],
+	);
 
-	// строим оглавление после монтирования контента
-	useEffect(() => {
-		if (!containerRef.current) return;
-		const hs = containerRef.current.querySelectorAll('h2, h3');
-		const entries = Array.from(hs).map((el) => ({
-			id: el.id,
-			text: el.textContent || '',
-			level: el.tagName.toLowerCase(),
-		}));
-		setToc(entries);
-	}, [contentHtml]);
-
-	const handlePrint = () => window.print();
-
-	// (опционально) «скачать как HTML» — компактно и без PDF-генерации на клиенте
-	const handleDownload = () => {
-		const blob = new Blob(
-			[
-				`<!doctype html><html><head><meta charset="utf-8"><title>${title}</title></head><body>${contentHtml}</body></html>`,
-			],
-			{ type: 'text/html;charset=utf-8' }
-		);
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = `${type || 'document'}.html`;
-		a.click();
-		URL.revokeObjectURL(url);
+	const handleDownload = async () => {
+		if (containerRef.current) {
+			try {
+				const html2pdf = (await import('html2pdf.js')).default;
+				await html2pdf()
+					.from(containerRef.current)
+					.save(`${type || 'document'}.pdf`);
+			} catch (err) {
+				const blob = new Blob(
+					[
+						`<!doctype html><html><head><meta charset='utf-8'><title>${title}</title></head><body>${contentHtml}</body></html>`,
+					],
+					{ type: 'text/html;charset=utf-8' },
+				);
+				const url = URL.createObjectURL(blob);
+				const a = document.createElement('a');
+				a.href = url;
+				a.download = `${type || 'document'}.html`;
+				a.click();
+				URL.revokeObjectURL(url);
+			}
+		}
 	};
 
 	return (
 		<Base>
-			<Container maxWidth='md' sx={{ py: { xs: 3, md: 5 } }}>
-				{/* Шапка */}
+			<Container maxWidth="md" sx={{ py: { xs: 3, md: 5 } }}>
 				<Paper
 					elevation={0}
-					sx={{ p: { xs: 2, md: 3 }, border: (t) => `1px solid ${t.palette.divider}`, borderRadius: 2 }}
+					sx={{
+						p: { xs: 2, md: 3 },
+						border: (t) => `1px solid ${t.palette.divider}`,
+						borderRadius: 2,
+					}}
 				>
-					<Stack direction='row' spacing={2} alignItems='center'>
-						<DescriptionOutlined fontSize='large' />
+					<Stack direction="row" spacing={2} alignItems="center">
+						<DescriptionOutlined fontSize="large" />
 						<Box sx={{ flex: 1 }}>
-							<Typography variant='h4' component='h1'>
+							<Typography variant="h4" component="h1">
 								{title}
 							</Typography>
-							<Stack direction='row' spacing={1} flexWrap='wrap' sx={{ mt: 1 }}>
-								{version && <Chip size='small' label={`Версия: ${version}`} />}
+							<Stack
+								direction="row"
+								spacing={1}
+								flexWrap="wrap"
+								sx={{ mt: 1 }}
+							>
+								{version && (
+									<Chip
+										size="small"
+										label={`${UI_LABELS.DOC.version} ${version}`}
+									/>
+								)}
 								{effectiveDate && (
 									<Chip
-										size='small'
-										color='default'
-										variant='outlined'
-										label={`Действует с: ${new Date(effectiveDate).toLocaleDateString()}`}
+										size="small"
+										color="default"
+										variant="outlined"
+										label={`${UI_LABELS.DOC.effective_from} ${new Date(effectiveDate).toLocaleDateString()}`}
 									/>
 								)}
 							</Stack>
 						</Box>
-						<Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
-							<Button onClick={handlePrint} startIcon={<PrintOutlined />} variant='outlined'>
-								Печать
-							</Button>
-							<Button onClick={handleDownload} startIcon={<DownloadOutlined />} variant='contained'>
-								Скачать
-							</Button>
-						</Stack>
+						<Button
+							onClick={handleDownload}
+							startIcon={<DownloadOutlined />}
+							variant="contained"
+						>
+							{UI_LABELS.BUTTONS.download}
+						</Button>
 					</Stack>
 				</Paper>
 
 				<Divider sx={{ my: { xs: 2, md: 3 } }} />
 
-				{/* Контент + оглавление */}
-				<Grid container spacing={3}>
-					<Grid item xs={12} md={8.5}>
-						<Paper
-							elevation={0}
-							sx={{
-								p: { xs: 2, md: 3 },
-								border: (t) => `1px solid ${t.palette.divider}`,
-								borderRadius: 2,
-								'& *:first-of-type': { mt: 0 }, // убираем верхний отступ у первого заголовка
-							}}
-						>
-							<Box ref={containerRef} sx={proseSx} dangerouslySetInnerHTML={{ __html: contentHtml }} />
-							<Divider sx={{ my: 3 }} />
-							<Typography variant='caption' color='text.secondary'>
-								Последнее обновление:{' '}
-								{consentDoc?.updated_at ? new Date(consentDoc.updated_at).toLocaleString() : '—'}
-							</Typography>
-						</Paper>
-					</Grid>
-
-					<Grid item xs={12} md={3.5}>
-						<Paper
-							elevation={0}
-							sx={{ p: 2, border: (t) => `1px solid ${t.palette.divider}`, borderRadius: 2 }}
-						>
-							<Typography variant='subtitle2' gutterBottom>
-								Оглавление
-							</Typography>
-							<Box sx={tocBoxSx}>
-								{toc.length === 0 ? (
-									<Typography variant='body2' color='text.secondary'>
-										Заголовки будут показаны здесь
-									</Typography>
-								) : (
-									toc.map(({ id, text, level }) => (
-										<Box key={id} sx={{ pl: level === 'h3' ? 2 : 0 }}>
-											<a href={`#${id}`}>{text}</a>
-										</Box>
-									))
-								)}
-							</Box>
-						</Paper>
-					</Grid>
-				</Grid>
+				<Paper
+					elevation={0}
+					sx={{
+						p: { xs: 2, md: 3 },
+						border: (t) => `1px solid ${t.palette.divider}`,
+						borderRadius: 2,
+						'& *:first-of-type': { mt: 0 },
+					}}
+				>
+					<Box
+						ref={containerRef}
+						sx={proseSx}
+						dangerouslySetInnerHTML={{ __html: contentHtml }}
+					/>
+					<Divider sx={{ my: 3 }} />
+					<Typography variant="caption" color="text.secondary">
+						{UI_LABELS.DOC.last_updated}{' '}
+						{consentDoc?.updated_at
+							? new Date(consentDoc.updated_at).toLocaleString()
+							: UI_LABELS.DOC.not_available}
+					</Typography>
+				</Paper>
 			</Container>
 		</Base>
 	);

--- a/client/src/components/utils/formField.js
+++ b/client/src/components/utils/formField.js
@@ -49,7 +49,16 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 
 		switch (type) {
 			case FIELD_TYPES.EMAIL: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -72,7 +81,16 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.PHONE: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -95,7 +113,16 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.TEXT: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -112,7 +139,16 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.TEXT_AREA: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -134,27 +170,77 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.RICH_TEXT: {
-				const { value = '', onChange, fullWidth, error, helperText, sx, rows } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					sx,
+					rows,
+				} = allProps;
 				const editorRows = rows || field.rows || 20;
 				const editorMinHeight = editorRows * 24;
+				const modules = {
+					toolbar: [
+						[{ header: [1, 2, false] }],
+						['bold', 'italic', 'underline', 'strike', 'blockquote'],
+						[
+							{ list: 'ordered' },
+							{ list: 'bullet' },
+							{ indent: '-1' },
+							{ indent: '+1' },
+						],
+						['link', 'clean'],
+					],
+				};
+				const formats = [
+					'header',
+					'bold',
+					'italic',
+					'underline',
+					'strike',
+					'blockquote',
+					'list',
+					'bullet',
+					'indent',
+					'link',
+				];
 				return (
 					<FormControl
 						fullWidth={fullWidth}
 						error={!!error}
 						sx={{
 							'& .ql-editor': { minHeight: editorMinHeight },
+							'& .ql-editor ul': { listStyle: 'disc' },
+							'& .ql-editor ol': { listStyle: 'decimal' },
 							...sx,
 						}}
 					>
 						<InputLabel shrink>{field.label}</InputLabel>
-						<ReactQuill theme='snow' value={value} onChange={onChange} />
+						<ReactQuill
+							theme="snow"
+							value={value}
+							onChange={onChange}
+							modules={modules}
+							formats={formats}
+						/>
 						{error && <FormHelperText>{helperText}</FormHelperText>}
 					</FormControl>
 				);
 			}
 
 			case FIELD_TYPES.NUMBER: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+				} = allProps;
 
 				const step = field.inputProps?.step ?? (field.float ? 0.01 : 1);
 				const min = field.inputProps?.min ?? 0;
@@ -162,7 +248,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 
 				return (
 					<TextField
-						type='number'
+						type="number"
 						label={field.label}
 						fullWidth={fullWidth}
 						error={error}
@@ -172,12 +258,21 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 						onBlur={(e) => {
 							const num = e.target.valueAsNumber;
 							if (!isNaN(num)) {
-								const clamped = Math.min(Math.max(min, num), max);
-								const rounded = Math.round(clamped / step) * step;
+								const clamped = Math.min(
+									Math.max(min, num),
+									max,
+								);
+								const rounded =
+									Math.round(clamped / step) * step;
 								onChange(rounded);
 							}
 						}}
-						inputProps={{ min, step, ...field.inputProps, ...inputProps }}
+						inputProps={{
+							min,
+							step,
+							...field.inputProps,
+							...inputProps,
+						}}
 						size={size}
 						sx={{ ...sx }}
 					/>
@@ -185,14 +280,29 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.DATE: {
-				const { value, onChange, fullWidth, error, helperText, sx, minDate, maxDate, textFieldProps, size } =
-					allProps;
+				const {
+					value,
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					sx,
+					minDate,
+					maxDate,
+					textFieldProps,
+					size,
+				} = allProps;
 				return (
-					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
+					<LocalizationProvider
+						dateAdapter={AdapterDateFns}
+						adapterLocale={dateLocale}
+					>
 						<DatePicker
 							label={field.label}
 							value={value ? parseDate(value) : null}
-							onChange={(date) => onChange(formatDate(date, DATE_API_FORMAT))}
+							onChange={(date) =>
+								onChange(formatDate(date, DATE_API_FORMAT))
+							}
 							minDate={minDate ? parseDate(minDate) : undefined}
 							maxDate={maxDate ? parseDate(maxDate) : undefined}
 							format={field.dateFormat || DATE_FORMAT}
@@ -212,10 +322,22 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.TIME: {
-				const { value, onChange, fullWidth, error, helperText, sx, textFieldProps, size } = allProps;
+				const {
+					value,
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					sx,
+					textFieldProps,
+					size,
+				} = allProps;
 
 				return (
-					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
+					<LocalizationProvider
+						dateAdapter={AdapterDateFns}
+						adapterLocale={dateLocale}
+					>
 						<TimePicker
 							label={field.label}
 							value={value ? parseTime(value) : null}
@@ -254,20 +376,34 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 					size,
 				} = allProps;
 
-				const resolvedValue = value !== undefined && value !== null ? value : field.defaultValue;
-				const isValidValue = options.some((o) => o.value === resolvedValue);
+				const resolvedValue =
+					value !== undefined && value !== null
+						? value
+						: field.defaultValue;
+				const isValidValue = options.some(
+					(o) => o.value === resolvedValue,
+				);
 				const safeValue = isValidValue ? resolvedValue : '';
 
 				if (!simpleSelect && options.length > 100) {
-					const valueObj = options.find((o) => o.value === value) || null;
+					const valueObj =
+						options.find((o) => o.value === value) || null;
 					return (
 						<Autocomplete
 							options={options}
 							value={valueObj}
-							onChange={(e, val) => onChange(val ? val.value : '')}
+							onChange={(e, val) =>
+								onChange(val ? val.value : '')
+							}
 							filterOptions={(opts, state) =>
 								opts
-									.filter((o) => o.label.toLowerCase().includes(state.inputValue.toLowerCase()))
+									.filter((o) =>
+										o.label
+											.toLowerCase()
+											.includes(
+												state.inputValue.toLowerCase(),
+											),
+									)
 									.slice(0, 100)
 							}
 							getOptionLabel={(o) => o.label}
@@ -298,7 +434,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 							sx={{ ...sx }}
 						>
 							{options.map((option) => (
-								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
+								<MenuItem
+									key={option.value}
+									value={option.value}
+									{...MenuItemProps}
+								>
 									{option.label}
 								</MenuItem>
 							))}
@@ -307,7 +447,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				}
 
 				return (
-					<FormControl fullWidth={fullWidth} error={!!error} size={size}>
+					<FormControl
+						fullWidth={fullWidth}
+						error={!!error}
+						size={size}
+					>
 						<InputLabel>{field.label}</InputLabel>
 						<Select
 							value={safeValue}
@@ -319,7 +463,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 							sx={{ ...sx }}
 						>
 							{options.map((option) => (
-								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
+								<MenuItem
+									key={option.value}
+									value={option.value}
+									{...MenuItemProps}
+								>
 									{option.label}
 								</MenuItem>
 							))}
@@ -334,7 +482,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				return (
 					<FormControlLabel
 						control={
-							<Checkbox checked={!!value} onChange={(e) => onChange(e.target.checked)} color='primary' />
+							<Checkbox
+								checked={!!value}
+								onChange={(e) => onChange(e.target.checked)}
+								color="primary"
+							/>
 						}
 						label={field.label}
 						sx={{ ...sx }}
@@ -343,10 +495,18 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.CUSTOM:
-				return (customProps) => field.renderField({ ...allProps, ...customProps });
+				return (customProps) =>
+					field.renderField({ ...allProps, ...customProps });
 
 			default: {
-				const { value = '', onChange, fullWidth, inputProps, sx, size } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					inputProps,
+					sx,
+					size,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -20,6 +20,7 @@ export const UI_LABELS = {
 		confirm: 'Подтвердить',
 		send: 'Отправить',
 		continue: 'Продолжить',
+		download: 'Скачать',
 		pagination: {
 			rows_per_page: 'Записей на странице',
 			displayed_rows: ({ from, to, count }) => {
@@ -61,7 +62,8 @@ export const UI_LABELS = {
 	},
 	ABOUT: {
 		company_name: 'АВЕКСМАР',
-		company_full_name: 'Общество с ограниченной ответственностью «АВЕКСМАР»',
+		company_full_name:
+			'Общество с ограниченной ответственностью «АВЕКСМАР»',
 		contact_email: 'contact@avexmar.com',
 		contact_phone: '+7 (123) 456-78-90',
 		legal_address_value: 'г. Москва, ул. Примерная, д. 1',
@@ -81,7 +83,8 @@ export const UI_LABELS = {
 		public_offer: 'Публичная оферта',
 		marketing_consent: 'Согласие на получение рекламной рассылки',
 		all_rights_reserved: 'Все права защищены',
-		company_description: 'Надежный партнер в сфере организации пассажирских и грузовых авиаперевозок с 1995 года',
+		company_description:
+			'Надежный партнер в сфере организации пассажирских и грузовых авиаперевозок с 1995 года',
 		cards: [
 			{
 				title: 'Широкий спектр клиентов и партнёров в сфере воздушных перевозок',
@@ -105,6 +108,12 @@ export const UI_LABELS = {
 				icon: 'airplane',
 			},
 		],
+	},
+	DOC: {
+		version: 'Версия:',
+		effective_from: 'Действует с:',
+		last_updated: 'Последнее обновление:',
+		not_available: '—',
 	},
 	ADMIN: {
 		actions: 'Действия',
@@ -301,18 +310,25 @@ export const UI_LABELS = {
 		},
 		buyer_form: {
 			title: 'Покупатель',
-			privacy_policy: (link) => <>Даю {link('согласие')} на обработку персональных данных</>,
+			privacy_policy: (link) => (
+				<>Даю {link('согласие')} на обработку персональных данных</>
+			),
 			public_offer: (link) => (
-				<>Нажимая «Продолжить», Вы принимаете условия {link('публичной оферты')} ООО «АВЕКСМАР»</>
+				<>
+					Нажимая «Продолжить», Вы принимаете условия{' '}
+					{link('публичной оферты')} ООО «АВЕКСМАР»
+				</>
 			),
 			summary: {
 				total: 'Итого',
 				passenger_word: (count) =>
 					count % 10 === 1 && count % 100 !== 11
 						? `${count} пассажир`
-						: count % 10 >= 2 && count % 10 <= 4 && (count % 100 < 10 || count % 100 >= 20)
-						? `${count} пассажира`
-						: `${count} пассажиров`,
+						: count % 10 >= 2 &&
+							  count % 10 <= 4 &&
+							  (count % 100 < 10 || count % 100 >= 20)
+							? `${count} пассажира`
+							: `${count} пассажиров`,
 				tickets: 'Стоимость перевозки',
 				fees: 'Сборы',
 				discount: 'Скидка',
@@ -354,7 +370,8 @@ export const UI_LABELS = {
 			last_name: 'Фамилия',
 			first_name: 'Имя',
 			patronymic_name: 'Отчество (при наличии)',
-			name_hint: (requiresCyrillic) => `${requiresCyrillic ? 'Кириллицей' : 'Латиницей'}, как в документе`,
+			name_hint: (requiresCyrillic) =>
+				`${requiresCyrillic ? 'Кириллицей' : 'Латиницей'}, как в документе`,
 		},
 		payment_form: {
 			title: (timeLeft) => `${timeLeft} для оплаты`,
@@ -415,21 +432,32 @@ export const UI_LABELS = {
 			passenger_word: (count) =>
 				count % 10 === 1 && count % 100 !== 11
 					? 'пассажир'
-					: count % 10 >= 2 && count % 10 <= 4 && (count % 100 < 10 || count % 100 >= 20)
-					? 'пассажира'
-					: 'пассажиров',
+					: count % 10 >= 2 &&
+						  count % 10 <= 4 &&
+						  (count % 100 < 10 || count % 100 >= 20)
+						? 'пассажира'
+						: 'пассажиров',
 			passenger_categories: [
 				{ key: 'adults', label: 'Взрослые', desc: '12 лет и старше' },
 				{ key: 'children', label: 'Дети', desc: '2–11 лет' },
-				{ key: 'infants', label: 'Младенцы без места', desc: 'до 2 лет' },
-				{ key: 'infants_seat', label: 'Младенцы с местом', desc: 'до 2 лет' },
+				{
+					key: 'infants',
+					label: 'Младенцы без места',
+					desc: 'до 2 лет',
+				},
+				{
+					key: 'infants_seat',
+					label: 'Младенцы с местом',
+					desc: 'до 2 лет',
+				},
 			],
 		},
 		results: 'Результаты поиска',
 		no_results: 'Рейсы не найдены',
 		from_to_date: (from, to, date_from, date_to) => {
 			if (!from || !to) return '';
-			if (date_to) return `${from} ⇄ ${to}, ${formatDate(date_from, 'dd.MM')} - ${formatDate(date_to, 'dd.MM')}`;
+			if (date_to)
+				return `${from} ⇄ ${to}, ${formatDate(date_from, 'dd.MM')} - ${formatDate(date_to, 'dd.MM')}`;
 			else return `${from} → ${to}, ${formatDate(date_from, 'dd.MM')}`;
 		},
 		flight_details: {


### PR DESCRIPTION
## Summary
- restyle ConsentDocPage to match project conventions and drop table of contents
- switch print action to downloadable document with PDF fallback, move strings to constants
- fix Rich Text editor list rendering and expose document-specific labels
- document tab-based indentation for client JavaScript and reformat ConsentDocPage, formField, and uiLabels accordingly

## Testing
- `npx prettier -w --single-quote --use-tabs --tab-width 4 client/src/components/ConsentDocPage.js client/src/components/utils/formField.js client/src/constants/uiLabels.js`
- `npx eslint client/src/components/ConsentDocPage.js client/src/components/utils/formField.js client/src/constants/uiLabels.js` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a6f330a78c832f9dc2393c270d9de2