### PR TITLE
Ensure delete operations commit and add admin bulk delete buttons

### DIFF
--- a/client/src/components/admin/ConsentDocManagement.js
+++ b/client/src/components/admin/ConsentDocManagement.js
@@ -2,7 +2,13 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from './AdminDataTable';
-import { fetchConsentDocs, createConsentDoc, updateConsentDoc, deleteConsentDoc } from '../../redux/actions/consentDoc';
+import {
+	fetchConsentDocs,
+	createConsentDoc,
+	updateConsentDoc,
+	deleteConsentDoc,
+	deleteAllConsentDocs,
+} from '../../redux/actions/consentDoc';
 import { createAdminManager } from './utils';
 import { FIELD_TYPES } from '../utils';
 import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES, getEnumOptions } from '../../constants';
@@ -51,26 +57,32 @@ const ConsentDocManagement = () => {
 
 	const handleAdd = (data) => dispatch(createConsentDoc(adminManager.toApiFormat(data))).unwrap();
 	const handleEdit = async (data) => {
-		await dispatch(updateConsentDoc(adminManager.toApiFormat(data))).unwrap();
-		dispatch(fetchConsentDocs());
+	await dispatch(updateConsentDoc(adminManager.toApiFormat(data))).unwrap();
+	dispatch(fetchConsentDocs());
 	};
 	const handleDelete = (id) => dispatch(deleteConsentDoc(id)).unwrap();
+	
+	const handleDeleteAll = async () => {
+	await dispatch(deleteAllConsentDocs()).unwrap();
+	dispatch(fetchConsentDocs());
+	};
 
 	const formattedDocs = consentDocs.map(adminManager.toUiFormat);
 
 	return (
-		<AdminDataTable
-			title={UI_LABELS.ADMIN.modules.consentDocs.management}
-			data={formattedDocs}
-			columns={adminManager.columns}
-			onAdd={handleAdd}
-			onEdit={handleEdit}
-			onDelete={handleDelete}
-			renderForm={adminManager.renderForm}
-			addButtonText={UI_LABELS.ADMIN.modules.consentDocs.add_button}
-			isLoading={isLoading}
-			error={errors}
-		/>
+	<AdminDataTable
+	title={UI_LABELS.ADMIN.modules.consentDocs.management}
+	data={formattedDocs}
+	columns={adminManager.columns}
+	onAdd={handleAdd}
+	onEdit={handleEdit}
+	onDelete={handleDelete}
+	onDeleteAll={handleDeleteAll}
+	renderForm={adminManager.renderForm}
+	addButtonText={UI_LABELS.ADMIN.modules.consentDocs.add_button}
+	isLoading={isLoading}
+	error={errors}
+	/>
 	);
 };
 

--- a/client/src/components/admin/ConsentEventManagement.js
+++ b/client/src/components/admin/ConsentEventManagement.js
@@ -7,6 +7,7 @@ import {
 	createConsentEvent,
 	updateConsentEvent,
 	deleteConsentEvent,
+	deleteAllConsentEvents,
 } from '../../redux/actions/consentEvent';
 import { createAdminManager } from './utils';
 import { FIELD_TYPES } from '../utils';
@@ -98,22 +99,28 @@ const ConsentEventManagement = () => {
 	const handleAdd = (data) => dispatch(createConsentEvent(adminManager.toApiFormat(data))).unwrap();
 	const handleEdit = (data) => dispatch(updateConsentEvent(adminManager.toApiFormat(data))).unwrap();
 	const handleDelete = (id) => dispatch(deleteConsentEvent(id)).unwrap();
+	
+	const handleDeleteAll = async () => {
+	await dispatch(deleteAllConsentEvents()).unwrap();
+	dispatch(fetchConsentEvents());
+	};
 
 	const formattedEvents = consentEvents.map(adminManager.toUiFormat);
 
 	return (
-		<AdminDataTable
-			title={UI_LABELS.ADMIN.modules.consentEvents.management}
-			data={formattedEvents}
-			columns={adminManager.columns}
-			onAdd={handleAdd}
-			onEdit={handleEdit}
-			onDelete={handleDelete}
-			renderForm={adminManager.renderForm}
-			addButtonText={UI_LABELS.ADMIN.modules.consentEvents.add_button}
-			isLoading={isLoading}
-			error={errors}
-		/>
+	<AdminDataTable
+	title={UI_LABELS.ADMIN.modules.consentEvents.management}
+	data={formattedEvents}
+	columns={adminManager.columns}
+	onAdd={handleAdd}
+	onEdit={handleEdit}
+	onDelete={handleDelete}
+	onDeleteAll={handleDeleteAll}
+	renderForm={adminManager.renderForm}
+	addButtonText={UI_LABELS.ADMIN.modules.consentEvents.add_button}
+	isLoading={isLoading}
+	error={errors}
+	/>
 	);
 };
 

--- a/client/src/components/admin/UserManagement.js
+++ b/client/src/components/admin/UserManagement.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import AdminDataTable from '../../components/admin/AdminDataTable';
 
