### PR TITLE
Integrate password change into profile and add user names

### DIFF
--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -127,25 +127,36 @@ const Passengers = () => {
 	};
 
 	const [buyer, setBuyer] = useState({
-		buyerLastName: '',
-		buyerFirstName: '',
-		emailAddress: '',
-		phoneNumber: '',
-		consent: false,
+	        buyerLastName: '',
+	        buyerFirstName: '',
+	        emailAddress: '',
+	        phoneNumber: '',
+	        consent: false,
 	});
 
 	useEffect(() => {
-		if (passengersExist) {
-			const mapped = fromApiBuyer(booking);
-			setBuyer({
-				buyerLastName: mapped.buyerLastName || '',
-				buyerFirstName: mapped.buyerFirstName || '',
-				emailAddress: mapped.emailAddress || '',
-				phoneNumber: mapped.phoneNumber || '',
-				consent: mapped.consent || false,
-			});
-		}
+	        if (passengersExist) {
+	                const mapped = fromApiBuyer(booking);
+	                setBuyer({
+	                        buyerLastName: mapped.buyerLastName || '',
+	                        buyerFirstName: mapped.buyerFirstName || '',
+	                        emailAddress: mapped.emailAddress || '',
+	                        phoneNumber: mapped.phoneNumber || '',
+	                        consent: mapped.consent || false,
+	                });
+	        }
 	}, [booking, passengersExist]);
