### PR TITLE
feat: record booking consents

### DIFF
--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -129,10 +129,10 @@ const Passengers = () => {
 				buyerFirstName: mapped.buyerFirstName || '',
 				emailAddress: mapped.emailAddress || '',
 				phoneNumber: mapped.phoneNumber || '',
-				consent: passengersExist ? true : mapped.consent,
+				consent: mapped.consent || false,
 			});
 		}
-	}, [booking?.buyer, passengersExist]);
+	}, [booking, passengersExist]);
 
 	const buyerFormFields = useMemo(() => {
 		const fields = {

--- a/server/app/controllers/booking_process_controller.py
+++ b/server/app/controllers/booking_process_controller.py
@@ -9,7 +9,13 @@ from app.models.payment import Payment
 from app.middlewares.auth_middleware import current_user
 from app.utils.business_logic import calculate_price_details
 from app.utils.yookassa import create_payment, handle_webhook
-from app.utils.enum import BOOKING_STATUS, PASSENGER_PLURAL_CATEGORY
+from app.utils.enum import (
+    BOOKING_STATUS,
+    PASSENGER_PLURAL_CATEGORY,
+    CONSENT_ACTION,
+    CONSENT_EVENT_TYPE,
+)
+from app.utils.consent import create_booking_consents
 
 
 @current_user
@@ -88,6 +94,7 @@ def create_booking_process_passengers(current_user):
     data = request.json or {}
     public_id = data.get('public_id')
     buyer = data.get('buyer', {})
+    consent = bool(buyer.pop('consent', False))
     passengers = data.get('passengers') or []
     if not public_id:
         return jsonify({'message': 'public_id required'}), 400
@@ -162,6 +169,14 @@ def create_booking_process_passengers(current_user):
         commit=False,
         to_status=BOOKING_STATUS.passengers_added,
     )
+
+    if consent:
+        create_booking_consents(
+            booking,
+            current_user.id if current_user else None,
+            list(processed_ids),
+            session=session,
+        )
 
     session.commit()
 
@@ -238,6 +253,13 @@ def get_booking_process_details(current_user, public_id):
     outbound_tariff_id = tariffs_map.get(outbound_id)
     return_tariff_id = tariffs_map.get(return_id)
 
+    consent_exists = (
+        booking.consent_events.filter_by(
+            type=CONSENT_EVENT_TYPE.pd_processing, action=CONSENT_ACTION.agree
+        ).count()
+        > 0
+    )
+
     result['passengers'] = passengers
     result['passengers_exist'] = passengers_exist
     result['flights'] = flights
@@ -248,6 +270,7 @@ def get_booking_process_details(current_user, public_id):
         return_tariff_id,
         passenger_counts,
     )
+    result['consent'] = consent_exists
 
     return jsonify(result), 200
 

--- a/server/app/utils/consent.py
+++ b/server/app/utils/consent.py
@@ -1,0 +1,50 @@
+from flask import request
+
+from app.database import db
+from app.models.consent import ConsentDoc, ConsentEvent
+from app.utils.enum import (
+    CONSENT_ACTION,
+    CONSENT_DOC_TYPE,
+    CONSENT_EVENT_TYPE,
+)
+
+
+def get_sender_info() -> dict:
+    ip = request.headers.get('X-Forwarded-For', request.remote_addr)
+    return {
+        'ip': ip,
+        'user_agent': request.headers.get('User-Agent'),
+        'device_fingerprint': request.headers.get('X-Device-Fingerprint'),
+    }
+
+
+def create_booking_consents(
+    booking,
+    granter_user_id=None,
+    subject_ids=None,
+    *,
+    session=None,
+):
+    session = session or db.session
+    subject_ids = subject_ids or []
+    sender_info = get_sender_info()
+
+    mappings = [
+        (CONSENT_EVENT_TYPE.pd_processing, CONSENT_DOC_TYPE.pd_policy, subject_ids),
+        (CONSENT_EVENT_TYPE.offer_acceptance, CONSENT_DOC_TYPE.offer, []),
+    ]
+
+    for event_type, doc_type, subs in mappings:
+        doc = ConsentDoc.get_latest(doc_type, session=session)
+        ConsentEvent.create(
+            session=session,
+            commit=False,
+            type=event_type,
+            granter_user_id=granter_user_id,
+            booking_id=booking.id,
+            doc_id=doc.id,
+            action=CONSENT_ACTION.agree,
+            subject_ids=subs,
+            **sender_info,
+        )
+


### PR DESCRIPTION
## Summary
- capture sender info for booking consents and persist consent events
- flag existing booking consent for buyer form

## Testing
- `pytest -q` *(fails: SERVER_JWT_EXP_HOURS not set)*
- `npm test --silent -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a734e8ba14832fb377cca55203b802