-import { fetchUsers, createUser, updateUser, deleteUser } from '../../redux/actions/user';
+import { fetchUsers, createUser, updateUser, deleteUser, deleteAllUsers } from '../../redux/actions/user';
 import { createAdminManager } from './utils';
 import { FIELD_TYPES } from '../utils';
 import { ENUM_LABELS, FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES, getEnumOptions } from '../../constants';
@@ -51,21 +51,27 @@ const UserManagement = () => {
 	const handleAddUser = (data) => dispatch(createUser(adminManager.toApiFormat(data))).unwrap();
 	const handleEditUser = (data) => dispatch(updateUser(adminManager.toApiFormat(data))).unwrap();
 	const handleDeleteUser = (id) => dispatch(deleteUser(id)).unwrap();
+	
+	const handleDeleteAllUsers = async () => {
+	await dispatch(deleteAllUsers()).unwrap();
+	dispatch(fetchUsers());
+	};
 
 	const formattedUsers = users.map(adminManager.toUiFormat);
 
 	return (
-		<AdminDataTable
-			title={UI_LABELS.ADMIN.modules.users.management}
-			data={formattedUsers}
-			columns={adminManager.columns}
-			onAdd={handleAddUser}
-			onEdit={handleEditUser}
-			onDelete={handleDeleteUser}
-			renderForm={adminManager.renderForm}
-			isLoading={isLoading}
-			error={errors}
-		/>
+	<AdminDataTable
+	title={UI_LABELS.ADMIN.modules.users.management}
+	data={formattedUsers}
+	columns={adminManager.columns}
+	onAdd={handleAddUser}
+	onEdit={handleEditUser}
+	onDelete={handleDeleteUser}
+	onDeleteAll={handleDeleteAllUsers}
+	renderForm={adminManager.renderForm}
+	isLoading={isLoading}
+	error={errors}
+	/>
 	);
 };
 

--- a/server/app/controllers/_dev_controller.py
+++ b/server/app/controllers/_dev_controller.py
@@ -38,6 +38,6 @@ def clear_table(current_user, table_name: str):
     if not model:
         return jsonify({'message': 'Invalid table name'}), 404
 
-    deleted = model.delete_all()
+    deleted = model.delete_all(commit=True)
 
     return jsonify({'deleted': deleted})

--- a/server/app/controllers/aircraft_controller.py
+++ b/server/app/controllers/aircraft_controller.py
@@ -30,5 +30,5 @@ def update_aircraft(current_user, aircraft_id):
 
 @admin_required
 def delete_aircraft(current_user, aircraft_id):
-    aircraft = Aircraft.delete(aircraft_id)
+    aircraft = Aircraft.delete(aircraft_id, commit=True)
     return jsonify(aircraft)

--- a/server/app/controllers/airline_controller.py
+++ b/server/app/controllers/airline_controller.py
@@ -31,7 +31,7 @@ def update_airline(current_user, airline_id):
 
 @admin_required
 def delete_airline(current_user, airline_id):
-    deleted = Airline.delete_or_404(airline_id)
+    deleted = Airline.delete_or_404(airline_id, commit=True)
     return jsonify(deleted)
 
 

--- a/server/app/controllers/airport_controller.py
+++ b/server/app/controllers/airport_controller.py
@@ -31,7 +31,7 @@ def update_airport(current_user, airport_id):
 
 @admin_required
 def delete_airport(current_user, airport_id):
-    deleted = Airport.delete_or_404(airport_id)
+    deleted = Airport.delete_or_404(airport_id, commit=True)
     return jsonify(deleted)
 
 

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -36,5 +36,5 @@ def update_booking(current_user, booking_id):
 @admin_required
 def delete_booking(current_user, booking_id):
     session = db.session
