### PR TITLE
Ensure consent docs reload on page change

### DIFF
--- a/client/src/redux/reducers/consentDoc.js
+++ b/client/src/redux/reducers/consentDoc.js
@@ -34,7 +34,10 @@ const consentDocSlice = createSlice({
 			'consentDoc'
 		);
 		builder
-			.addCase(fetchLatestConsentDoc.pending, handlePending)
+			.addCase(fetchLatestConsentDoc.pending, (state) => {
+				state.consentDoc = null;
+				handlePending(state);
+			})
 			.addCase(fetchLatestConsentDoc.fulfilled, (state, action) => {
 				state.consentDoc = action.payload;
 				state.isLoading = false;


### PR DESCRIPTION
## Summary
- reset consent document state before fetching new document

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npx eslint .` (fails: ESLint couldn't find a configuration file)
- `npx prettier -c .` (fails: Code style issues found)
- `ruff check` (fails: Found 171 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a8689d3114832fbdc794410dcd8016