### PR TITLE
refactor: centralize email configs

### DIFF
--- a/server/app/controllers/auth_controller.py
+++ b/server/app/controllers/auth_controller.py
@@ -3,7 +3,7 @@ from flask import request, jsonify
 from app.config import Config
 from app.models.user import User
 from app.utils.jwt import signJWT
-from app.utils.email import send_email
+from app.utils.email import EMAIL_TYPE, send_email
 from app.utils.enum import USER_ROLE, DEFAULT_USER_ROLE
 from app.middlewares.auth_middleware import login_required
 
@@ -59,11 +59,10 @@ def forgot_password():
     token = PasswordResetToken.create(user)
     reset_url = f"{Config.CLIENT_URL}/reset_password?token={token.token}"
     send_email(
-        'Сброс пароля',
-        [user.email],
-        'forgot_password.txt',
+        EMAIL_TYPE.password_reset,
+        recipients=[user.email],
         reset_url=reset_url,
-        expires_in_hours=Config.PASSWORD_RESET_EXP_HOURS
+        expires_in_hours=Config.PASSWORD_RESET_EXP_HOURS,
     )
     return jsonify({'message': 'Password reset instructions sent'}), 200
 

--- a/server/app/utils/email.py
+++ b/server/app/utils/email.py
@@ -1,9 +1,29 @@
 from threading import Thread
+import enum
 
 from flask import current_app, render_template
 from flask_mail import Mail, Message
 
 mail = Mail()
+
+
+class EMAIL_TYPE(enum.Enum):
+    booking_confirmation = (
+        'booking_confirmation.txt',
+        'Подтверждение бронирования № {booking_number}',
+    )
+    invoice_payment = (
+        'invoice_payment.txt',
+        'Счёт на оплату бронирования',
+    )
+    password_reset = (
+        'forgot_password.txt',
+        'Сброс пароля',
+    )
+
+    def __init__(self, template: str, subject: str):
+        self.template = template
+        self.subject = subject
 
 
 def init_mail(app):
@@ -15,8 +35,16 @@ def _send_async_email(app, msg) -> None:
         mail.send(msg)
 
 
-def send_email(subject: str, recipients: list[str], template: str, **context) -> None:
-    msg = Message(subject=subject, recipients=recipients)
+def send_email(email_type: EMAIL_TYPE, **context) -> None:
+    recipients = context.pop('recipients', None)
+    if not recipients:
+        return
+    subject = email_type.subject.format(**context)
+    template = email_type.template
+    msg = Message(
+        subject=subject,
+        recipients=recipients if isinstance(recipients, list) else [recipients],
+    )
     msg.body = render_template(template, **context)
     app = current_app._get_current_object()
     Thread(target=_send_async_email, args=(app, msg), daemon=True).start()

--- a/server/app/utils/yookassa.py
+++ b/server/app/utils/yookassa.py
@@ -11,7 +11,7 @@ from app.models.payment import Payment
 from app.utils.business_logic import calculate_receipt_details
 from app.utils.datetime import format_date
 from app.utils.enum import PAYMENT_METHOD, PAYMENT_STATUS, BOOKING_STATUS, PAYMENT_TYPE
-from app.utils.email import send_email
+from app.utils.email import EMAIL_TYPE, send_email
 
 # Configure YooKassa SDK
 Configuration.account_id = Config.YOOKASSA_SHOP_ID
@@ -94,9 +94,8 @@ def __send_confirmation_email(booking: Booking) -> bool:
         f'?access_token={booking.access_token}'
     )
     send_email(
-        subject=f'Подтверждение бронирования № {str(booking.booking_number)}',
+        EMAIL_TYPE.booking_confirmation,
         recipients=[booking.email_address],
-        template='booking_confirmation.txt',
         booking_number=str(booking.booking_number),
         total_price=f'{booking.total_price:.2f}',
         currency=booking.currency.value.upper(),
@@ -109,9 +108,8 @@ def __send_invoice_email(booking: Booking, payment_url: str) -> bool:
     if not booking.email_address or not payment_url:
         return False
     send_email(
-        subject='Счёт на оплату бронирования',
+        EMAIL_TYPE.invoice_payment,
         recipients=[booking.email_address],
-        template='invoice_payment.txt',
         payment_url=payment_url,
     )
     return True


### PR DESCRIPTION
## Summary
- centralize email subjects and templates via EmailType enum
- simplify email sending API to use EmailType and context
- update password reset and payment emails to new utility

## Testing
- `pytest` *(fails: Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68a83fbaf144832f823429903ed74895