### PR TITLE
Enhance profile tabs and consent handling

### DIFF
--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -24,10 +24,19 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import Base from '../Base';
 import BookingProgress from './BookingProgress';
 import PassengerForm from './PassengerForm';
-import { processBookingPassengers, fetchBookingDetails, fetchBookingAccess } from '../../redux/actions/bookingProcess';
+import {
+	processBookingPassengers,
+	fetchBookingDetails,
+	fetchBookingAccess,
+} from '../../redux/actions/bookingProcess';
 import { fetchCountries } from '../../redux/actions/country';
 import { fetchUserPassengers } from '../../redux/actions/passenger';
-import { FIELD_LABELS, UI_LABELS, VALIDATION_MESSAGES, ENUM_LABELS } from '../../constants';
+import {
+	FIELD_LABELS,
+	UI_LABELS,
+	VALIDATION_MESSAGES,
+	ENUM_LABELS,
+} from '../../constants';
 import {
 	createFormFields,
 	FIELD_TYPES,
@@ -86,7 +95,9 @@ const Passengers = () => {
 		if (Array.isArray(errors)) return errors.filter(Boolean);
 
 		if (typeof errors === 'object') {
-			const values = Object.values(errors).flatMap((v) => (Array.isArray(v) ? v : [v]));
+			const values = Object.values(errors).flatMap((v) =>
+				Array.isArray(v) ? v : [v],
+			);
 			return values.filter(Boolean).map(String);
 		}
 
@@ -118,7 +129,7 @@ const Passengers = () => {
 
 	const citizenshipOptions = useMemo(
 		() => (countries || []).map((c) => ({ value: c.id, label: c.name })),
-		[countries]
+		[countries],
 	);
 
 	const isPassengerComplete = (p) => {
@@ -127,36 +138,36 @@ const Passengers = () => {
 	};
 
 	const [buyer, setBuyer] = useState({
-	        buyerLastName: '',
-	        buyerFirstName: '',
-	        emailAddress: '',
-	        phoneNumber: '',
-	        consent: false,
+		buyerLastName: '',
+		buyerFirstName: '',
+		emailAddress: '',
+		phoneNumber: '',
+		consent: false,
 	});
 
 	useEffect(() => {
-	        if (passengersExist) {
-	                const mapped = fromApiBuyer(booking);
-	                setBuyer({
-	                        buyerLastName: mapped.buyerLastName || '',
-	                        buyerFirstName: mapped.buyerFirstName || '',
-	                        emailAddress: mapped.emailAddress || '',
-	                        phoneNumber: mapped.phoneNumber || '',
-	                        consent: mapped.consent || false,
-	                });
-	        }
+		if (passengersExist) {
+			const mapped = fromApiBuyer(booking);
+			setBuyer({
+				buyerLastName: mapped.buyerLastName || '',
+				buyerFirstName: mapped.buyerFirstName || '',
+				emailAddress: mapped.emailAddress || '',
+				phoneNumber: mapped.phoneNumber || '',
+				consent: mapped.consent || false,
+			});
+		}
 	}, [booking, passengersExist]);
 
 	useEffect(() => {
-		if (currentUser?.first_name && currentUser?.last_name) {
+		if (currentUser) {
 			setBuyer((prev) => ({
 				...prev,
 				buyerLastName: prev.buyerLastName || currentUser.last_name,
 				buyerFirstName: prev.buyerFirstName || currentUser.first_name,
+				phoneNumber: prev.phoneNumber || currentUser.phone_number || '',
 			}));
 		}
 	}, [currentUser]);
-
 
 	const buyerFormFields = useMemo(() => {
 		const fields = {
@@ -164,13 +175,15 @@ const Passengers = () => {
 				key: 'buyerLastName',
 				type: FIELD_TYPES.TEXT,
 				label: FIELD_LABELS.PASSENGER.last_name,
-				validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED : ''),
+				validate: (v) =>
+					!v ? VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED : '',
 			},
 			buyerFirstName: {
 				key: 'buyerFirstName',
 				type: FIELD_TYPES.TEXT,
 				label: FIELD_LABELS.PASSENGER.first_name,
-				validate: (v) => (!v ? VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED : ''),
+				validate: (v) =>
+					!v ? VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED : '',
 			},
 			emailAddress: {
 				key: 'emailAddress',
@@ -178,7 +191,9 @@ const Passengers = () => {
 				type: FIELD_TYPES.EMAIL,
 				validate: (v) => {
 					if (!v) return VALIDATION_MESSAGES.BOOKING.email_address.REQUIRED;
-					return validateEmail(v) ? '' : VALIDATION_MESSAGES.BOOKING.email_address.INVALID;
+					return validateEmail(v)
+						? ''
+						: VALIDATION_MESSAGES.BOOKING.email_address.INVALID;
 				},
 			},
 			phoneNumber: {
@@ -187,7 +202,9 @@ const Passengers = () => {
 				type: FIELD_TYPES.PHONE,
 				validate: (v) => {
 					if (!v) return VALIDATION_MESSAGES.BOOKING.phone_number.REQUIRED;
-					return validatePhoneNumber(v) ? '' : VALIDATION_MESSAGES.BOOKING.phone_number.INVALID;
+					return validatePhoneNumber(v)
+						? ''
+						: VALIDATION_MESSAGES.BOOKING.phone_number.INVALID;
 				},
 			},
 		};
@@ -199,14 +216,18 @@ const Passengers = () => {
 
 	const handlePassengerChange = (index) => (field, value, data) => {
 		setPassengerData((prev) =>
-			Array.isArray(prev) ? prev.map((p, i) => (i === index ? { ...p, ...data } : p)) : prev
+			Array.isArray(prev)
+				? prev.map((p, i) => (i === index ? { ...p, ...data } : p))
+				: prev,
 		);
 	};
 
 	const handlePrefillPassenger = (index, passenger) => {
 		const mapped = fromApiPassenger(passenger);
 		setPassengerData((prev) =>
-			Array.isArray(prev) ? prev.map((p, i) => (i === index ? { ...p, ...mapped } : p)) : prev
+			Array.isArray(prev)
+				? prev.map((p, i) => (i === index ? { ...p, ...mapped } : p))
+				: prev,
 		);
 	};
 
@@ -223,7 +244,8 @@ const Passengers = () => {
 				if (err) errs[f.name] = err;
 			}
 		});
-		if (!buyer.consent) errs.consent = VALIDATION_MESSAGES.BOOKING.consent.REQUIRED;
+		if (!buyer.consent)
+			errs.consent = VALIDATION_MESSAGES.BOOKING.consent.REQUIRED;
 		setBuyerErrors(errs);
 		return Object.keys(errs).length === 0;
 	};
@@ -242,7 +264,8 @@ const Passengers = () => {
 
 		if (!allPassengersValid) return;
 
-		const hasPassengerDuplicate = findBookingPassengerDuplicates(passengerData || []).length > 0;
+		const hasPassengerDuplicate =
+			findBookingPassengerDuplicates(passengerData || []).length > 0;
 		if (hasPassengerDuplicate) {
 			setErrors((prev) => ({
 				...prev,
@@ -262,7 +285,7 @@ const Passengers = () => {
 					public_id: publicId,
 					buyer: apiBuyer,
 					passengers: apiPassengers,
-				})
+				}),
 			).unwrap();
 			await dispatch(fetchBookingDetails(publicId)).unwrap();
 			await dispatch(fetchBookingAccess(publicId)).unwrap();
@@ -283,7 +306,7 @@ const Passengers = () => {
 				outboundRouteInfo.from,
 				outboundRouteInfo.to,
 				outboundRouteInfo.date,
-				returnRouteInfo.date
+				returnRouteInfo.date,
 			);
 		}
 	}, [outboundRouteInfo, returnRouteInfo]);
@@ -297,33 +320,44 @@ const Passengers = () => {
 	const fees = booking?.fees || 0;
 	const discount = booking?.total_discounts || 0;
 	const totalPrice = booking?.total_price || 0;
-	const currencySymbol = booking ? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || '' : '';
+	const currencySymbol = booking
+		? ENUM_LABELS.CURRENCY_SYMBOL[booking.currency] || ''
+		: '';
 
 	const passengersReady = !bookingLoading && Array.isArray(passengerData);
 
 	return (
-		<Base maxWidth='lg'>
-			<BookingProgress activeStep='passengers' />
+		<Base maxWidth="lg">
+			<BookingProgress activeStep="passengers" />
 			{expiresAt && (
 				<Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-					<Typography variant='h6' sx={{ fontWeight: 600 }}>
+					<Typography variant="h6" sx={{ fontWeight: 600 }}>
 						{timeLeft}
 					</Typography>
 				</Box>
 			)}
 			<Grid container spacing={2}>
-				<Grid item xs={12} md={8} sx={{ maxHeight: 'calc(100vh - 200px)', overflowY: 'auto', pr: { md: 2 } }}>
+				<Grid
+					item
+					xs={12}
+					md={8}
+					sx={{
+						maxHeight: 'calc(100vh - 200px)',
+						overflowY: 'auto',
+						pr: { md: 2 },
+					}}
+				>
 					{errorMessages.length > 0 && (
 						<Stack spacing={1} sx={{ mb: 2 }}>
 							{errorMessages.map((msg, idx) => (
-								<Alert key={idx} severity='error'>
+								<Alert key={idx} severity="error">
 									{msg}
 								</Alert>
 							))}
 						</Stack>
 					)}
 					{!currentUser && (
-						<Alert severity='info' sx={{ mb: 2 }}>
+						<Alert severity="info" sx={{ mb: 2 }}>
 							{UI_LABELS.BOOKING.passenger_form.login_hint}
 						</Alert>
 					)}
@@ -331,14 +365,16 @@ const Passengers = () => {
 						passengerData.map((p, index) => (
 							<Box key={p.id || index} sx={{ mb: 2 }}>
 								{currentUser && userPassengers.length > 0 && (
-									<Box sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+									<Box
+										sx={{ mb: 1, display: 'flex', gap: 1, flexWrap: 'wrap' }}
+									>
 										{userPassengers.map((up) => {
 											const mapped = fromApiPassenger(up);
 											return (
 												<Chip
 													key={up.id}
 													label={`${mapped.lastName || ''} ${mapped.firstName || ''}`}
-													size='small'
+													size="small"
 													onClick={() => handlePrefillPassenger(index, up)}
 												/>
 											);
@@ -355,27 +391,28 @@ const Passengers = () => {
 							</Box>
 						))}
 					<Box sx={{ p: 2, border: '1px solid #eee', borderRadius: 2, mb: 2 }}>
-						<Typography variant='h4' sx={{ mb: 3 }}>
+						<Typography variant="h4" sx={{ mb: 3 }}>
 							{UI_LABELS.BOOKING.buyer_form.title}
 						</Typography>
-						{passengersReady && passengerData.filter(isPassengerComplete).length > 0 && (
-							<Box sx={{ mb: 2, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-								{passengerData.filter(isPassengerComplete).map((p, index) => (
-									<Chip
-										key={p.id || index}
-										label={`${p.lastName || ''} ${p.firstName || ''}`}
-										size='small'
-										onClick={() =>
-											setBuyer((prev) => ({
-												...prev,
-												buyerLastName: p.lastName || '',
-												buyerFirstName: p.firstName || '',
-											}))
-										}
-									/>
-								))}
-							</Box>
-						)}
+						{passengersReady &&
+							passengerData.filter(isPassengerComplete).length > 0 && (
+								<Box sx={{ mb: 2, display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+									{passengerData.filter(isPassengerComplete).map((p, index) => (
+										<Chip
+											key={p.id || index}
+											label={`${p.lastName || ''} ${p.firstName || ''}`}
+											size="small"
+											onClick={() =>
+												setBuyer((prev) => ({
+													...prev,
+													buyerLastName: p.lastName || '',
+													buyerFirstName: p.firstName || '',
+												}))
+											}
+										/>
+									))}
+								</Box>
+							)}
 						<Grid container spacing={2}>
 							{Object.values(buyerFormFields).map((field) => (
 								<Grid item xs={12} sm={6} key={field.name}>
@@ -395,185 +432,260 @@ const Passengers = () => {
 				<Grid item xs={12} md={4} sx={{ position: 'sticky', top: 16 }}>
 					<Card>
 						<CardContent>
-							{Array.isArray(booking?.flights) && booking.flights.length > 0 && (
-								<Accordion variant='outlined' sx={{ mb: 2 }}>
-									<AccordionSummary expandIcon={<ExpandMoreIcon />}>
-										{outboundRouteInfo && (
-											<Typography variant='subtitle1' sx={{ fontWeight: 'bold' }}>
-												{Object.keys(returnRouteInfo || {}).length > 0
-													? UI_LABELS.BOOKING.flight_details.from_to_from(
-															outboundRouteInfo.from,
-															outboundRouteInfo.to
-													  )
-													: UI_LABELS.BOOKING.flight_details.from_to(
-															outboundRouteInfo.from,
-															outboundRouteInfo.to
-													  )}
-											</Typography>
-										)}
-									</AccordionSummary>
-									<AccordionDetails>
-										{booking.flights.map((f, idx) => {
-											const origin = f.route?.origin_airport || {};
-											const dest = f.route?.destination_airport || {};
-											const depDate = formatDate(f.scheduled_departure);
-											const depTime = formatTime(f.scheduled_departure_time);
-											const arrDate = formatDate(f.scheduled_arrival);
-											const arrTime = formatTime(f.scheduled_arrival_time);
-											const duration = formatDuration(f.duration);
-											const airline = f.airline?.name || '';
-											const flightNo = f.airline_flight_number || f.flight_number || '';
-											const aircraft = f.aircraft?.type;
-											const direction = idx === 0 ? 'outbound' : 'return';
-											const tariff = tariffMap[direction];
-											return (
-												<Box
-													key={f.id || idx}
-													sx={{ mb: idx < booking.flights.length - 1 ? 2 : 0 }}
+							{Array.isArray(booking?.flights) &&
+								booking.flights.length > 0 && (
+									<Accordion variant="outlined" sx={{ mb: 2 }}>
+										<AccordionSummary expandIcon={<ExpandMoreIcon />}>
+											{outboundRouteInfo && (
+												<Typography
+													variant="subtitle1"
+													sx={{ fontWeight: 'bold' }}
 												>
+													{Object.keys(returnRouteInfo || {}).length > 0
+														? UI_LABELS.BOOKING.flight_details.from_to_from(
+																outboundRouteInfo.from,
+																outboundRouteInfo.to,
+															)
+														: UI_LABELS.BOOKING.flight_details.from_to(
+																outboundRouteInfo.from,
+																outboundRouteInfo.to,
+															)}
+												</Typography>
+											)}
+										</AccordionSummary>
+										<AccordionDetails>
+											{booking.flights.map((f, idx) => {
+												const origin = f.route?.origin_airport || {};
+												const dest = f.route?.destination_airport || {};
+												const depDate = formatDate(f.scheduled_departure);
+												const depTime = formatTime(f.scheduled_departure_time);
+												const arrDate = formatDate(f.scheduled_arrival);
+												const arrTime = formatTime(f.scheduled_arrival_time);
+												const duration = formatDuration(f.duration);
+												const airline = f.airline?.name || '';
+												const flightNo =
+													f.airline_flight_number || f.flight_number || '';
+												const aircraft = f.aircraft?.type;
+												const direction = idx === 0 ? 'outbound' : 'return';
+												const tariff = tariffMap[direction];
+												return (
 													<Box
+														key={f.id || idx}
 														sx={{
-															display: 'flex',
-															justifyContent: 'space-between',
-															alignItems: 'center',
-															mb: 0.5,
+															mb: idx < booking.flights.length - 1 ? 2 : 0,
 														}}
 													>
-														<Typography variant='subtitle2'>{airline}</Typography>
-														<Typography variant='caption' color='text.secondary'>
-															{flightNo}
-														</Typography>
-													</Box>
-													{tariff && (
-														<Typography
-															variant='caption'
-															color='text.secondary'
-															sx={{ mb: 0.5, display: 'block' }}
-														>
-															{`${ENUM_LABELS.SEAT_CLASS[tariff.seat_class]} — ${
-																tariff.title
-															}`}
-														</Typography>
-													)}
-													<Box
-														sx={{
-															display: 'grid',
-															gridTemplateColumns: '1fr auto 1fr',
-															gap: 1,
-															alignItems: 'center',
-														}}
-													>
-														<Box>
-															<Typography variant='h6'>{depTime}</Typography>
-															<Typography variant='caption' color='text.secondary'>
-																{depDate}
-															</Typography>
-															<Typography variant='body2'>{origin.city_name}</Typography>
-															<Typography variant='caption' color='text.secondary'>
-																{origin.iata_code}
-															</Typography>
-														</Box>
-														<Box sx={{ textAlign: 'center' }}>
-															<Typography variant='caption' color='text.secondary'>
-																{duration}
-															</Typography>
-															<Divider flexItem sx={{ my: 0.5 }} />
-														</Box>
-														<Box sx={{ textAlign: 'right' }}>
-															<Typography variant='h6'>{arrTime}</Typography>
-															<Typography variant='caption' color='text.secondary'>
-																{arrDate}
-															</Typography>
-															<Typography variant='body2'>{dest.city_name}</Typography>
-															<Typography variant='caption' color='text.secondary'>
-																{dest.iata_code}
-															</Typography>
-														</Box>
-													</Box>
-													{aircraft && (
 														<Box
 															sx={{
 																display: 'flex',
-																justifyContent: 'center',
-																mt: 0.5,
+																justifyContent: 'space-between',
+																alignItems: 'center',
+																mb: 0.5,
 															}}
 														>
-															{aircraft && (
-																<Typography variant='caption' color='text.secondary'>
-																	{aircraft}
-																</Typography>
-															)}
+															<Typography variant="subtitle2">
+																{airline}
+															</Typography>
+															<Typography
+																variant="caption"
+																color="text.secondary"
+															>
+																{flightNo}
+															</Typography>
 														</Box>
-													)}
-													{idx < booking.flights.length - 1 && <Divider sx={{ mt: 1 }} />}
-												</Box>
-											);
-										})}
-									</AccordionDetails>
-								</Accordion>
-							)}
+														{tariff && (
+															<Typography
+																variant="caption"
+																color="text.secondary"
+																sx={{ mb: 0.5, display: 'block' }}
+															>
+																{`${ENUM_LABELS.SEAT_CLASS[tariff.seat_class]} — ${
+																	tariff.title
+																}`}
+															</Typography>
+														)}
+														<Box
+															sx={{
+																display: 'grid',
+																gridTemplateColumns: '1fr auto 1fr',
+																gap: 1,
+																alignItems: 'center',
+															}}
+														>
+															<Box>
+																<Typography variant="h6">{depTime}</Typography>
+																<Typography
+																	variant="caption"
+																	color="text.secondary"
+																>
+																	{depDate}
+																</Typography>
+																<Typography variant="body2">
+																	{origin.city_name}
+																</Typography>
+																<Typography
+																	variant="caption"
+																	color="text.secondary"
+																>
+																	{origin.iata_code}
+																</Typography>
+															</Box>
+															<Box sx={{ textAlign: 'center' }}>
+																<Typography
+																	variant="caption"
+																	color="text.secondary"
+																>
+																	{duration}
+																</Typography>
+																<Divider flexItem sx={{ my: 0.5 }} />
+															</Box>
+															<Box sx={{ textAlign: 'right' }}>
+																<Typography variant="h6">{arrTime}</Typography>
+																<Typography
+																	variant="caption"
+																	color="text.secondary"
+																>
+																	{arrDate}
+																</Typography>
+																<Typography variant="body2">
+																	{dest.city_name}
+																</Typography>
+																<Typography
+																	variant="caption"
+																	color="text.secondary"
+																>
+																	{dest.iata_code}
+																</Typography>
+															</Box>
+														</Box>
+														{aircraft && (
+															<Box
+																sx={{
+																	display: 'flex',
+																	justifyContent: 'center',
+																	mt: 0.5,
+																}}
+															>
+																{aircraft && (
+																	<Typography
+																		variant="caption"
+																		color="text.secondary"
+																	>
+																		{aircraft}
+																	</Typography>
+																)}
+															</Box>
+														)}
+														{idx < booking.flights.length - 1 && (
+															<Divider sx={{ mt: 1 }} />
+														)}
+													</Box>
+												);
+											})}
+										</AccordionDetails>
+									</Accordion>
+								)}
 
-							<Typography variant='h4' sx={{ mb: 2 }}>
+							<Typography variant="h4" sx={{ mb: 2 }}>
 								{`${UI_LABELS.BOOKING.buyer_form.summary.passenger_word(
-									passengersReady ? passengerData.length : 0
+									passengersReady ? passengerData.length : 0,
 								)}`}
 							</Typography>
-							<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-								<Typography>{UI_LABELS.BOOKING.buyer_form.summary.tickets}</Typography>
+							<Box
+								sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}
+							>
+								<Typography>
+									{UI_LABELS.BOOKING.buyer_form.summary.tickets}
+								</Typography>
 								<Typography>{`${formatNumber(farePrice)} ${currencySymbol}`}</Typography>
 							</Box>
 							{fees > 0 && (
-								<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-									<Typography>{UI_LABELS.BOOKING.buyer_form.summary.fees}</Typography>
+								<Box
+									sx={{
+										display: 'flex',
+										justifyContent: 'space-between',
+										mb: 1,
+									}}
+								>
+									<Typography>
+										{UI_LABELS.BOOKING.buyer_form.summary.fees}
+									</Typography>
 									<Typography>{`${formatNumber(fees)} ${currencySymbol}`}</Typography>
 								</Box>
 							)}
 							{discount > 0 && (
-								<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-									<Typography>{UI_LABELS.BOOKING.buyer_form.summary.discount}</Typography>
+								<Box
+									sx={{
+										display: 'flex',
+										justifyContent: 'space-between',
+										mb: 1,
+									}}
+								>
+									<Typography>
+										{UI_LABELS.BOOKING.buyer_form.summary.discount}
+									</Typography>
 									<Typography>{`- ${formatNumber(discount)} ${currencySymbol}`}</Typography>
 								</Box>
 							)}
-							<Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
-								<Typography variant='h4' sx={{ mb: 0.25 }}>
+							<Box
+								sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}
+							>
+								<Typography variant="h4" sx={{ mb: 0.25 }}>
 									{UI_LABELS.BOOKING.buyer_form.summary.total}
 								</Typography>
-								<Typography variant='subtitle1'>
+								<Typography variant="subtitle1">
 									{`${formatNumber(totalPrice)} ${currencySymbol}`}
 								</Typography>
 							</Box>
 
 							<Divider sx={{ my: 2 }} />
 
-							<FormControl required error={!!buyerErrors.consent} sx={{ mb: 2 }}>
+							<FormControl
+								required
+								error={!!buyerErrors.consent}
+								sx={{ mb: 2 }}
+							>
 								<FormControlLabel
 									control={
 										<Checkbox
 											checked={buyer.consent}
-											onChange={(e) => handleBuyerChange('consent', e.target.checked)}
+											onChange={(e) =>
+												handleBuyerChange('consent', e.target.checked)
+											}
 										/>
 									}
 									label={
-										<Typography variant='subtitle2' color='textSecondary'>
+										<Typography variant="subtitle2" color="textSecondary">
 											{UI_LABELS.BOOKING.buyer_form.privacy_policy((text) => (
-												<Link to='/privacy_policy' target='_blank'>
+												<Link to="/privacy_policy" target="_blank">
 													{text}
 												</Link>
 											))}
 										</Typography>
 									}
 								/>
-								{buyerErrors.consent && <FormHelperText>{buyerErrors.consent}</FormHelperText>}
+								{buyerErrors.consent && (
+									<FormHelperText>{buyerErrors.consent}</FormHelperText>
+								)}
 							</FormControl>
 
-							<Button variant='contained' color='orange' fullWidth onClick={handleContinue}>
+							<Button
+								variant="contained"
+								color="orange"
+								fullWidth
+								onClick={handleContinue}
+							>
 								{UI_LABELS.BUTTONS.continue}
 							</Button>
 						</CardContent>
 					</Card>
-					<Typography variant='body2' color='textSecondary' sx={{ ml: 1, mt: 1 }}>
+					<Typography
+						variant="body2"
+						color="textSecondary"
+						sx={{ ml: 1, mt: 1 }}
+					>
 						{UI_LABELS.BOOKING.buyer_form.public_offer((text) => (
-							<Link to='/public_offer' target='_blank'>
+							<Link to="/public_offer" target="_blank">
 								{text}
 							</Link>
 						))}

--- a/client/src/components/profile/BookingsTab.js
+++ b/client/src/components/profile/BookingsTab.js
@@ -30,17 +30,21 @@ const BookingsTab = () => {
 	}
 
 	return bookings && bookings.length ? (
-		<Box>
-			<Typography variant='h6' sx={{ mb: 2 }}>
+		<Box sx={{ maxWidth: 600, mx: 'auto' }}>
+			<Typography variant="h6" sx={{ mb: 2 }}>
 				{UI_LABELS.PROFILE.bookings}
 			</Typography>
 			<TableContainer component={Paper}>
-				<Table size='small'>
+				<Table size="small">
 					<TableHead sx={{ bgcolor: 'background.paper' }}>
 						<TableRow>
-							<TableCell sx={{ fontWeight: 'bold' }}>{UI_LABELS.PROFILE.booking_number}</TableCell>
-							<TableCell sx={{ fontWeight: 'bold' }}>{UI_LABELS.PROFILE.status}</TableCell>
-							<TableCell align='right' sx={{ fontWeight: 'bold' }}>
+							<TableCell sx={{ fontWeight: 'bold' }}>
+								{UI_LABELS.PROFILE.booking_number}
+							</TableCell>
+							<TableCell sx={{ fontWeight: 'bold' }}>
+								{UI_LABELS.PROFILE.status}
+							</TableCell>
+							<TableCell align="right" sx={{ fontWeight: 'bold' }}>
 								{UI_LABELS.PROFILE.total_price}
 							</TableCell>
 						</TableRow>
@@ -50,7 +54,7 @@ const BookingsTab = () => {
 							<TableRow key={b.id}>
 								<TableCell>{b.booking_number}</TableCell>
 								<TableCell>{b.status}</TableCell>
-								<TableCell align='right'>{b.total_price}</TableCell>
+								<TableCell align="right">{b.total_price}</TableCell>
 							</TableRow>
 						))}
 					</TableBody>
@@ -58,7 +62,9 @@ const BookingsTab = () => {
 			</TableContainer>
 		</Box>
 	) : (
-		<Typography>{UI_LABELS.PROFILE.no_bookings}</Typography>
+		<Typography sx={{ textAlign: 'center' }}>
+			{UI_LABELS.PROFILE.no_bookings}
+		</Typography>
 	);
 };
 

--- a/client/src/components/profile/PassengersTab.js
+++ b/client/src/components/profile/PassengersTab.js
@@ -3,7 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Box, Button, Typography, Stack, Paper } from '@mui/material';
 
 import PassengerForm from '../booking/PassengerForm';
-import { fetchUserPassengers, createUserPassenger } from '../../redux/actions/passenger';
+import {
+	fetchUserPassengers,
+	createUserPassenger,
+} from '../../redux/actions/passenger';
 import { fetchCountries } from '../../redux/actions/country';
 import { mapToApi, mappingConfigs } from '../utils/mappers';
 import { UI_LABELS } from '../../constants/uiLabels';
@@ -27,7 +30,7 @@ const PassengersTab = () => {
 
 	const citizenshipOptions = useMemo(
 		() => (countries || []).map((c) => ({ value: c.id, label: c.name })),
-		[countries]
+		[countries],
 	);
 
 	const handleChange = (_field, _value, d) => setData(d);
@@ -35,16 +38,20 @@ const PassengersTab = () => {
 	const handleSubmit = () => {
 		if (!formRef.current?.validate()) return;
 		const apiData = mapToApi(data, mappingConfigs.passenger);
-		dispatch(createUserPassenger({ userId: currentUser.id, data: apiData })).then(() => {
+		dispatch(
+			createUserPassenger({ userId: currentUser.id, data: apiData }),
+		).then(() => {
 			setShowForm(false);
 			setData({});
 		});
 	};
 
 	return (
-		<Box>
+		<Box sx={{ maxWidth: 600, mx: 'auto' }}>
 			{passengers.length === 0 ? (
-				<Typography sx={{ mb: 2 }}>{UI_LABELS.PROFILE.no_passengers}</Typography>
+				<Typography sx={{ mb: 2 }}>
+					{UI_LABELS.PROFILE.no_passengers}
+				</Typography>
 			) : (
 				<Stack spacing={1} sx={{ mb: 2 }}>
 					{passengers.map((p) => (
@@ -62,15 +69,15 @@ const PassengersTab = () => {
 						citizenshipOptions={citizenshipOptions}
 						ref={formRef}
 					/>
-					<Button variant='contained' onClick={handleSubmit} sx={{ mr: 1 }}>
+					<Button variant="contained" onClick={handleSubmit} sx={{ mr: 1 }}>
 						{UI_LABELS.BOOKING.passenger_form.add_passenger}
 					</Button>
-					<Button variant='text' onClick={() => setShowForm(false)}>
+					<Button variant="text" onClick={() => setShowForm(false)}>
 						{UI_LABELS.BUTTONS.cancel}
 					</Button>
 				</Paper>
 			) : (
-				<Button variant='outlined' onClick={() => setShowForm(true)}>
+				<Button variant="outlined" onClick={() => setShowForm(true)}>
 					{UI_LABELS.BOOKING.passenger_form.add_passenger}
 				</Button>
 			)}

--- a/client/src/components/profile/PasswordTab.js
+++ b/client/src/components/profile/PasswordTab.js
@@ -48,48 +48,48 @@ const PasswordTab = () => {
 	};
 
 	return (
-		<Paper sx={{ p: 2, maxWidth: 400 }}>
-			<Typography variant='h6' sx={{ mb: 2 }}>
+		<Paper sx={{ p: 2, maxWidth: 400, width: '100%' }}>
+			<Typography variant="h6" sx={{ mb: 2 }}>
 				{UI_LABELS.PROFILE.change_password}
 			</Typography>
-			<Box component='form' onSubmit={handleSubmit}>
+			<Box component="form" onSubmit={handleSubmit}>
 				{errors.message && (
-					<Alert severity='error' sx={{ mb: 2 }}>
+					<Alert severity="error" sx={{ mb: 2 }}>
 						{errors.message}
 					</Alert>
 				)}
 				{successMessage && (
-					<Alert severity='success' sx={{ mb: 2 }}>
+					<Alert severity="success" sx={{ mb: 2 }}>
 						{successMessage}
 					</Alert>
 				)}
 				<TextField
-					margin='dense'
+					margin="dense"
 					required
 					fullWidth
-					name='newPassword'
+					name="newPassword"
 					label={UI_LABELS.AUTH.new_password}
-					type='password'
-					id='newPassword'
+					type="password"
+					id="newPassword"
 					value={passwordData.newPassword}
 					onChange={handleChange}
 					error={!!errors.newPassword}
 					helperText={errors.newPassword ? errors.newPassword : ''}
 				/>
 				<TextField
-					margin='dense'
+					margin="dense"
 					required
 					fullWidth
-					name='confirmPassword'
+					name="confirmPassword"
 					label={UI_LABELS.AUTH.confirm_password}
-					type='password'
-					id='confirmPassword'
+					type="password"
+					id="confirmPassword"
 					value={passwordData.confirmPassword}
 					onChange={handleChange}
 					error={!!errors.confirmPassword}
 					helperText={errors.confirmPassword ? errors.confirmPassword : ''}
 				/>
-				<Button type='submit' fullWidth variant='contained' sx={{ mt: 2 }}>
+				<Button type="submit" fullWidth variant="contained" sx={{ mt: 2 }}>
 					{UI_LABELS.BUTTONS.save_changes}
 				</Button>
 			</Box>

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -25,18 +25,26 @@ const Profile = () => {
 	};
 
 	return (
-		<Base maxWidth='lg'>
-			<Box maxWidth='md' sx={{ mx: 'auto', p: 4 }}>
-				<Paper elevation={0} sx={{ p: 3,  mt: 3 }}>
-					<Typography variant='h5' sx={{ mb: 2 }}>
+		<Base maxWidth="lg">
+			<Box
+				sx={{
+					minHeight: '80vh',
+					display: 'flex',
+					justifyContent: 'center',
+					alignItems: 'center',
+					p: 4,
+				}}
+			>
+				<Paper elevation={0} sx={{ p: 3, width: '100%', maxWidth: 600 }}>
+					<Typography variant="h5" sx={{ mb: 2 }}>
 						{UI_LABELS.PROFILE.settings}
 					</Typography>
 					<Tabs
 						value={tab}
 						onChange={handleChange}
 						centered
-						indicatorColor='primary'
-						textColor='primary'
+						indicatorColor="primary"
+						textColor="primary"
 						sx={{ mb: 3 }}
 					>
 						<Tab icon={<PersonIcon />} label={UI_LABELS.PROFILE.user_info} />
@@ -44,7 +52,7 @@ const Profile = () => {
 						<Tab icon={<GroupIcon />} label={UI_LABELS.PROFILE.passengers} />
 					</Tabs>
 					{tab === 0 && (
-						<Stack spacing={3}>
+						<Stack spacing={3} alignItems="center">
 							<UserInfo />
 							<PasswordTab />
 						</Stack>

--- a/client/src/components/profile/UserInfo.js
+++ b/client/src/components/profile/UserInfo.js
@@ -1,24 +1,144 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 
+import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
-import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import FormControl from '@mui/material/FormControl';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import FormHelperText from '@mui/material/FormHelperText';
+import { Link } from 'react-router-dom';
 
 import { UI_LABELS } from '../../constants/uiLabels';
+import { FIELD_LABELS } from '../../constants/fieldLabels';
+import { VALIDATION_MESSAGES } from '../../constants/validationMessages';
+import { updateUser } from '../../redux/actions/user';
+import { setCurrentUser } from '../../redux/reducers/auth';
 
 const UserInfo = () => {
+	const dispatch = useDispatch();
 	const currentUser = useSelector((state) => state.auth.currentUser);
+	const [formData, setFormData] = useState({
+		firstName: '',
+		lastName: '',
+		phoneNumber: '',
+		consent: false,
+	});
+	const [errors, setErrors] = useState({});
+
+	useEffect(() => {
+		if (currentUser) {
+			setFormData((prev) => ({
+				...prev,
+				firstName: currentUser.first_name || '',
+				lastName: currentUser.last_name || '',
+				phoneNumber: currentUser.phone_number || '',
+			}));
+		}
+	}, [currentUser]);
+
+	const handleChange = (e) => {
+		setFormData({ ...formData, [e.target.name]: e.target.value });
+	};
+
+	const handleSubmit = (e) => {
+		e.preventDefault();
+		const newErrors = {};
+		if (!formData.lastName)
+			newErrors.lastName = VALIDATION_MESSAGES.PASSENGER.last_name.REQUIRED;
+		if (!formData.firstName)
+			newErrors.firstName = VALIDATION_MESSAGES.PASSENGER.first_name.REQUIRED;
+		if (!formData.phoneNumber)
+			newErrors.phoneNumber = VALIDATION_MESSAGES.BOOKING.phone_number.REQUIRED;
+		if (!formData.consent)
+			newErrors.consent = VALIDATION_MESSAGES.BOOKING.consent.REQUIRED;
+		if (Object.keys(newErrors).length) {
+			setErrors(newErrors);
+			return;
+		}
+		dispatch(
+			updateUser({
+				id: currentUser.id,
+				first_name: formData.firstName,
+				last_name: formData.lastName,
+				phone_number: formData.phoneNumber,
+				consent: formData.consent,
+			}),
+		)
+			.unwrap()
+			.then((user) => {
+				dispatch(setCurrentUser(user));
+				setErrors({});
+				setFormData((prev) => ({ ...prev, consent: false }));
+			})
+			.catch((res) => setErrors(res));
+	};
 
 	return (
-		<Paper sx={{ p: 2 }}>
-			<Typography variant='h6' gutterBottom>
+		<Paper sx={{ p: 2, width: '100%', maxWidth: 400 }}>
+			<Typography variant="h6" sx={{ mb: 2 }}>
 				{UI_LABELS.PROFILE.user_info}
 			</Typography>
-			<Stack spacing={1}>
-				<Typography>{`${currentUser?.last_name || ''} ${currentUser?.first_name || ''}`}</Typography>
-				<Typography>{`${UI_LABELS.PROFILE.email}: ${currentUser?.email}`}</Typography>
-			</Stack>
+			<Box component="form" onSubmit={handleSubmit}>
+				<TextField
+					margin="dense"
+					fullWidth
+					name="lastName"
+					label={FIELD_LABELS.PASSENGER.last_name}
+					value={formData.lastName}
+					onChange={handleChange}
+					error={!!errors.lastName}
+					helperText={errors.lastName || ''}
+				/>
+				<TextField
+					margin="dense"
+					fullWidth
+					name="firstName"
+					label={FIELD_LABELS.PASSENGER.first_name}
+					value={formData.firstName}
+					onChange={handleChange}
+					error={!!errors.firstName}
+					helperText={errors.firstName || ''}
+				/>
+				<TextField
+					margin="dense"
+					fullWidth
+					name="phoneNumber"
+					label={FIELD_LABELS.BOOKING.phone_number}
+					value={formData.phoneNumber}
+					onChange={handleChange}
+					error={!!errors.phoneNumber}
+					helperText={errors.phoneNumber || ''}
+				/>
+				<FormControl required error={!!errors.consent} sx={{ mt: 2 }}>
+					<FormControlLabel
+						control={
+							<Checkbox
+								checked={formData.consent}
+								onChange={(e) =>
+									setFormData({ ...formData, consent: e.target.checked })
+								}
+							/>
+						}
+						label={
+							<Typography variant="subtitle2" color="textSecondary">
+								{UI_LABELS.BOOKING.buyer_form.privacy_policy((text) => (
+									<Link to="/privacy_policy" target="_blank">
+										{text}
+									</Link>
+								))}
+							</Typography>
+						}
+					/>
+					{errors.consent && <FormHelperText>{errors.consent}</FormHelperText>}
+				</FormControl>
+				<Button type="submit" fullWidth variant="contained" sx={{ mt: 2 }}>
+					{UI_LABELS.BUTTONS.save_changes}
+				</Button>
+			</Box>
 		</Paper>
 	);
 };

--- a/server/app/models/consent.py
+++ b/server/app/models/consent.py
@@ -102,7 +102,7 @@ class ConsentEvent(BaseModel):
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     type = db.Column(db.Enum(CONSENT_EVENT_TYPE), nullable=False)
     granter_user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
-    booking_id = db.Column(db.Integer, db.ForeignKey('bookings.id'), nullable=False)
+    booking_id = db.Column(db.Integer, db.ForeignKey('bookings.id'), nullable=True)
     doc_id = db.Column(UUID(as_uuid=True), db.ForeignKey('consent_docs.id'), nullable=False)
     action = db.Column(db.Enum(CONSENT_ACTION), nullable=False)
     ip = db.Column(INET, nullable=True)

--- a/server/app/models/user.py
+++ b/server/app/models/user.py
@@ -26,6 +26,7 @@ class User(BaseModel):
     is_locked = db.Column(db.Boolean, default=False, nullable=False)
     first_name = db.Column(db.String, nullable=True)
     last_name = db.Column(db.String, nullable=True)
+    phone_number = db.Column(db.String, nullable=True)
 
     reset_tokens: Mapped[List['PasswordResetToken']] = db.relationship(
         'PasswordResetToken', back_populates='user', lazy='dynamic', cascade='all, delete-orphan'
@@ -46,6 +47,7 @@ class User(BaseModel):
             'email': self.email,
             'first_name': self.first_name,
             'last_name': self.last_name,
+            'phone_number': self.phone_number,
             'role': self.role.value,
             'is_active': self.is_active,
             'failed_login_attempts': self.failed_login_attempts,

--- a/server/app/utils/consent.py
+++ b/server/app/utils/consent.py
@@ -42,3 +42,27 @@ def create_booking_consent(
         subject_ids=subject_ids,
         **sender_info,
     )
+
+
+def create_user_consent(
+    user,
+    event_type: CONSENT_EVENT_TYPE,
+    doc_type: CONSENT_DOC_TYPE,
+    *,
+    session=None,
+):
+    session = session or db.session
+    sender_info = get_sender_info()
+
+    doc = ConsentDoc.get_latest(doc_type, session=session)
+    return ConsentEvent.create(
+        session=session,
+        commit=False,
+        type=event_type,
+        granter_user_id=user.id,
+        booking_id=None,
+        doc_id=doc.id,
+        action=CONSENT_ACTION.agree,
+        subject_ids=[],
+        **sender_info,
+    )


### PR DESCRIPTION
## Summary
- Center and resize profile tabs and forms
- Allow editing user name and phone with consent
- Auto-fill phone number during booking

## Testing
- `ruff check server/app/models/user.py server/app/models/consent.py server/app/utils/consent.py server/app/controllers/user_controller.py`
- `npx --yes prettier -c --use-tabs --single-quote client/src/components/profile/Profile.js client/src/components/profile/UserInfo.js client/src/components/profile/PasswordTab.js client/src/components/profile/BookingsTab.js client/src/components/profile/PassengersTab.js client/src/components/booking/Passengers.js`
- `npx --yes eslint client/src/components/profile/Profile.js client/src/components/profile/UserInfo.js client/src/components/profile/PasswordTab.js client/src/components/profile/BookingsTab.js client/src/components/profile/PassengersTab.js client/src/components/booking/Passengers.js` *(fails: ESLint couldn't find a config file)*
- `pytest` *(fails: TypeError: str expected, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68aebaa92abc832fb8199518d3aaf700