### PR TITLE
Refactor profile page and improve profile tabs

### DIFF
--- a/client/src/components/profile/BookingsTab.js
+++ b/client/src/components/profile/BookingsTab.js
@@ -9,6 +9,7 @@ import TableRow from '@mui/material/TableRow';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
 
 import { fetchUserBookings } from '../../redux/actions/booking';
 import { UI_LABELS } from '../../constants/uiLabels';
@@ -24,38 +25,45 @@ const BookingsTab = () => {
 		}
 	}, [dispatch, currentUser]);
 
-	if (isLoading) {
-		return <Typography>{UI_LABELS.MESSAGES.loading}</Typography>;
-	}
+		if (isLoading) {
+				return <Typography>{UI_LABELS.MESSAGES.loading}</Typography>;
+		}
 
-	return bookings && bookings.length ? (
-		<TableContainer component={Paper}>
-			<Table size='small'>
-				<TableHead>
-					<TableRow>
-						<TableCell>
-							{UI_LABELS.PROFILE.booking_number}
-						</TableCell>
-						<TableCell>{UI_LABELS.PROFILE.status}</TableCell>
-						<TableCell align='right'>
-							{UI_LABELS.PROFILE.total_price}
-						</TableCell>
-					</TableRow>
-				</TableHead>
-				<TableBody>
-					{bookings.map((b) => (
-						<TableRow key={b.id}>
-							<TableCell>{b.booking_number}</TableCell>
-							<TableCell>{b.status}</TableCell>
-							<TableCell align='right'>{b.total_price}</TableCell>
-						</TableRow>
-					))}
-				</TableBody>
-			</Table>
-		</TableContainer>
-	) : (
-		<Typography>{UI_LABELS.PROFILE.no_bookings}</Typography>
-	);
+		return bookings && bookings.length ? (
+				<Box>
+						<Typography variant='h6' sx={{ mb: 2 }}>
+								{UI_LABELS.PROFILE.bookings}
+						</Typography>
+						<TableContainer component={Paper}>
+								<Table size='small'>
+										<TableHead sx={{ bgcolor: 'background.paper' }}>
+												<TableRow>
+														<TableCell sx={{ fontWeight: 'bold' }}>
+																{UI_LABELS.PROFILE.booking_number}
+														</TableCell>
+														<TableCell sx={{ fontWeight: 'bold' }}>
+																{UI_LABELS.PROFILE.status}
+														</TableCell>
+														<TableCell align='right' sx={{ fontWeight: 'bold' }}>
+																{UI_LABELS.PROFILE.total_price}
+														</TableCell>
+												</TableRow>
+										</TableHead>
+										<TableBody>
+												{bookings.map((b) => (
+														<TableRow key={b.id}>
+																<TableCell>{b.booking_number}</TableCell>
+																<TableCell>{b.status}</TableCell>
+																<TableCell align='right'>{b.total_price}</TableCell>
+														</TableRow>
+												))}
+										</TableBody>
+								</Table>
+						</TableContainer>
+				</Box>
+		) : (
+				<Typography>{UI_LABELS.PROFILE.no_bookings}</Typography>
+		);
 };
 
 export default BookingsTab;

--- a/client/src/components/profile/PassengersTab.js
+++ b/client/src/components/profile/PassengersTab.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Box, Button, Typography, Stack } from '@mui/material';
+import { Box, Button, Typography, Stack, Paper } from '@mui/material';
 
 import PassengerForm from '../booking/PassengerForm';
 import { fetchUserPassengers, createUserPassenger } from '../../redux/actions/passenger';
@@ -41,39 +41,41 @@ const PassengersTab = () => {
 		});
 	};
 
