### PR TITLE
feat: add passenger management for users

### DIFF
--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -26,6 +26,7 @@ import BookingProgress from './BookingProgress';
 import PassengerForm from './PassengerForm';
 import { processBookingPassengers, fetchBookingDetails, fetchBookingAccess } from '../../redux/actions/bookingProcess';
 import { fetchCountries } from '../../redux/actions/country';
+import { fetchUserPassengers } from '../../redux/actions/passenger';
 import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES, ENUM_LABELS } from '../../constants';
 import {
 	createFormFields,
@@ -52,10 +53,12 @@ const Passengers = () => {
 		isLoading: bookingLoading,
 		errors: bookingErrors,
 	} = useSelector((state) => state.bookingProcess);
-	const { countries } = useSelector((state) => state.countries);
+const { countries } = useSelector((state) => state.countries);
+const { currentUser } = useSelector((state) => state.auth);
+const userPassengers = useSelector((state) => state.passengers.passengers);
 
-	const expiresAt = booking?.expires_at;
-	const timeLeft = useExpiryCountdown(expiresAt);
+const expiresAt = booking?.expires_at;
+const timeLeft = useExpiryCountdown(expiresAt);
 
 	const existingPassengerData = booking?.passengers;
 	const passengersExist = booking?.passengersExist;
@@ -90,12 +93,18 @@ const Passengers = () => {
 		return [];
 	}, [errors]);
 
