### PR TITLE
Enforce ownership checks and server-driven admin routing

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,7 +11,7 @@ import AuthModal from './components/auth/AuthModal';
 import AdminRoutes from './routes/AdminRoutes';
 import PublicRoutes from './routes/PublicRoutes';
 
-import { selectIsAuth, selectIsAdmin } from './redux/reducers/auth';
+import { selectIsAuth } from './redux/reducers/auth';
 import { auth } from './redux/actions/auth';
 import theme from './theme';
 
@@ -20,7 +20,7 @@ function App() {
 	const [isLoading, setIsLoading] = useState(true);
 
 	const isAuth = useSelector(selectIsAuth);
-	const isAdmin = useSelector(selectIsAdmin);
+	const currentUser = useSelector((state) => state.auth.currentUser);
 
 	useEffect(() => {
 		const initAuth = async () => {
@@ -31,7 +31,7 @@ function App() {
 		initAuth();
 	}, [dispatch]);
 
-        const routes = [...PublicRoutes({ isAuth }), ...AdminRoutes({ isAdmin })];
+	const routes = [...PublicRoutes({ isAuth }), ...AdminRoutes({ currentUser })];
 	const routing = useRoutes(routes);
 
 	// Show loading indicator while authenticating

--- a/client/src/routes/AdminRoutes.js
+++ b/client/src/routes/AdminRoutes.js
@@ -22,7 +22,9 @@ import ConsentEventManagement from '../components/admin/ConsentEventManagement';
 
 import ProtectedRoute from './ProtectedRoute';
 
-const AdminRoutes = ({ isAdmin }) => [
+const AdminRoutes = ({ currentUser }) => {
+	const isAdmin = currentUser?.role === 'admin';
+	return [
 	{
 		path: '/admin',
 		element: <ProtectedRoute children={<AdminPanel />} condition={isAdmin} />,
@@ -98,7 +100,8 @@ const AdminRoutes = ({ isAdmin }) => [
 	{
 		path: '/admin/exports/flight-passengers',
 		element: <ProtectedRoute children={<FlightPassengerExport />} condition={isAdmin} />,
-	},
-];
+},
+	];
+};
 
 export default AdminRoutes;

--- a/server/app/controllers/booking_controller.py
+++ b/server/app/controllers/booking_controller.py
@@ -5,8 +5,8 @@ from app.database import db
 from app.models.booking import Booking
 from app.models.booking_passenger import BookingPassenger
 from app.models.passenger import Passenger
-from app.utils.enum import BOOKING_STATUS
-from app.middlewares.auth_middleware import admin_required
+from app.utils.enum import BOOKING_STATUS, USER_ROLE
+from app.middlewares.auth_middleware import admin_required, login_required
 
 
 @admin_required
@@ -15,9 +15,11 @@ def get_bookings(current_user):
     return jsonify([booking.to_dict() for booking in bookings])
 
 
-@admin_required
+@login_required
 def get_booking(current_user, booking_id):
     booking = Booking.get_or_404(booking_id)
+    if current_user.role != USER_ROLE.admin and booking.user_id != current_user.id:
+        return jsonify({'message': 'Forbidden'}), 403
     return jsonify(booking.to_dict()), 200
 
 

--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -3,6 +3,7 @@ from flask import request, jsonify
 from app.models.user import User
 from app.models.booking import Booking
 from app.models.passenger import Passenger
+from app.utils.enum import USER_ROLE
 from app.middlewares.auth_middleware import admin_required, login_required
 
 
@@ -63,7 +64,7 @@ def deactivate_user(current_user, user_id):
 
 @login_required
 def get_user_bookings(current_user, user_id):
-    if current_user.id != user_id:
+    if current_user.id != user_id and current_user.role != USER_ROLE.admin:
         return jsonify({'message': 'Forbidden'}), 403
     bookings = Booking.query.filter_by(user_id=user_id).all()
     return jsonify([b.to_dict() for b in bookings])
@@ -71,7 +72,7 @@ def get_user_bookings(current_user, user_id):
 
 @login_required
 def get_user_passengers(current_user, user_id):
-    if current_user.id != user_id:
+    if current_user.id != user_id and current_user.role != USER_ROLE.admin:
         return jsonify({'message': 'Forbidden'}), 403
     passengers = Passenger.query.filter_by(owner_user_id=user_id).all()
     return jsonify([p.to_dict() for p in passengers])
@@ -79,7 +80,7 @@ def get_user_passengers(current_user, user_id):
 
 @login_required
 def create_user_passenger(current_user, user_id):
-    if current_user.id != user_id:
+    if current_user.id != user_id and current_user.role != USER_ROLE.admin:
         return jsonify({'message': 'Forbidden'}), 403
     body = request.json or {}
     passenger = Passenger.create(owner_user_id=user_id, **body)


### PR DESCRIPTION
## Summary
- require login and ownership validation when retrieving bookings
- allow admins to access any user's bookings or passengers
- drive admin routing from server-supplied user role

## Testing
- `ruff check app/controllers/booking_controller.py app/controllers/user_controller.py`
- `pytest` *(fails: ImportError while loading conftest 'TypeError: str expected, not NoneType')*
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68aaddc662a0832fa94fe320a9fc4a79