-	return (
-		<Box>
-			{passengers.length === 0 ? (
-				<Typography sx={{ mb: 2 }}>{UI_LABELS.PROFILE.no_passengers}</Typography>
-			) : (
-				<Stack spacing={1} sx={{ mb: 2 }}>
-					{passengers.map((p) => (
-						<Typography key={p.id}>{`${p.last_name} ${p.first_name}`}</Typography>
-					))}
-				</Stack>
-			)}
-			{showForm ? (
+		return (
 				<Box>
-					<PassengerForm
-						passenger={data}
-						onChange={handleChange}
-						citizenshipOptions={citizenshipOptions}
-						ref={formRef}
-					/>
-					<Button variant='contained' onClick={handleSubmit} sx={{ mr: 1 }}>
-						{UI_LABELS.BOOKING.passenger_form.add_passenger}
-					</Button>
-					<Button variant='text' onClick={() => setShowForm(false)}>
-						{UI_LABELS.BUTTONS.cancel}
-					</Button>
+						{passengers.length === 0 ? (
+								<Typography sx={{ mb: 2 }}>{UI_LABELS.PROFILE.no_passengers}</Typography>
+						) : (
+								<Stack spacing={1} sx={{ mb: 2 }}>
+										{passengers.map((p) => (
+												<Paper key={p.id} sx={{ p: 1 }}>
+														<Typography>{`${p.last_name} ${p.first_name}`}</Typography>
+												</Paper>
+										))}
+								</Stack>
+						)}
+						{showForm ? (
+								<Paper sx={{ p: 2 }}>
+										<PassengerForm
+												passenger={data}
+												onChange={handleChange}
+												citizenshipOptions={citizenshipOptions}
+												ref={formRef}
+										/>
+										<Button variant='contained' onClick={handleSubmit} sx={{ mr: 1 }}>
+												{UI_LABELS.BOOKING.passenger_form.add_passenger}
+										</Button>
+										<Button variant='text' onClick={() => setShowForm(false)}>
+												{UI_LABELS.BUTTONS.cancel}
+										</Button>
+								</Paper>
+						) : (
+								<Button variant='outlined' onClick={() => setShowForm(true)}>
+										{UI_LABELS.BOOKING.passenger_form.add_passenger}
+								</Button>
+						)}
 				</Box>
-			) : (
-				<Button variant='outlined' onClick={() => setShowForm(true)}>
-					{UI_LABELS.BOOKING.passenger_form.add_passenger}
-				</Button>
-			)}
-		</Box>
-	);
+		);
 };
 
 export default PassengersTab;

--- a/client/src/components/profile/PasswordTab.js
+++ b/client/src/components/profile/PasswordTab.js
@@ -5,6 +5,8 @@ import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
 
 import { changePassword } from '../../redux/actions/user';
 import { UI_LABELS } from '../../constants/uiLabels';
@@ -45,51 +47,56 @@ const PasswordTab = () => {
 			});
 	};
 
-	return (
-		<Box component='form' onSubmit={handleSubmit} sx={{ maxWidth: 400 }}>
-			{errors.message && (
-				<Alert severity='error' sx={{ mb: 2 }}>
-					{errors.message}
-				</Alert>
-			)}
-			{successMessage && (
-				<Alert severity='success' sx={{ mb: 2 }}>
-					{successMessage}
-				</Alert>
-			)}
-			<TextField
-				margin='dense'
-				required
-				fullWidth
-				name='newPassword'
-				label={UI_LABELS.AUTH.new_password}
-				type='password'
-				id='newPassword'
-				value={passwordData.newPassword}
-				onChange={handleChange}
-				error={!!errors.newPassword}
-				helperText={errors.newPassword ? errors.newPassword : ''}
-			/>
-			<TextField
-				margin='dense'
-				required
-				fullWidth
-				name='confirmPassword'
-				label={UI_LABELS.AUTH.confirm_password}
-				type='password'
-				id='confirmPassword'
-				value={passwordData.confirmPassword}
-				onChange={handleChange}
-				error={!!errors.confirmPassword}
-				helperText={
-					errors.confirmPassword ? errors.confirmPassword : ''
-				}
-			/>
-			<Button type='submit' fullWidth variant='contained' sx={{ mt: 2 }}>
-				{UI_LABELS.BUTTONS.save_changes}
-			</Button>
-		</Box>
-	);
+		return (
+				<Paper sx={{ p: 2, maxWidth: 400 }}>
+						<Typography variant='h6' sx={{ mb: 2 }}>
+								{UI_LABELS.PROFILE.change_password}
+						</Typography>
+						<Box component='form' onSubmit={handleSubmit}>
+								{errors.message && (
+										<Alert severity='error' sx={{ mb: 2 }}>
+												{errors.message}
+										</Alert>
+								)}
+								{successMessage && (
+										<Alert severity='success' sx={{ mb: 2 }}>
+												{successMessage}
+										</Alert>
+								)}
+								<TextField
+										margin='dense'
+										required
+										fullWidth
+										name='newPassword'
+										label={UI_LABELS.AUTH.new_password}
+										type='password'
+										id='newPassword'
+										value={passwordData.newPassword}
+										onChange={handleChange}
+										error={!!errors.newPassword}
+										helperText={errors.newPassword ? errors.newPassword : ''}
+								/>
+								<TextField
+										margin='dense'
+										required
+										fullWidth
+										name='confirmPassword'
+										label={UI_LABELS.AUTH.confirm_password}
+										type='password'
+										id='confirmPassword'
+										value={passwordData.confirmPassword}
+										onChange={handleChange}
+										error={!!errors.confirmPassword}
+										helperText={
+												errors.confirmPassword ? errors.confirmPassword : ''
+										}
+								/>
+								<Button type='submit' fullWidth variant='contained' sx={{ mt: 2 }}>
+										{UI_LABELS.BUTTONS.save_changes}
+								</Button>
+						</Box>
+				</Paper>
+		);
 };
 
 export default PasswordTab;

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -5,7 +5,12 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
+import PersonIcon from '@mui/icons-material/Person';
+import FlightIcon from '@mui/icons-material/Flight';
+import GroupIcon from '@mui/icons-material/Group';
+import LockIcon from '@mui/icons-material/Lock';
 
