### PR TITLE
Improve Celery logging and booking cleanup

### DIFF
--- a/server/app/celery_app.py
+++ b/server/app/celery_app.py
@@ -1,14 +1,12 @@
-from celery import Celery
+from celery import Celery, signals
 
 from app.app import app
 from app.config import Config
 
 
-celery = Celery(
-    __name__,
-    broker=Config.CELERY_BROKER_URL,
-    backend=Config.CELERY_RESULT_BACKEND,
-)
+celery = Celery(__name__, broker=Config.CELERY_BROKER_URL, backend=Config.CELERY_RESULT_BACKEND)
+celery.config_from_object(Config)
+celery.conf.update(task_track_started=True)
 
 
 class AppContextTask(celery.Task):
@@ -22,7 +20,17 @@ class AppContextTask(celery.Task):
 celery.Task = AppContextTask
 
 
-from app.tasks.booking import cleanup_expired_bookings
+@signals.task_prerun.connect
+def log_task_start(sender=None, task_id=None, task=None, args=None, kwargs=None, **extra):
+    app.logger.info('Starting task %s[%s]', task.name, task_id)
+
+
+@signals.task_postrun.connect
+def log_task_end(sender=None, task_id=None, task=None, retval=None, state=None, **extra):
+    app.logger.info('Task %s[%s] finished with state=%s result=%s', task.name, task_id, state, retval)
+
+
+from app.tasks.booking import cleanup_expired_bookings  # noqa: E402
 
 
 @celery.on_after_configure.connect


### PR DESCRIPTION
## Summary
- add Celery signal hooks to log task start and end, using Flask logger
- load Celery config from Flask settings and track task starts
- mark expired bookings and remove holds instead of deleting records

## Testing
- `ruff check app/celery_app.py app/tasks/booking.py`
- `SERVER_DATABASE_URI="sqlite:///:memory:" SERVER_TEST_DATABASE_URI="sqlite:///:memory:" pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87653a2a4832fbc78f72dbee3b692