-    deleted = Booking.delete_or_404(booking_id, session=session)
+    deleted = Booking.delete_or_404(booking_id, session=session, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/booking_passenger_controller.py
+++ b/server/app/controllers/booking_passenger_controller.py
@@ -32,5 +32,5 @@ def update_booking_passenger(current_user, booking_passenger_id):
 
 @admin_required
 def delete_booking_passenger(current_user, booking_passenger_id):
-    deleted = BookingPassenger.delete_or_404(booking_passenger_id)
+    deleted = BookingPassenger.delete_or_404(booking_passenger_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/country_controller.py
+++ b/server/app/controllers/country_controller.py
@@ -31,7 +31,7 @@ def update_country(current_user, country_id):
 
 @admin_required
 def delete_country(current_user, country_id):
-    deleted = Country.delete_or_404(country_id)
+    deleted = Country.delete_or_404(country_id, commit=True)
     return jsonify(deleted)
 
 

--- a/server/app/controllers/discount_controller.py
+++ b/server/app/controllers/discount_controller.py
@@ -32,5 +32,5 @@ def update_discount(current_user, discount_id):
 
 @admin_required
 def delete_discount(current_user, discount_id):
-    deleted = Discount.delete_or_404(discount_id)
+    deleted = Discount.delete_or_404(discount_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/fee_controller.py
+++ b/server/app/controllers/fee_controller.py
@@ -30,5 +30,5 @@ def update_fee(current_user, fee_id):
 
 @admin_required
 def delete_fee(current_user, fee_id):
-    deleted = Fee.delete_or_404(fee_id)
+    deleted = Fee.delete_or_404(fee_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/flight_controller.py
+++ b/server/app/controllers/flight_controller.py
@@ -31,7 +31,7 @@ def update_flight(current_user, flight_id):
 
 @admin_required
 def delete_flight(current_user, flight_id):
-    deleted = Flight.delete_or_404(flight_id)
+    deleted = Flight.delete_or_404(flight_id, commit=True)
     return jsonify(deleted)
 
 

--- a/server/app/controllers/flight_tariff_controller.py
+++ b/server/app/controllers/flight_tariff_controller.py
@@ -34,5 +34,5 @@ def update_flight_tariff(current_user, flight_tariff_id):
 
 @admin_required
 def delete_flight_tariff(current_user, flight_tariff_id):
-    deleted = FlightTariff.delete_or_404(flight_tariff_id)
+    deleted = FlightTariff.delete_or_404(flight_tariff_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/passenger_controller.py
+++ b/server/app/controllers/passenger_controller.py
@@ -32,5 +32,5 @@ def update_passenger(current_user, passenger_id):
 
 @admin_required
 def delete_passenger(current_user, passenger_id):
-    deleted = Passenger.delete_or_404(passenger_id)
+    deleted = Passenger.delete_or_404(passenger_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/payment_controller.py
+++ b/server/app/controllers/payment_controller.py
@@ -33,5 +33,5 @@ def update_payment(current_user, payment_id):
 
 @admin_required
 def delete_payment(current_user, payment_id):
-    deleted = Payment.delete_or_404(payment_id)
+    deleted = Payment.delete_or_404(payment_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/route_controller.py
+++ b/server/app/controllers/route_controller.py
@@ -31,5 +31,5 @@ def update_route(current_user, route_id):
 
 @admin_required
 def delete_route(current_user, route_id):
-    deleted = Route.delete_or_404(route_id)
+    deleted = Route.delete_or_404(route_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/tariff_controller.py
+++ b/server/app/controllers/tariff_controller.py
@@ -30,5 +30,5 @@ def update_tariff(current_user, tariff_id):
 
 @admin_required
 def delete_tariff(current_user, tariff_id):
-    deleted = Tariff.delete_or_404(tariff_id)
+    deleted = Tariff.delete_or_404(tariff_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/ticket_controller.py
+++ b/server/app/controllers/ticket_controller.py
@@ -32,5 +32,5 @@ def update_ticket(current_user, ticket_id):
 
 @admin_required
 def delete_ticket(current_user, ticket_id):
-    deleted = Ticket.delete_or_404(ticket_id)
+    deleted = Ticket.delete_or_404(ticket_id, commit=True)
     return jsonify(deleted)

--- a/server/app/controllers/timezone_controller.py
+++ b/server/app/controllers/timezone_controller.py
@@ -32,7 +32,7 @@ def update_timezone(current_user, timezone_id):
 
 @admin_required
 def delete_timezone(current_user, timezone_id):
-    deleted = Timezone.delete_or_404(timezone_id)
+    deleted = Timezone.delete_or_404(timezone_id, commit=True)
     return jsonify(deleted)
 
 

--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -38,7 +38,7 @@ def update_user(current_user, user_id):
 
 @admin_required
 def delete_user(current_user, user_id):
-    deleted_user = User.delete_or_404(user_id)
+    deleted_user = User.delete_or_404(user_id, commit=True)
     return jsonify(deleted_user)
 
 

--- a/server/app/models/_base_model.py
+++ b/server/app/models/_base_model.py
@@ -233,10 +233,14 @@ class BaseModel(db.Model):
 
     @classmethod
     def delete(
-        cls, _id, session: Session | None = None
+        cls,
+        _id,
+        session: Session | None = None,
+        *,
+        commit: bool = False,
     ) -> Optional[Dict]:
         session = session or db.session
-        return cls.delete_or_404(_id, session)
+        return cls.delete_or_404(_id, session, commit=commit)
 
     @classmethod
     def delete_all(
@@ -248,7 +252,7 @@ class BaseModel(db.Model):
         session = session or db.session
         try:
             count = session.query(cls).delete()
-            if commit and not session.in_transaction():
+            if commit:
                 session.commit()
             else:
                 session.flush()


### PR DESCRIPTION
## Summary
- add commit option to BaseModel.delete and align delete_all commit handling
- pass commit=True for resource deletions across controllers
- add bulk delete buttons in consent doc, consent event, and user admin pages

## Testing
- `pytest -q` *(fails: RuntimeError: Either 'SQLALCHEMY_DATABASE_URI' or 'SQLALCHEMY_BINDS' must be set)*
- `cd client && npm test -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a865938358832f9cd8810edf8d3d38