### PR TITLE
feat: add user info feedback and centralize totp

### DIFF
--- a/client/src/components/profile/UserInfo.js
+++ b/client/src/components/profile/UserInfo.js
@@ -31,7 +31,9 @@ const UserInfo = () => {
 		emailAddress: '',
 		consent: false,
 	});
-	const [errors, setErrors] = useState({});
+        const [errors, setErrors] = useState({});
+        const [successMessage, setSuccessMessage] = useState('');
+        const [lastSubmittedData, setLastSubmittedData] = useState(null);
 
 	const formFields = useMemo(() => {
 		const fields = {
@@ -66,20 +68,27 @@ const UserInfo = () => {
 
 	useEffect(() => {
 		if (currentUser) {
-			setFormData((prev) => ({
-				...prev,
-				firstName: currentUser.first_name || '',
-				lastName: currentUser.last_name || '',
-				phoneNumber: currentUser.phone_number || '',
-				emailAddress: currentUser.email_address || currentUser.email || '',
-			}));
-		}
-	}, [currentUser]);
+                        const initData = {
+                                firstName: currentUser.first_name || '',
+                                lastName: currentUser.last_name || '',
+                                phoneNumber: currentUser.phone_number || '',
+                                emailAddress: currentUser.email_address || currentUser.email || '',
+                        };
+                        setFormData((prev) => ({ ...prev, ...initData }));
+                        setLastSubmittedData(initData);
+                }
+        }, [currentUser]);
 
-	const handleFieldChange = (field, value) => {
-		setFormData((prev) => ({ ...prev, [field]: value }));
-		if (errors[field]) setErrors((e) => ({ ...e, [field]: '' }));
-	};
+        const handleFieldChange = (field, value) => {
+                setFormData((prev) => {
+                        const updated = { ...prev, [field]: value };
+                        if (field !== 'consent' && lastSubmittedData && value !== lastSubmittedData[field]) {
+                                updated.consent = false;
+                        }
+                        return updated;
+                });
+                if (errors[field]) setErrors((e) => ({ ...e, [field]: '' }));
+        };
 
 	const handleSubmit = (e) => {
 		e.preventDefault();
@@ -97,23 +106,30 @@ const UserInfo = () => {
 			setErrors(newErrors);
 			return;
 		}
-		dispatch(
-			updateUser({
-				id: currentUser.id,
-				first_name: formData.firstName,
-				last_name: formData.lastName,
-				phone_number: formData.phoneNumber,
-				consent: formData.consent,
-			})
-		)
-			.unwrap()
-			.then((user) => {
-				dispatch(setCurrentUser(user));
-				setErrors({});
-				setFormData((prev) => ({ ...prev, consent: false }));
-			})
-			.catch((res) => setErrors(res));
-	};
+                setSuccessMessage('');
+                dispatch(
+                        updateUser({
+                                id: currentUser.id,
+                                first_name: formData.firstName,
+                                last_name: formData.lastName,
+                                phone_number: formData.phoneNumber,
+                                consent: formData.consent,
+                        })
+                )
+                        .unwrap()
+                        .then((user) => {
+                                dispatch(setCurrentUser(user));
+                                setErrors({});
+                                setSuccessMessage(UI_LABELS.SUCCESS.update);
+                                setLastSubmittedData({
+                                        firstName: formData.firstName,
+                                        lastName: formData.lastName,
+                                        phoneNumber: formData.phoneNumber,
+                                        emailAddress: formData.emailAddress,
+                                });
+                        })
+                        .catch((res) => setErrors(res));
+        };
 
 	return (
 		<Paper sx={{ p: 2, width: '100%' }}>
@@ -126,10 +142,15 @@ const UserInfo = () => {
 						{errors.message}
 					</Alert>
 				)}