-	useEffect(() => {
-		if (Array.isArray(existingPassengerData)) {
-			const mapped = existingPassengerData.map(fromApiPassenger);
-			setPassengerData(mapped);
-		}
-	}, [existingPassengerData, passengersExist]);
+useEffect(() => {
+if (Array.isArray(existingPassengerData)) {
+const mapped = existingPassengerData.map(fromApiPassenger);
+setPassengerData(mapped);
+}
+}, [existingPassengerData, passengersExist]);
+
+useEffect(() => {
+if (currentUser) {
+dispatch(fetchUserPassengers(currentUser.id));
+}
+}, [dispatch, currentUser]);
 
 	useEffect(() => {
 		dispatch(fetchBookingDetails(publicId));
@@ -177,11 +186,20 @@ const Passengers = () => {
 
 	const [buyerErrors, setBuyerErrors] = useState({});
 
-	const handlePassengerChange = (index) => (field, value, data) => {
-		setPassengerData((prev) =>
-			Array.isArray(prev) ? prev.map((p, i) => (i === index ? { ...p, ...data } : p)) : prev
-		);
-	};
+const handlePassengerChange = (index) => (field, value, data) => {
+setPassengerData((prev) =>
+Array.isArray(prev) ? prev.map((p, i) => (i === index ? { ...p, ...data } : p)) : prev
+);
+};
+
+const handlePrefillPassenger = (index, passenger) => {
+const mapped = fromApiPassenger(passenger);
+setPassengerData((prev) =>
+Array.isArray(prev)
+? prev.map((p, i) => (i === index ? { ...p, ...mapped } : p))
+: prev,
+);
+};
 
 	const handleBuyerChange = (field, value) => {
 		setBuyer((prev) => ({ ...prev, [field]: value }));
@@ -286,26 +304,47 @@ const Passengers = () => {
 			)}
 			<Grid container spacing={2}>
 				<Grid item xs={12} md={8} sx={{ maxHeight: 'calc(100vh - 200px)', overflowY: 'auto', pr: { md: 2 } }}>
-					{errorMessages.length > 0 && (
-						<Stack spacing={1} sx={{ mb: 2 }}>
+{errorMessages.length > 0 && (
+<Stack spacing={1} sx={{ mb: 2 }}>
 							{errorMessages.map((msg, idx) => (
 								<Alert key={idx} severity='error'>
 									{msg}
 								</Alert>
 							))}
 						</Stack>
-					)}
-					{passengersReady &&
-						passengerData.map((p, index) => (
-							<PassengerForm
-								key={p.id || index}
-								passenger={p}
-								flights={booking.flights}
-								onChange={handlePassengerChange(index)}
-								citizenshipOptions={citizenshipOptions}
-								ref={(el) => (passengerRefs.current[index] = el)}
-							/>
-						))}
+)}
+{!currentUser && (
+<Alert severity='info' sx={{ mb: 2 }}>
+{UI_LABELS.BOOKING.passenger_form.login_hint}
+</Alert>
+)}
+{passengersReady &&
+passengerData.map((p, index) => (
+<Box key={p.id || index} sx={{ mb: 2 }}>
+{currentUser && userPassengers.length > 0 && (
+<Box sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+{userPassengers.map((up) => {
+const mapped = fromApiPassenger(up);
+return (
+<Chip
+key={up.id}
+label={`${mapped.lastName || ''} ${mapped.firstName || ''}`}
+size='small'
+onClick={() => handlePrefillPassenger(index, up)}
+/>
+);
+})}
+</Box>
+)}
+<PassengerForm
+passenger={p}
+flights={booking.flights}
+onChange={handlePassengerChange(index)}
+citizenshipOptions={citizenshipOptions}
+ref={(el) => (passengerRefs.current[index] = el)}
+/>
+</Box>
+))}
 					<Box sx={{ p: 2, border: '1px solid #eee', borderRadius: 2, mb: 2 }}>
 						<Typography variant='h4' sx={{ mb: 3 }}>
 							{UI_LABELS.BOOKING.buyer_form.title}

--- a/client/src/components/profile/PassengersTab.js
+++ b/client/src/components/profile/PassengersTab.js
@@ -1,0 +1,79 @@
+import React, { useEffect, useState, useMemo, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Box, Button, Typography, Stack } from '@mui/material';
+
+import PassengerForm from '../booking/PassengerForm';
+import { fetchUserPassengers, createUserPassenger } from '../../redux/actions/passenger';
+import { fetchCountries } from '../../redux/actions/country';
+import { mapToApi, mappingConfigs } from '../utils/mappers';
+import { UI_LABELS } from '../../constants/uiLabels';
+
+const PassengersTab = () => {
+	const dispatch = useDispatch();
+	const { currentUser } = useSelector((state) => state.auth);
+	const { passengers } = useSelector((state) => state.passengers);
+	const { countries } = useSelector((state) => state.countries);
+	const [showForm, setShowForm] = useState(false);
+	const [data, setData] = useState({});
+	const formRef = useRef();
+
+	useEffect(() => {
+		if (currentUser) dispatch(fetchUserPassengers(currentUser.id));
+	}, [dispatch, currentUser]);
+
+	useEffect(() => {
+		if (!countries || countries.length === 0) dispatch(fetchCountries());
+	}, [countries, dispatch]);
+
+	const citizenshipOptions = useMemo(
+		() => (countries || []).map((c) => ({ value: c.id, label: c.name })),
+		[countries],
+	);
+
+	const handleChange = (_field, _value, d) => setData(d);
+
+	const handleSubmit = () => {
+		if (!formRef.current?.validate()) return;
+		const apiData = mapToApi(data, mappingConfigs.passenger);
+		dispatch(createUserPassenger({ userId: currentUser.id, data: apiData })).then(() => {
+			setShowForm(false);
+			setData({});
+		});
+	};
+
+	return (
+		<Box>
+			{passengers.length === 0 ? (
+				<Typography sx={{ mb: 2 }}>{UI_LABELS.PROFILE.no_passengers}</Typography>
+			) : (
+				<Stack spacing={1} sx={{ mb: 2 }}>
+					{passengers.map((p) => (
+						<Typography key={p.id}>{`${p.last_name} ${p.first_name}`}</Typography>
+					))}
+				</Stack>
+			)}
+			{showForm ? (
+				<Box>
+					<PassengerForm
+						passenger={data}
+						onChange={handleChange}
+						citizenshipOptions={citizenshipOptions}
+						ref={formRef}
+					/>
+					<Button variant='contained' onClick={handleSubmit} sx={{ mr: 1 }}>
+						{UI_LABELS.BOOKING.passenger_form.add_passenger}
+					</Button>
+					<Button variant='text' onClick={() => setShowForm(false)}>
+						{UI_LABELS.BUTTONS.cancel}
+					</Button>
+				</Box>
+			) : (
+				<Button variant='outlined' onClick={() => setShowForm(true)}>
+					{UI_LABELS.BOOKING.passenger_form.add_passenger}
+				</Button>
+			)}
+		</Box>
+	);
+};
+
+export default PassengersTab;

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -9,6 +9,7 @@ import Typography from '@mui/material/Typography';
 import { UI_LABELS } from '../../constants/uiLabels';
 import UserInfo from './UserInfo';
 import BookingsTab from './BookingsTab';
+import PassengersTab from './PassengersTab';
 import PasswordTab from './PasswordTab';
 
 const Profile = () => {
@@ -24,14 +25,16 @@ const Profile = () => {
 				<Typography variant='h5' sx={{ mb: 2 }}>
 					{UI_LABELS.PROFILE.settings}
 				</Typography>
-				<Tabs value={tab} onChange={handleChange} sx={{ mb: 3 }}>
-					<Tab label={UI_LABELS.PROFILE.user_info} />
-					<Tab label={UI_LABELS.PROFILE.bookings} />
-					<Tab label={UI_LABELS.PROFILE.change_password} />
-				</Tabs>
-				{tab === 0 && <UserInfo />}
-				{tab === 1 && <BookingsTab />}
-				{tab === 2 && <PasswordTab />}
+<Tabs value={tab} onChange={handleChange} sx={{ mb: 3 }}>
+<Tab label={UI_LABELS.PROFILE.user_info} />
+<Tab label={UI_LABELS.PROFILE.bookings} />
+<Tab label={UI_LABELS.PROFILE.passengers} />
+<Tab label={UI_LABELS.PROFILE.change_password} />
+</Tabs>
+{tab === 0 && <UserInfo />}
+{tab === 1 && <BookingsTab />}
+{tab === 2 && <PassengersTab />}
+{tab === 3 && <PasswordTab />}
 			</Paper>
 		</Box>
 	);

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -290,22 +290,24 @@ export const UI_LABELS = {
 		or: 'или',
 		forgot_password: 'Забыли пароль?',
 	},
-	PROFILE: {
-		profile: 'Профиль',
-		settings: 'Настройки профиля',
-		maintenance: 'Скоро здесь будет личный кабинет',
-		change_password: 'Сменить пароль',
-		password_changed: 'Пароль успешно изменен',
-		passwords_dont_match: 'Пароли не совпадают',
-		user_info: 'Данные пользователя',
-		email: 'Электронная почта',
-		role: 'Роль',
-		bookings: 'Мои бронирования',
-		no_bookings: 'Бронирования отсутствуют',
-		booking_number: 'Номер',
-		status: 'Статус',
-		total_price: 'Сумма',
-	},
+PROFILE: {
+profile: 'Профиль',
+settings: 'Настройки профиля',
+maintenance: 'Скоро здесь будет личный кабинет',
+change_password: 'Сменить пароль',
+password_changed: 'Пароль успешно изменен',
+passwords_dont_match: 'Пароли не совпадают',
+user_info: 'Данные пользователя',
+email: 'Электронная почта',
+role: 'Роль',
+bookings: 'Мои бронирования',
+passengers: 'Пассажиры',
+no_passengers: 'Пассажиры отсутствуют',
+no_bookings: 'Бронирования отсутствуют',
+booking_number: 'Номер',
+status: 'Статус',
+total_price: 'Сумма',
+},
 	HOME: {},
 	BOOKING: {
 		progress_steps: {
@@ -382,9 +384,9 @@ export const UI_LABELS = {
 				infants_seat: 'Младенцы с местом',
 			},
 		},
-		passenger_form: {
-			type_labels: {
-				adult: 'Взрослый, старше 12 лет',
+passenger_form: {
+type_labels: {
+adult: 'Взрослый, старше 12 лет',
 				child: 'Ребёнок, от 2 до 12 лет',
 				infant: 'Младенец, до 2 лет',
 				infant_seat: 'Младенец с местом, до 2 лет',
@@ -392,10 +394,11 @@ export const UI_LABELS = {
 			add_passenger: 'Добавить пассажира',
 			last_name: 'Фамилия',
 			first_name: 'Имя',
-			patronymic_name: 'Отчество (при наличии)',
-			name_hint: (requiresCyrillic) =>
-				`${requiresCyrillic ? 'Кириллицей' : 'Латиницей'}, как в документе`,
-		},
+patronymic_name: 'Отчество (при наличии)',
+name_hint: (requiresCyrillic) =>
+`${requiresCyrillic ? 'Кириллицей' : 'Латиницей'}, как в документе`,
+login_hint: 'Войдите, чтобы заполнить данные пассажиров автоматически',
+},
 		payment_form: {
 			title: (timeLeft) => `${timeLeft} для оплаты`,
 			total: 'К оплате',

--- a/client/src/redux/actions/passenger.js
+++ b/client/src/redux/actions/passenger.js
@@ -1,4 +1,6 @@
-import { createCrudActions } from '../utils';
+import { createCrudActions, getErrorData } from '../utils';
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { serverApi } from '../../api';
 
 export const {
 	fetchAll: fetchPassengers,
@@ -8,3 +10,27 @@ export const {
 	remove: deletePassenger,
 	removeAll: deleteAllPassengers,
 } = createCrudActions('passengers');
+
+export const fetchUserPassengers = createAsyncThunk(
+	'passengers/fetchUserPassengers',
+	async (userId, { rejectWithValue }) => {
+		try {
+			const res = await serverApi.get(`/users/${userId}/passengers`);
+			return res.data;
+		} catch (err) {
+			return rejectWithValue(getErrorData(err));
+		}
+	},
+);
+
+export const createUserPassenger = createAsyncThunk(
+	'passengers/createUserPassenger',
+	async ({ userId, data }, { rejectWithValue }) => {
+		try {
+			const res = await serverApi.post(`/users/${userId}/passengers`, data);
+			return res.data;
+		} catch (err) {
+			return rejectWithValue(getErrorData(err));
+		}
+	},
+);

--- a/client/src/redux/reducers/passenger.js
+++ b/client/src/redux/reducers/passenger.js
@@ -6,8 +6,10 @@ import {
 	createPassenger,
 	updatePassenger,
 	deletePassenger,
+	fetchUserPassengers,
+	createUserPassenger,
 } from '../actions/passenger';
-import { addCrudCases } from '../utils';
+import { addCrudCases, handlePending, handleRejected } from '../utils';
 
 const initialState = {
 	passengers: [],
@@ -33,6 +35,20 @@ const passengerSlice = createSlice({
 			'passengers',
 			'passenger'
 		);
+
+		builder
+			.addCase(fetchUserPassengers.pending, handlePending)
+			.addCase(fetchUserPassengers.fulfilled, (state, action) => {
+				state.passengers = action.payload;
+				state.isLoading = false;
+			})
+			.addCase(fetchUserPassengers.rejected, handleRejected)
+			.addCase(createUserPassenger.pending, handlePending)
+			.addCase(createUserPassenger.fulfilled, (state, action) => {
+				state.passengers.push(action.payload);
+				state.isLoading = false;
+			})
+			.addCase(createUserPassenger.rejected, handleRejected);
 	},
 });
 

--- a/server/app/app.py
+++ b/server/app/app.py
@@ -79,6 +79,8 @@ def __create_app(_config_class, _db):
     app.route('/users/<int:user_id>/activate', methods=['PUT'])(activate_user)
     app.route('/users/<int:user_id>/deactivate', methods=['PUT'])(deactivate_user)
     app.route('/users/<int:user_id>/bookings', methods=['GET'])(get_user_bookings)
+    app.route('/users/<int:user_id>/passengers', methods=['GET'])(get_user_passengers)
+    app.route('/users/<int:user_id>/passengers', methods=['POST'])(create_user_passenger)
     app.route('/users/change_password', methods=['PUT'])(change_password)
 
     # airports

--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -2,6 +2,7 @@ from flask import request, jsonify
 
 from app.models.user import User
 from app.models.booking import Booking
+from app.models.passenger import Passenger
 from app.middlewares.auth_middleware import admin_required, login_required
 
 
@@ -66,6 +67,23 @@ def get_user_bookings(current_user, user_id):
         return jsonify({'message': 'Forbidden'}), 403
     bookings = Booking.query.filter_by(user_id=user_id).all()
     return jsonify([b.to_dict() for b in bookings])
+
+
+@login_required
+def get_user_passengers(current_user, user_id):
+    if current_user.id != user_id:
+        return jsonify({'message': 'Forbidden'}), 403
+    passengers = Passenger.query.filter_by(owner_user_id=user_id).all()
+    return jsonify([p.to_dict() for p in passengers])
+
+
+@login_required
+def create_user_passenger(current_user, user_id):
+    if current_user.id != user_id:
+        return jsonify({'message': 'Forbidden'}), 403
+    body = request.json or {}
+    passenger = Passenger.create(owner_user_id=user_id, **body)
+    return jsonify(passenger.to_dict()), 201
 
 
 @login_required


### PR DESCRIPTION
## Summary
- add API for retrieving and creating passengers linked to current user
- expose user passengers in profile with ability to add new entries
- allow selecting saved passengers during booking with login hint

## Testing
- `pytest` *(fails: TypeError: str expected, not NoneType)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaca801774832fa09daeee7435278a