### PR TITLE
feat: use react-timer-hook for booking expiry

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
 		"react-redux": "^9.2.0",
 		"react-router-dom": "^6.30.1",
 		"react-scripts": "^5.0.1",
+		"react-timer-hook": "^3.0.6",
 		"redux-thunk": "^3.1.0",
 		"typeface-open-sans": "^1.1.13",
 		"typeface-roboto": "^1.1.13"


### PR DESCRIPTION
## Summary
- use `react-timer-hook` for booking countdown
- add `react-timer-hook` dependency

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-timer-hook)*
- `npx eslint src/components/utils/time.js src/components/booking/Passengers.js src/components/booking/Confirmation.js src/components/booking/Payment.js` *(fails: ESLint couldn't find a configuration file)*
- `npx prettier --check src/components/utils/time.js src/components/booking/Passengers.js src/components/booking/Confirmation.js src/components/booking/Payment.js`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a857603534832fb7958f07a1911e79