-				{['lastName', 'firstName', 'phoneNumber', 'emailAddress'].map((name, idx) => {
-					const field = formFields[name];
-					return (
-						<Box key={name} sx={{ mt: idx ? 2 : 0 }}>
+                                {successMessage && (
+                                        <Alert severity='success' sx={{ mb: 2 }}>
+                                                {successMessage}
+                                        </Alert>
+                                )}
+                                {['lastName', 'firstName', 'phoneNumber', 'emailAddress'].map((name, idx) => {
+                                        const field = formFields[name];
+                                        return (
+                                                <Box key={name} sx={{ mt: idx ? 2 : 0 }}>
 							{field.renderField({
 								value: formData[name],
 								onChange: (val) => handleFieldChange(name, val),

--- a/client/src/components/utils/formField.js
+++ b/client/src/components/utils/formField.js
@@ -49,7 +49,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 
 		switch (type) {
 			case FIELD_TYPES.EMAIL: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+								const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -57,7 +57,8 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 						onChange={(e) => onChange(e.target.value)}
 						fullWidth={fullWidth}
 						error={error}
-						helperText={error ? helperText : ''}
+												  helperText={error ? helperText : ''}
+												  disabled={disabled}
 						inputProps={{
 							placeholder: DEFAULT_EMAIL,
 							type: 'email',
@@ -72,7 +73,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.PHONE: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+								const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -80,7 +81,8 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 						onChange={(e) => onChange(e.target.value)}
 						fullWidth={fullWidth}
 						error={error}
-						helperText={error ? helperText : ''}
+												  helperText={error ? helperText : ''}
+												  disabled={disabled}
 						inputProps={{
 							placeholder: DEFAULT_PHONE_NUMBER,
 							type: 'tel',
@@ -95,7 +97,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.TEXT: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+								const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -103,7 +105,8 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 						onChange={(e) => onChange(e.target.value)}
 						fullWidth={fullWidth}
 						error={error}
-						helperText={error ? helperText : ''}
+												  helperText={error ? helperText : ''}
+												  disabled={disabled}
 						inputProps={{ ...field.inputProps, ...inputProps }}
 						size={size}
 						sx={{ ...sx }}
@@ -112,7 +115,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.TEXT_AREA: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+								const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -120,7 +123,8 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 						onChange={(e) => onChange(e.target.value)}
 						fullWidth={fullWidth}
 						error={error}
-						helperText={error ? helperText : ''}
+												  helperText={error ? helperText : ''}
+												  disabled={disabled}
 						multiline
 						rows={field.rows || 5}
 						inputProps={{ ...field.inputProps, ...inputProps }}
@@ -134,7 +138,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.RICH_TEXT: {
-				const { value = '', onChange, fullWidth, error, helperText, sx, rows } = allProps;
+								const { value = '', onChange, fullWidth, error, helperText, sx, rows, disabled } = allProps;
 				const editorRows = rows || field.rows || 20;
 				const editorMinHeight = editorRows * 24;
 				const modules = {
@@ -169,20 +173,21 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 						}}
 					>
 						<InputLabel shrink>{field.label}</InputLabel>
-						<ReactQuill
-							theme='snow'
-							value={value}
-							onChange={onChange}
-							modules={modules}
-							formats={formats}
-						/>
+												  <ReactQuill
+														  theme='snow'
+														  value={value}
+														  onChange={onChange}
+														  modules={modules}
+														  formats={formats}
+														  readOnly={disabled}
+												  />
 						{error && <FormHelperText>{helperText}</FormHelperText>}
 					</FormControl>
 				);
 			}
 
 			case FIELD_TYPES.NUMBER: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size } = allProps;
+								const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
 
 				const step = field.inputProps?.step ?? (field.float ? 0.01 : 1);
 				const min = field.inputProps?.min ?? 0;
@@ -194,9 +199,10 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 						label={field.label}
 						fullWidth={fullWidth}
 						error={error}
-						helperText={error ? helperText : ''}
-						value={value}
-						onChange={(e) => onChange(e.target.value)}
+												  helperText={error ? helperText : ''}
+												  value={value}
+												  onChange={(e) => onChange(e.target.value)}
+												  disabled={disabled}
 						onBlur={(e) => {
 							const num = e.target.valueAsNumber;
 							if (!isNaN(num)) {
@@ -218,74 +224,79 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.DATE: {
-				const { value, onChange, fullWidth, error, helperText, sx, minDate, maxDate, textFieldProps, size } =
-					allProps;
+								const { value, onChange, fullWidth, error, helperText, sx, minDate, maxDate, textFieldProps, size, disabled } =
+										allProps;
 				return (
 					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
-						<DatePicker
-							label={field.label}
-							value={value ? parseDate(value) : null}
-							onChange={(date) => onChange(formatDate(date, DATE_API_FORMAT))}
-							minDate={minDate ? parseDate(minDate) : undefined}
-							maxDate={maxDate ? parseDate(maxDate) : undefined}
-							format={field.dateFormat || DATE_FORMAT}
-							slotProps={{
-								textField: {
-									fullWidth,
-									error,
-									helperText: error ? helperText : '',
-									sx,
-									size,
-									...textFieldProps,
-								},
-							}}
-						/>
+												<DatePicker
+														label={field.label}
+														value={value ? parseDate(value) : null}
+														onChange={(date) => onChange(formatDate(date, DATE_API_FORMAT))}
+														minDate={minDate ? parseDate(minDate) : undefined}
+														maxDate={maxDate ? parseDate(maxDate) : undefined}
+														format={field.dateFormat || DATE_FORMAT}
+														disabled={disabled}
+														slotProps={{
+																textField: {
+																		fullWidth,
+																		error,
+																		helperText: error ? helperText : '',
+																		sx,
+																		size,
+																		disabled,
+																		...textFieldProps,
+																},
+														}}
+												/>
 					</LocalizationProvider>
 				);
 			}
 
 			case FIELD_TYPES.TIME: {
-				const { value, onChange, fullWidth, error, helperText, sx, textFieldProps, size } = allProps;
+								const { value, onChange, fullWidth, error, helperText, sx, textFieldProps, size, disabled } = allProps;
 
 				return (
 					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
-						<TimePicker
-							label={field.label}
-							value={value ? parseTime(value) : null}
-							onChange={(time) => onChange(formatTime(time))}
-							ampm={false}
-							format={field.timeFormat || TIME_FORMAT}
-							mask={TIME_MASK}
-							slotProps={{
-								textField: {
-									fullWidth,
-									error,
-									helperText: error ? helperText : '',
-									sx,
-									size,
-									...textFieldProps,
-								},
-							}}
-						/>
+												<TimePicker
+														label={field.label}
+														value={value ? parseTime(value) : null}
+														onChange={(time) => onChange(formatTime(time))}
+														ampm={false}
+														format={field.timeFormat || TIME_FORMAT}
+														mask={TIME_MASK}
+														disabled={disabled}
+														slotProps={{
+																textField: {
+																		fullWidth,
+																		error,
+																		helperText: error ? helperText : '',
+																		sx,
+																		size,
+																		disabled,
+																		...textFieldProps,
+																},
+														}}
+												/>
 					</LocalizationProvider>
 				);
 			}
 
 			case FIELD_TYPES.SELECT: {
-				const {
-					value = '',
-					onChange,
-					fullWidth,
-					error,
-					helperText,
-					options = field.options || [],
-					MenuProps,
-					MenuItemProps,
-					displayEmpty,
-					simpleSelect,
-					sx,
-					size,
-				} = allProps;
+								const {
+										value = '',
+										onChange,
+										fullWidth,
+										error,
+										helperText,
+										options = field.options || [],
+										MenuProps,
+										MenuItemProps,
+										displayEmpty,
+										simpleSelect,
+										sx,
+										size,
+										disabled,
+								} = allProps;
 
 				const resolvedValue = value !== undefined && value !== null ? value : field.defaultValue;
 				const isValidValue = options.some((o) => o.value === resolvedValue);
@@ -294,42 +305,45 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				if (!simpleSelect && options.length > 100) {
 					const valueObj = options.find((o) => o.value === value) || null;
 					return (
-						<Autocomplete
-							options={options}
-							value={valueObj}
-							onChange={(e, val) => onChange(val ? val.value : '')}
-							filterOptions={(opts, state) =>
-								opts
-									.filter((o) => o.label.toLowerCase().includes(state.inputValue.toLowerCase()))
-									.slice(0, 100)
-							}
-							getOptionLabel={(o) => o.label}
-							renderInput={(params) => (
-								<TextField
-									{...params}
-									label={field.label}
-									error={error}
-									helperText={error ? helperText : ''}
-									fullWidth={fullWidth}
-									size={size}
-									sx={{ ...sx }}
-								/>
-							)}
-						/>
+												<Autocomplete
+														options={options}
+														value={valueObj}
+														onChange={(e, val) => onChange(val ? val.value : '')}
+														filterOptions={(opts, state) =>
+																opts
+																		.filter((o) => o.label.toLowerCase().includes(state.inputValue.toLowerCase()))
+																		.slice(0, 100)
+														}
+														getOptionLabel={(o) => o.label}
+														disabled={disabled}
+														renderInput={(params) => (
+																<TextField
+																		{...params}
+																		label={field.label}
+																		error={error}
+																		helperText={error ? helperText : ''}
+																		fullWidth={fullWidth}
+																		size={size}
+																		sx={{ ...sx }}
+																		disabled={disabled}
+																/>
+														)}
+												/>
 					);
 				}
 
 				if (simpleSelect) {
 					return (
-						<Select
-							value={safeValue}
-							onChange={(e) => onChange(e.target.value)}
-							fullWidth={fullWidth}
-							MenuProps={MenuProps}
-							displayEmpty={displayEmpty}
-							size={size}
-							sx={{ ...sx }}
-						>
+												<Select
+														value={safeValue}
+														onChange={(e) => onChange(e.target.value)}
+														fullWidth={fullWidth}
+														MenuProps={MenuProps}
+														displayEmpty={displayEmpty}
+														size={size}
+														sx={{ ...sx }}
+														disabled={disabled}
+												>
 							{options.map((option) => (
 								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
 									{option.label}
@@ -340,17 +354,18 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				}
 
 				return (
-					<FormControl fullWidth={fullWidth} error={!!error} size={size}>
-						<InputLabel>{field.label}</InputLabel>
-						<Select
-							value={safeValue}
-							onChange={(e) => onChange(e.target.value)}
-							label={field.label}
-							MenuProps={MenuProps}
-							displayEmpty={displayEmpty}
-							size={size}
-							sx={{ ...sx }}
-						>
+										<FormControl fullWidth={fullWidth} error={!!error} size={size}>
+												<InputLabel>{field.label}</InputLabel>
+												<Select
+														value={safeValue}
+														onChange={(e) => onChange(e.target.value)}
+														label={field.label}
+														MenuProps={MenuProps}
+														displayEmpty={displayEmpty}
+														size={size}
+														sx={{ ...sx }}
+														disabled={disabled}
+												>
 							{options.map((option) => (
 								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
 									{option.label}
@@ -363,35 +378,37 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.BOOLEAN: {
-				const { value = false, onChange, sx } = allProps;
-				return (
-					<FormControlLabel
-						control={
-							<Checkbox checked={!!value} onChange={(e) => onChange(e.target.checked)} color='primary' />
+								const { value = false, onChange, sx, disabled } = allProps;
+								return (
+										<FormControlLabel
+												control={
+														<Checkbox checked={!!value} onChange={(e) => onChange(e.target.checked)} color='primary' disabled={disabled} />
+												}
+												label={field.label}
+												sx={{ ...sx }}
+												disabled={disabled}
+										/>
+								);
 						}
-						label={field.label}
-						sx={{ ...sx }}
-					/>
-				);
-			}
 
 			case FIELD_TYPES.CUSTOM:
 				return (customProps) => field.renderField({ ...allProps, ...customProps });
 
 			default: {
-				const { value = '', onChange, fullWidth, inputProps, sx, size } = allProps;
-				return (
-					<TextField
-						label={field.label}
-						value={value}
-						onChange={(e) => onChange(e.target.value)}
-						fullWidth={fullWidth}
-						inputProps={{ ...field.inputProps, ...inputProps }}
-						size={size}
-						sx={{ ...sx }}
-					/>
-				);
-			}
+								const { value = '', onChange, fullWidth, inputProps, sx, size, disabled } = allProps;
+								return (
+										<TextField
+												label={field.label}
+												value={value}
+												onChange={(e) => onChange(e.target.value)}
+												fullWidth={fullWidth}
+												inputProps={{ ...field.inputProps, ...inputProps }}
+												size={size}
+												sx={{ ...sx }}
+												disabled={disabled}
+										/>
+								);
+						}
 		}
 	};
 };

--- a/server/app/controllers/auth_controller.py
+++ b/server/app/controllers/auth_controller.py
@@ -1,5 +1,4 @@
 from flask import request, jsonify
-import pyotp
 import re
 
 from app.config import Config
@@ -59,12 +58,7 @@ def login():
     user = User.login(email, password)
     if user:
         if user.role == USER_ROLE.admin and re.match(r'^[^@]+@[^@]+\.[^@]+$', email):
-            totp_secret = user.totp_secret
-            if not totp_secret:
-                totp_secret = pyotp.random_base32()
-                user = User.update(user.id, commit=True, totp_secret=totp_secret)
-                user = User.get_by_email(email)
-            totp = pyotp.TOTP(user.totp_secret, interval=Config.LOGIN_TOTP_INTERVAL_SECONDS)
+            totp = user.get_totp(Config.LOGIN_TOTP_INTERVAL_SECONDS)
             code = totp.now()
             send_email(
                 EMAIL_TYPE.two_factor,
@@ -86,13 +80,7 @@ def setup_2fa():
     if not user or user.role != USER_ROLE.admin:
         return jsonify({'message': 'User not found'}), 404
     
-    totp_secret = user.totp_secret
-    if not totp_secret:
-        totp_secret = pyotp.random_base32()
-        user = User.update(user.id, commit=True, totp_secret=totp_secret)
-        user = User.get_by_email(email)
-
-    totp = pyotp.TOTP(user.totp_secret, interval=Config.LOGIN_TOTP_INTERVAL_SECONDS)
+    totp = user.get_totp(Config.LOGIN_TOTP_INTERVAL_SECONDS)
     code = totp.now()
     send_email(
         EMAIL_TYPE.two_factor,
@@ -111,7 +99,7 @@ def verify_2fa():
     user = User.get_by_email(email)
     if not user or user.role != USER_ROLE.admin or not user.totp_secret:
         return jsonify({'message': 'Invalid request'}), 400
-    totp = pyotp.TOTP(user.totp_secret, interval=Config.LOGIN_TOTP_INTERVAL_SECONDS)
+    totp = user.get_totp(Config.LOGIN_TOTP_INTERVAL_SECONDS)
     if totp.verify(code):
         User.reset_failed_logins(user)
         token = signJWT(user.email)

--- a/server/app/controllers/user_controller.py
+++ b/server/app/controllers/user_controller.py
@@ -1,7 +1,3 @@
-import base64
-import pyotp
-import hashlib
-
 from flask import request, jsonify
 
 from app.database import db
@@ -125,10 +121,7 @@ def change_password(current_user):
     if not password:
         return jsonify({'message': 'Invalid password'}), 400
 
-    secret_source = f'{current_user.email}{password}{Config.SECRET_KEY}'
-    digest = hashlib.sha256(secret_source.encode()).digest()
-    secret = base64.b32encode(digest).decode()
-    totp = pyotp.TOTP(secret, interval=Config.PASSWORD_CHANGE_TOTP_INTERVAL_SECONDS)
+    totp = current_user.get_totp(Config.PASSWORD_CHANGE_TOTP_INTERVAL_SECONDS)
 
     if code:
         if not totp.verify(str(code)):


### PR DESCRIPTION
## Summary
- show success message when profile info updates and reset consent on edits
- generate TOTP secret on user creation and reuse for password and 2FA codes
- allow disabling form fields and lock password inputs while submitting

## Testing
- `pytest` *(fails: TypeError: str expected, not NoneType)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af44017c34832f8e011c8d8af9bac6