+
+	useEffect(() => {
+		if (currentUser?.first_name && currentUser?.last_name) {
+			setBuyer((prev) => ({
+				...prev,
+				buyerLastName: prev.buyerLastName || currentUser.last_name,
+				buyerFirstName: prev.buyerFirstName || currentUser.first_name,
+			}));
+		}
+	}, [currentUser]);
+
 
 	const buyerFormFields = useMemo(() => {
 		const fields = {

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -8,7 +8,7 @@ import Typography from '@mui/material/Typography';
 import PersonIcon from '@mui/icons-material/Person';
 import FlightIcon from '@mui/icons-material/Flight';
 import GroupIcon from '@mui/icons-material/Group';
-import LockIcon from '@mui/icons-material/Lock';
+import Stack from '@mui/material/Stack';
 
 import Base from '../Base';
 import { UI_LABELS } from '../../constants/uiLabels';
@@ -26,31 +26,34 @@ const Profile = () => {
 
 	return (
 		<Base maxWidth='lg'>
-			<Box sx={{ maxWidth: 900, mx: 'auto', p: 4 }}>
-				<Paper elevation={0} sx={{ p: 3 }}>
+	                <Box sx={{ maxWidth: 900, mx: 'auto', p: 4, mt: 6 }}>
+	                        <Paper elevation={0} sx={{ p: 3 }}>
 					<Typography variant='h5' sx={{ mb: 2 }}>
 						{UI_LABELS.PROFILE.settings}
 					</Typography>
-					<Tabs
-						value={tab}
-						onChange={handleChange}
-						variant='fullWidth'
-						indicatorColor='primary'
-						textColor='primary'
-						sx={{ mb: 3 }}
-					>
-						<Tab icon={<PersonIcon />} label={UI_LABELS.PROFILE.user_info} />
-						<Tab icon={<FlightIcon />} label={UI_LABELS.PROFILE.bookings} />
-						<Tab icon={<GroupIcon />} label={UI_LABELS.PROFILE.passengers} />
-						<Tab icon={<LockIcon />} label={UI_LABELS.PROFILE.change_password} />
-					</Tabs>
-					{tab === 0 && <UserInfo />}
-					{tab === 1 && <BookingsTab />}
-					{tab === 2 && <PassengersTab />}
-					{tab === 3 && <PasswordTab />}
-				</Paper>
-			</Box>
-		</Base>
+	                                <Tabs
+	                                        value={tab}
+	                                        onChange={handleChange}
+	                                        centered
+	                                        indicatorColor='primary'
+	                                        textColor='primary'
+	                                        sx={{ mb: 3 }}
+	                                >
+	                                        <Tab icon={<PersonIcon />} label={UI_LABELS.PROFILE.user_info} />
+	                                        <Tab icon={<FlightIcon />} label={UI_LABELS.PROFILE.bookings} />
+	                                        <Tab icon={<GroupIcon />} label={UI_LABELS.PROFILE.passengers} />
+	                                </Tabs>
+	                                {tab === 0 && (
+	                                        <Stack spacing={3}>
+	                                                <UserInfo />
+	                                                <PasswordTab />
+	                                        </Stack>
+	                                )}
+	                                {tab === 1 && <BookingsTab />}
+	                                {tab === 2 && <PassengersTab />}
+	                        </Paper>
+	                </Box>
+	        </Base>
 	);
 };
 

--- a/client/src/components/profile/UserInfo.js
+++ b/client/src/components/profile/UserInfo.js
@@ -11,14 +11,15 @@ const UserInfo = () => {
 	const currentUser = useSelector((state) => state.auth.currentUser);
 
 	return (
-		<Paper sx={{ p: 2 }}>
-			<Typography variant='h6' gutterBottom>
-				{UI_LABELS.PROFILE.user_info}
-			</Typography>
-			<Stack spacing={1}>
-				<Typography>{`${UI_LABELS.PROFILE.email}: ${currentUser?.email}`}</Typography>
-			</Stack>
-		</Paper>
+	        <Paper sx={{ p: 2 }}>
+	                <Typography variant='h6' gutterBottom>
+	                        {UI_LABELS.PROFILE.user_info}
+	                </Typography>
+	                <Stack spacing={1}>
+	                        <Typography>{`${currentUser?.last_name || ''} ${currentUser?.first_name || ''}`}</Typography>
+	                        <Typography>{`${UI_LABELS.PROFILE.email}: ${currentUser?.email}`}</Typography>
+	                </Stack>
+	        </Paper>
 	);
 };
 

--- a/server/app/controllers/auth_controller.py
+++ b/server/app/controllers/auth_controller.py
@@ -16,6 +16,8 @@ def register():
     body = request.json
     email = body.get('email', '').lower()
     password = body.get('password', '')
+    first_name = body.get('first_name')
+    last_name = body.get('last_name')
     if not email or not password:
         return jsonify({'message': 'Email and password are required'}), 400
 
@@ -27,7 +29,9 @@ def register():
         'email': email,
         'password': password,
         'role': DEFAULT_USER_ROLE,
-        'is_active': False
+        'is_active': False,
+        'first_name': first_name,
+        'last_name': last_name,
     })
     if new_user:
         token = sign_activation_token(new_user.email)

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -24,6 +24,8 @@ class User(BaseModel):
     totp_secret = db.Column(db.String, nullable=True)
     failed_login_attempts = db.Column(db.Integer, default=0, nullable=False)
     is_locked = db.Column(db.Boolean, default=False, nullable=False)
+    first_name = db.Column(db.String, nullable=True)
+    last_name = db.Column(db.String, nullable=True)
 
     reset_tokens: Mapped[List['PasswordResetToken']] = db.relationship(
         'PasswordResetToken', back_populates='user', lazy='dynamic', cascade='all, delete-orphan'
@@ -42,6 +44,8 @@ class User(BaseModel):
         return {
             'id': self.id,
             'email': self.email,
+            'first_name': self.first_name,
+            'last_name': self.last_name,
             'role': self.role.value,
             'is_active': self.is_active,
             'failed_login_attempts': self.failed_login_attempts,

--- a/server/migrations/versions/e3c90f3a1b5d_add_user_names.py
+++ b/server/migrations/versions/e3c90f3a1b5d_add_user_names.py
@@ -1,0 +1,27 @@
+"""add user first and last name fields
+
+Revision ID: e3c90f3a1b5d
+Revises: 9ae584e79586
+Create Date: 2025-10-09 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e3c90f3a1b5d'
+down_revision = '9ae584e79586'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('first_name', sa.String(), nullable=True))
+        batch_op.add_column(sa.Column('last_name', sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('users', schema=None) as batch_op:
+        batch_op.drop_column('last_name')
+        batch_op.drop_column('first_name')


### PR DESCRIPTION
## Summary
- add first_name and last_name fields to users with migration and registration support
- merge password update into profile page and center profile tabs
- pre-fill booking buyer info with logged-in user's names

## Testing
- `pytest -q`
- `npm test --silent -- --watchAll=false` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aead8c3844832fb9a4e1786866a9df