### PR TITLE
feat: improve profile forms

### DIFF
--- a/client/src/components/profile/PasswordTab.js
+++ b/client/src/components/profile/PasswordTab.js
@@ -67,7 +67,7 @@ const PasswordTab = () => {
 			.then((res) => {
 				if (res.message) {
 					setCodeSent(true);
-					setSuccessMessage(res.message);
+					setSuccessMessage(UI_LABELS.PROFILE.verification_code_sent);
 				} else {
 					setPasswordData({ newPassword: '', confirmPassword: '', code: '' });
 					setErrors({});
@@ -92,7 +92,7 @@ const PasswordTab = () => {
 					</Alert>
 				)}
 				{successMessage && (
-					<Alert severity='success' sx={{ mb: 2 }}>
+					<Alert severity={codeSent ? 'info' : 'success'} sx={{ mb: 2 }}>
 						{successMessage}
 					</Alert>
 				)}
@@ -121,7 +121,7 @@ const PasswordTab = () => {
 						})}
 					</Box>
 				)}
-				<Button type='submit' fullWidth variant='contained' sx={{ mt: 2 }}>
+				<Button type='submit' fullWidth variant='contained' sx={{ mt: 2 }} disabled={codeSent && !passwordData.code}>
 					{UI_LABELS.BUTTONS.save_changes}
 				</Button>
 			</Box>

--- a/client/src/components/profile/UserInfo.js
+++ b/client/src/components/profile/UserInfo.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { Box, Typography, Paper, Button, FormControl, FormControlLabel, Checkbox, FormHelperText } from '@mui/material';
+import { Alert, Box, Typography, Paper, Button, FormControl, FormControlLabel, Checkbox, FormHelperText } from '@mui/material';
 
 import { UI_LABELS } from '../../constants/uiLabels';
 import { FIELD_LABELS } from '../../constants/fieldLabels';
@@ -80,6 +80,9 @@ const UserInfo = () => {
 				if (err) newErrors[f.name] = err;
 			}
 		});
+		if (!formData.consent) {
+			newErrors.consent = VALIDATION_MESSAGES.BOOKING.consent.REQUIRED;
+		}
 		if (Object.keys(newErrors).length) {
 			setErrors(newErrors);
 			return;
@@ -91,7 +94,7 @@ const UserInfo = () => {
 				last_name: formData.lastName,
 				phone_number: formData.phoneNumber,
 				consent: formData.consent,
-			})
+			}),
 		)
 			.unwrap()
 			.then((user) => {
@@ -108,6 +111,11 @@ const UserInfo = () => {
 				{UI_LABELS.PROFILE.user_info}
 			</Typography>
 			<Box component='form' onSubmit={handleSubmit}>
+				{errors.message && (
+					<Alert severity='error' sx={{ mb: 2 }}>
+						{errors.message}
+					</Alert>
+				)}
 				{['lastName', 'firstName', 'phoneNumber', 'emailAddress'].map((name, idx) => {
 					const field = formFields[name];
 					return (
@@ -142,7 +150,7 @@ const UserInfo = () => {
 					/>
 					{errors.consent && <FormHelperText>{errors.consent}</FormHelperText>}
 				</FormControl>
-				<Button type='submit' fullWidth variant='contained' sx={{ mt: 2 }}>
+				<Button type='submit' fullWidth variant='contained' sx={{ mt: 2 }} disabled={!formData.consent}>
 					{UI_LABELS.BUTTONS.save_changes}
 				</Button>
 			</Box>

--- a/client/src/constants/uiLabels.js
+++ b/client/src/constants/uiLabels.js
@@ -305,6 +305,7 @@ export const UI_LABELS = {
 		to_profile: 'Перейти в личный кабинет',
 		maintenance: 'Скоро здесь будет личный кабинет',
 		change_password: 'Сменить пароль',
+		verification_code_sent: 'Код отправлен на вашу электронную почту. Введите его для смены пароля',
 		password_changed: 'Пароль успешно изменен',
 		passwords_dont_match: 'Пароли не совпадают',
 		user_info: 'Личные данные',


### PR DESCRIPTION
## Summary
- require consent when updating user info and show server errors
- guide users through email verification when changing password
- add UI label for password change verification notice

## Testing
- `npm test`
- `pytest` *(fails: TypeError: str expected, not NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68af36f1ac34832f86bd012d128e697e