+import Base from '../Base';
 import { UI_LABELS } from '../../constants/uiLabels';
 import UserInfo from './UserInfo';
 import BookingsTab from './BookingsTab';
@@ -20,24 +25,34 @@ const Profile = () => {
 	};
 
 	return (
-		<Box sx={{ maxWidth: 900, mx: 'auto', p: 4 }}>
-			<Paper elevation={3} sx={{ p: 3 }}>
-				<Typography variant='h5' sx={{ mb: 2 }}>
-					{UI_LABELS.PROFILE.settings}
-				</Typography>
-<Tabs value={tab} onChange={handleChange} sx={{ mb: 3 }}>
-<Tab label={UI_LABELS.PROFILE.user_info} />
-<Tab label={UI_LABELS.PROFILE.bookings} />
-<Tab label={UI_LABELS.PROFILE.passengers} />
-<Tab label={UI_LABELS.PROFILE.change_password} />
-</Tabs>
-{tab === 0 && <UserInfo />}
-{tab === 1 && <BookingsTab />}
-{tab === 2 && <PassengersTab />}
-{tab === 3 && <PasswordTab />}
-			</Paper>
-		</Box>
+		<Base maxWidth='md'>
+			<Box sx={{ maxWidth: 900, mx: 'auto', p: 4 }}>
+				<Paper elevation={3} sx={{ p: 3 }}>
+					<Typography variant='h5' sx={{ mb: 2 }}>
+						{UI_LABELS.PROFILE.settings}
+					</Typography>
+					<Tabs
+						value={tab}
+						onChange={handleChange}
+						variant='fullWidth'
+						indicatorColor='primary'
+						textColor='primary'
+						sx={{ mb: 3 }}
+					>
+						<Tab icon={<PersonIcon />} label={UI_LABELS.PROFILE.user_info} />
+						<Tab icon={<FlightIcon />} label={UI_LABELS.PROFILE.bookings} />
+						<Tab icon={<GroupIcon />} label={UI_LABELS.PROFILE.passengers} />
+						<Tab icon={<LockIcon />} label={UI_LABELS.PROFILE.change_password} />
+					</Tabs>
+					{tab === 0 && <UserInfo />}
+					{tab === 1 && <BookingsTab />}
+					{tab === 2 && <PassengersTab />}
+					{tab === 3 && <PasswordTab />}
+				</Paper>
+			</Box>
+		</Base>
 	);
 };
 
 export default Profile;
+

--- a/client/src/components/profile/UserInfo.js
+++ b/client/src/components/profile/UserInfo.js
@@ -2,7 +2,8 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 
 import Typography from '@mui/material/Typography';
-import Box from '@mui/material/Box';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
 
 import { UI_LABELS } from '../../constants/uiLabels';
 
@@ -10,14 +11,18 @@ const UserInfo = () => {
 	const currentUser = useSelector((state) => state.auth.currentUser);
 
 	return (
-		<Box>
+		<Paper sx={{ p: 2 }}>
 			<Typography variant='h6' gutterBottom>
 				{UI_LABELS.PROFILE.user_info}
 			</Typography>
-			<Typography>{`${UI_LABELS.PROFILE.email}: ${currentUser?.email}`}</Typography>
-			<Typography>{`${UI_LABELS.PROFILE.role}: ${currentUser?.role}`}</Typography>
-		</Box>
+			<Stack spacing={1}>
+				<Typography>
+					{`${UI_LABELS.PROFILE.email}: ${currentUser?.email}`}
+				</Typography>
+			</Stack>
+		</Paper>
 	);
 };
 
 export default UserInfo;
+


### PR DESCRIPTION
## Summary
- Wrap profile page with shared Base layout and add icons to tabs
- Restyle profile tabs and remove user role from displayed info

## Testing
- `npx eslint src/components/profile/*.js` *(fails: ESLint couldn't find a configuration file)*
- `npm test -- --watchAll=false --passWithNoTests`
- `npx prettier --write --use-tabs --tab-width 4 client/src/components/profile/Profile.js` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68aea6113264832f841f7e5aee1afad5