### PR TITLE
feat(auth): block inputs during auth requests

### DIFF
--- a/client/src/components/auth/Login.js
+++ b/client/src/components/auth/Login.js
@@ -33,6 +33,7 @@ const Login = ({ isModal = false }) => {
 	const { closeAuthModal, openRegisterModal, openForgotPasswordModal, authModal } = useAuthModal();
 
 	const isAdmin = useSelector(selectIsAdmin);
+	const isLoading = useSelector((state) => state.auth.isLoading);
 
 	const [formData, setFormData] = useState({
 		email: '',
@@ -176,6 +177,7 @@ const Login = ({ isModal = false }) => {
 							onChange={onChange}
 							error={!!errors.email}
 							helperText={errors.email ? errors.email : ''}
+							disabled={isLoading}
 						/>
 						<TextField
 							margin='dense'
@@ -190,10 +192,11 @@ const Login = ({ isModal = false }) => {
 							onChange={onChange}
 							error={!!errors.password}
 							helperText={errors.password ? errors.password : ''}
+							disabled={isLoading}
 						/>
 						<Divider sx={{ my: 1 }} />
-						<Button type='submit' fullWidth variant='contained'>
-							{UI_LABELS.BUTTONS.login}
+						<Button type='submit' fullWidth variant='contained' disabled={isLoading} >
+							{isLoading ? <CircularProgress size={24} color='inherit' /> : UI_LABELS.BUTTONS.login}
 						</Button>
 					</Box>
 				) : !successMessage && twoFactorRequired ? (
@@ -213,10 +216,11 @@ const Login = ({ isModal = false }) => {
 							onChange={(e) => setCode(e.target.value)}
 							error={!!twoFactorErrors.message}
 							helperText={twoFactorErrors.message ? twoFactorErrors.message : ''}
+							disabled={isLoading}
 						/>
 						<Divider sx={{ my: 1 }} />
-						<Button type='submit' fullWidth variant='contained'>
-							{UI_LABELS.BUTTONS.confirm}
+						<Button type='submit' fullWidth variant='contained' disabled={isLoading} >
+							{isLoading ? <CircularProgress size={24} color='inherit' /> : UI_LABELS.BUTTONS.confirm}
 						</Button>
 					</Box>
 				) : (

--- a/client/src/components/auth/Register.js
+++ b/client/src/components/auth/Register.js
@@ -28,6 +28,7 @@ import { FIELD_LABELS, UI_LABELS } from '../../constants';
 const Register = ({ isModal = false }) => {
 	const dispatch = useDispatch();
 	const isAuth = useSelector(selectIsAuth);
+	const isLoading = useSelector((state) => state.auth.isLoading);
 	const { closeAuthModal, openLoginModal } = useAuthModal();
 
 	const [formData, setFormData] = useState({
@@ -136,6 +137,7 @@ const Register = ({ isModal = false }) => {
 							onChange={onChange}
 							error={!!errors.email}
 							helperText={errors.email ? errors.email : ''}
+							disabled={isLoading}
 						/>
 						<TextField
 							margin='dense'
@@ -150,6 +152,7 @@ const Register = ({ isModal = false }) => {
 							onChange={onChange}
 							error={!!errors.password}
 							helperText={errors.email ? errors.email : ''}
+							disabled={isLoading}
 						/>
 						<TextField
 							margin='dense'
@@ -164,10 +167,11 @@ const Register = ({ isModal = false }) => {
 							onChange={onChange}
 							error={!!errors.password2}
 							helperText={errors.email ? errors.email : ''}
+							disabled={isLoading}
 						/>
 						<Divider sx={{ my: 1 }} />
-						<Button type='submit' fullWidth variant='contained'>
-							{UI_LABELS.BUTTONS.register}
+						<Button type='submit' fullWidth variant='contained' disabled={isLoading} >
+							{isLoading ? <CircularProgress size={24} color='inherit' /> : UI_LABELS.BUTTONS.register}
 						</Button>
 					</Box>
 				) : (


### PR DESCRIPTION
## Summary
- disable login and register fields while authentication requests run
- show a spinner in submit buttons and two-factor verification during loading

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npx eslint src/components/auth/Login.js src/components/auth/Register.js` *(fails: ESLint couldn't find a configuration file)*
- `npx prettier --check src/components/auth/Login.js src/components/auth/Register.js` *(warn: code style issues found in 2 files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9f895840832fac1ca46623030351