### PR TITLE
Refactor admin 2FA workflow

### DIFF
--- a/client/src/components/auth/Login.js
+++ b/client/src/components/auth/Login.js
@@ -22,7 +22,7 @@ import { authIconContainer, authIcon, authLink } from '../../theme/styles';
 
 import Base from '../Base';
 import { selectIsAdmin } from '../../redux/reducers/auth';
-import { login, setupTwoFactor, verifyTwoFactor } from '../../redux/actions/auth';
+import { login, verifyTwoFactor } from '../../redux/actions/auth';
 import { useAuthModal } from '../../context/AuthModalContext';
 import { FIELD_LABELS, UI_LABELS } from '../../constants';
 
@@ -39,11 +39,12 @@ const Login = ({ isModal = false }) => {
 		password: '',
 	});
 
-		const [errors, setErrors] = useState({});
-		const [successMessage, setSuccessMessage] = useState('');
-		const [twoFactorRequired, setTwoFactorRequired] = useState(false);
-		const [code, setCode] = useState('');
-		const [twoFactorErrors, setTwoFactorErrors] = useState({});
+const [errors, setErrors] = useState({});
+const [successMessage, setSuccessMessage] = useState('');
+const [twoFactorRequired, setTwoFactorRequired] = useState(false);
+const [code, setCode] = useState('');
+const [twoFactorErrors, setTwoFactorErrors] = useState({});
+const [twoFactorEmail, setTwoFactorEmail] = useState('');
 
 	useEffect(() => {
 		if (successMessage && isAdmin) {
@@ -69,14 +70,14 @@ const Login = ({ isModal = false }) => {
 										setTimeout(() => closeAuthModal(), 1500);
 								}
 						})
-						.catch((res) => {
-								if (res && res.message === 'Two-factor authentication required') {
-										setTwoFactorRequired(true);
-										dispatch(setupTwoFactor(email));
-								} else {
-										setErrors(res);
-								}
-						});
+.catch((res) => {
+if (res && res.message === 'Two-factor authentication required') {
+setTwoFactorRequired(true);
+setTwoFactorEmail(res.email || email);
+} else {
+setErrors(res);
+}
+});
 		};
 
 		const onVerify = async (e) => {
@@ -188,25 +189,28 @@ const Login = ({ isModal = false }) => {
 												</Button>
 										</Box>
 								) : !successMessage && twoFactorRequired ? (
-										<Box component='form' onSubmit={onVerify}>
-												<TextField
-														margin='dense'
-														required
-														fullWidth
-														id='code'
-														label='Код'
-														name='code'
-														autoFocus
-														value={code}
-														onChange={(e) => setCode(e.target.value)}
-														error={!!twoFactorErrors.message}
-														helperText={twoFactorErrors.message ? twoFactorErrors.message : ''}
-												/>
-												<Divider sx={{ my: 1 }} />
-												<Button type='submit' fullWidth variant='contained'>
-														{UI_LABELS.BUTTONS.confirm}
-												</Button>
-										</Box>
+								<Box component='form' onSubmit={onVerify}>
+									<Alert severity='info' sx={{ mb: 2 }}>
+									{UI_LABELS.AUTH.two_factor_prompt(twoFactorEmail)}
+									</Alert>
+									<TextField
+									margin='dense'
+									required
+									fullWidth
+									id='code'
+									label={UI_LABELS.AUTH.two_factor_code_label}
+									name='code'
+									autoFocus
+									value={code}
+									onChange={(e) => setCode(e.target.value)}
+									error={!!twoFactorErrors.message}
+									helperText={twoFactorErrors.message ? twoFactorErrors.message : ''}
+									/>
+									<Divider sx={{ my: 1 }} />
+									<Button type='submit' fullWidth variant='contained'>
+									{UI_LABELS.BUTTONS.confirm}
+									</Button>
+								</Box>
 								) : (
 										<Box
 												sx={{

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -289,6 +289,8 @@ export const UI_LABELS = {
 		have_account: 'Уже есть аккаунт?',
 		or: 'или',
 		forgot_password: 'Забыли пароль?',
+		two_factor_prompt: (email) => `Введите код, отправленный на ${email}`,
+		two_factor_code_label: 'Код',
 	},
 PROFILE: {
 profile: 'Профиль',

--- a/client/src/redux/actions/auth.js
+++ b/client/src/redux/actions/auth.js
@@ -36,15 +36,6 @@ export const login = createAsyncThunk('auth/login', async (formData, { rejectWit
 	}
 });
 
-export const setupTwoFactor = createAsyncThunk('auth/setupTwoFactor', async (email, { rejectWithValue }) => {
-	try {
-		const res = await serverApi.post('/setup_2fa', { email: email.toLowerCase() });
-		return res.data;
-	} catch (err) {
-		return rejectWithValue(getErrorData(err));
-	}
-});
-
 export const verifyTwoFactor = createAsyncThunk('auth/verifyTwoFactor', async (data, { rejectWithValue }) => {
 	try {
 		const res = await serverApi.post('/verify_2fa', { ...data, email: data.email.toLowerCase() });


### PR DESCRIPTION
## Summary
- trigger server-side 2FA only when an admin logs in with a valid email
- fix TOTP verification interval and type handling
- display 2FA email info to admins during login and simplify client flow
- centralize 2FA prompt text in shared UI labels

## Testing
- `pytest -q` *(fails: TypeError: str expected, not NoneType)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68ab48a963cc832f81bbb837c8c9360d