### PR TITLE
feat: add responsive header drawer

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -8,11 +8,18 @@ import Avatar from '@mui/material/Avatar';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Button from '@mui/material/Button';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import IconButton from '@mui/material/IconButton';
+import Drawer from '@mui/material/Drawer';
+import useMediaQuery from '@mui/material/useMediaQuery';
+import { useTheme } from '@mui/material/styles';
 
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import LoginIcon from '@mui/icons-material/Login';
 import PersonAddIcon from '@mui/icons-material/PersonAdd';
 import SearchIcon from '@mui/icons-material/Search';
+import MenuIcon from '@mui/icons-material/Menu';
 
 import { useAuthModal } from '../context/AuthModalContext';
 import { selectIsAuth, selectIsAdmin } from '../redux/reducers/auth';
@@ -27,12 +34,16 @@ const Header = () => {
 	const { openLoginModal, openRegisterModal } = useAuthModal();
 	const navigate = useNavigate();
 
+	const theme = useTheme();
+	const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
 	const isAuth = useSelector(selectIsAuth);
 	const isAdmin = useSelector(selectIsAdmin);
 	const currentUser = useSelector((state) => state.auth.currentUser);
 
 	const [anchorEl, setAnchorEl] = useState(null);
 	const open = Boolean(anchorEl);
+	const [drawerOpen, setDrawerOpen] = useState(false);
 
 	const handleProfileClick = (event) => {
 		setAnchorEl(event.currentTarget);
@@ -45,133 +56,241 @@ const Header = () => {
 	const handleGoToProfile = () => {
 		navigate('/profile');
 		handleMenuClose();
+		setDrawerOpen(false);
 	};
 
 	const handleLogout = () => {
 		handleMenuClose();
 		dispatch(logout());
+		setDrawerOpen(false);
+	};
+
+	const toggleDrawer = (openState) => () => {
+		setDrawerOpen(openState);
 	};
 
 	return (
-		<Box
-			component='header'
-			sx={{
-				display: 'flex',
-				alignItems: 'center',
-				justifyContent: 'space-between',
-				py: 2,
-				borderBottom: 1,
-				borderColor: 'divider',
-			}}
+		<AppBar
+			component="header"
+			position="static"
+			color="transparent"
+			elevation={0}
+			sx={{ borderBottom: 1, borderColor: 'divider' }}
 		>
-			<Box
-				component={Link}
-				to='/'
-				sx={{
-					display: 'flex',
-					alignItems: 'center',
-					textDecoration: 'none',
-					color: 'inherit',
-				}}
-			>
+			<Toolbar sx={{ justifyContent: 'space-between', py: 2 }}>
 				<Box
-					component='img'
-					src='/images/logo/logo32.png'
-					alt='Avexmar logo'
-					sx={{ width: 32, height: 32, mr: 1 }}
-				/>
-				<Typography variant='h4' component='span'>
-					{companyName.toUpperCase()}
-				</Typography>
-			</Box>
-
-			<Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-				<Button
 					component={Link}
-					to='/search/booking'
-					color='inherit'
-					startIcon={<SearchIcon sx={{ width: 32, height: 32 }} />}
-					sx={{ textTransform: 'none' }}
+					to="/"
+					sx={{
+						display: 'flex',
+						alignItems: 'center',
+						textDecoration: 'none',
+						color: 'inherit',
+					}}
 				>
-					{UI_LABELS.BOOKING_SEARCH.link}
-				</Button>
+					<Box
+						component="img"
+						src="/images/logo/logo32.png"
+						alt="Avexmar logo"
+						sx={{ width: 32, height: 32, mr: 1 }}
+					/>
+					<Typography variant="h4" component="span">
+						{companyName.toUpperCase()}
+					</Typography>
+				</Box>
 
-				{isAdmin && (
-					<Button
-						component={Link}
-						to='/admin'
-						color='inherit'
-						startIcon={<AdminPanelSettingsIcon sx={{ width: 32, height: 32 }} />}
-						sx={{ textTransform: 'none' }}
-					>
-						{UI_LABELS.ADMIN.panel}
-					</Button>
-				)}
-				{isAuth ? (
+				{isMobile ? (
 					<>
-						<Button
-							color='inherit'
-							onClick={handleProfileClick}
-							startIcon={<Avatar sx={{ width: 32, height: 32 }} />}
-							sx={{ textTransform: 'none' }}
+						<IconButton
+							edge="end"
+							color="inherit"
+							onClick={toggleDrawer(true)}
 						>
-							{UI_LABELS.PROFILE.profile}
-						</Button>
-
-						<Menu
-							anchorEl={anchorEl}
-							open={open}
-							onClose={handleMenuClose}
-							anchorOrigin={{
-								vertical: 'bottom',
-								horizontal: 'right',
-							}}
-							transformOrigin={{
-								vertical: 'top',
-								horizontal: 'right',
-							}}
+							<MenuIcon />
+						</IconButton>
+						<Drawer
+							anchor="right"
+							open={drawerOpen}
+							onClose={toggleDrawer(false)}
 						>
-							<MenuItem onClick={handleGoToProfile} sx={{ py: 1.5 }}>
-								<Box sx={{ display: 'flex', alignItems: 'center' }}>
-									<Avatar sx={{ width: 32, height: 32, mr: 1 }} />
-									<Box>
-										<Typography variant='subtitle2'>{UI_LABELS.PROFILE.to_profile}</Typography>
-										{currentUser?.email && (
-											<Typography variant='caption' color='text.secondary'>
-												{currentUser.email}
-											</Typography>
-										)}
-									</Box>
-								</Box>
-							</MenuItem>
-							<MenuItem onClick={handleLogout}>
-								<LoginIcon fontSize='small' sx={{ mr: 1, color: 'red' }} />
-								{UI_LABELS.BUTTONS.exit}
-							</MenuItem>
-						</Menu>
+							<Box
+								sx={{
+									width: 250,
+									p: 2,
+									display: 'flex',
+									flexDirection: 'column',
+									gap: 2,
+								}}
+							>
+								<Button
+									component={Link}
+									to="/search/booking"
+									color="inherit"
+									startIcon={
+										<SearchIcon
+											sx={{ width: 32, height: 32 }}
+										/>
+									}
+									sx={{ textTransform: 'none' }}
+								>
+									{UI_LABELS.BOOKING_SEARCH.link}
+								</Button>
+								{isAdmin && (
+									<Button
+										component={Link}
+										to="/admin"
+										color="inherit"
+										startIcon={
+											<AdminPanelSettingsIcon
+												sx={{ width: 32, height: 32 }}
+											/>
+										}
+										sx={{ textTransform: 'none' }}
+									>
+										{UI_LABELS.ADMIN.panel}
+									</Button>
+								)}
+								{isAuth ? (
+									<Button
+										color="inherit"
+										onClick={handleProfileClick}
+										startIcon={
+											<Avatar
+												sx={{ width: 32, height: 32 }}
+											/>
+										}
+										sx={{ textTransform: 'none' }}
+									>
+										{UI_LABELS.PROFILE.profile}
+									</Button>
+								) : (
+									<>
+										<Button
+											color="inherit"
+											onClick={openLoginModal}
+											startIcon={<LoginIcon />}
+											sx={{ textTransform: 'none' }}
+										>
+											{UI_LABELS.BUTTONS.login}
+										</Button>
+										<Button
+											color="inherit"
+											onClick={openRegisterModal}
+											startIcon={<PersonAddIcon />}
+											sx={{ textTransform: 'none' }}
+										>
+											{UI_LABELS.BUTTONS.register}
+										</Button>
+									</>
+								)}
+							</Box>
+						</Drawer>
 					</>
 				) : (
-					<>
+					<Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
 						<Button
-							color='inherit'
-							onClick={openLoginModal}
-							startIcon={<LoginIcon />}
+							component={Link}
+							to="/search/booking"
+							color="inherit"
+							startIcon={
+								<SearchIcon sx={{ width: 32, height: 32 }} />
+							}
 							sx={{ textTransform: 'none' }}
 						>
-							{UI_LABELS.BUTTONS.login}
+							{UI_LABELS.BOOKING_SEARCH.link}
 						</Button>
-						<Button
-							color='inherit'
-							onClick={openRegisterModal}
-							startIcon={<PersonAddIcon />}
-							sx={{ textTransform: 'none' }}
-						>
-							{UI_LABELS.BUTTONS.register}
-						</Button>
-					</>
+						{isAdmin && (
+							<Button
+								component={Link}
+								to="/admin"
+								color="inherit"
+								startIcon={
+									<AdminPanelSettingsIcon
+										sx={{ width: 32, height: 32 }}
+									/>
+								}
+								sx={{ textTransform: 'none' }}
+							>
+								{UI_LABELS.ADMIN.panel}
+							</Button>
+						)}
+						{isAuth ? (
+							<Button
+								color="inherit"
+								onClick={handleProfileClick}
+								startIcon={
+									<Avatar sx={{ width: 32, height: 32 }} />
+								}
+								sx={{ textTransform: 'none' }}
+							>
+								{UI_LABELS.PROFILE.profile}
+							</Button>
+						) : (
+							<>
+								<Button
+									color="inherit"
+									onClick={openLoginModal}
+									startIcon={<LoginIcon />}
+									sx={{ textTransform: 'none' }}
+								>
+									{UI_LABELS.BUTTONS.login}
+								</Button>
+								<Button
+									color="inherit"
+									onClick={openRegisterModal}
+									startIcon={<PersonAddIcon />}
+									sx={{ textTransform: 'none' }}
+								>
+									{UI_LABELS.BUTTONS.register}
+								</Button>
+							</>
+						)}
+					</Box>
 				)}
-			</Box>
-		</Box>
+
+				{isAuth && (
+					<Menu
+						anchorEl={anchorEl}
+						open={open}
+						onClose={handleMenuClose}
+						anchorOrigin={{
+							vertical: 'bottom',
+							horizontal: 'right',
+						}}
+						transformOrigin={{
+							vertical: 'top',
+							horizontal: 'right',
+						}}
+					>
+						<MenuItem onClick={handleGoToProfile} sx={{ py: 1.5 }}>
+							<Box sx={{ display: 'flex', alignItems: 'center' }}>
+								<Avatar sx={{ width: 32, height: 32, mr: 1 }} />
+								<Box>
+									<Typography variant="subtitle2">
+										{UI_LABELS.PROFILE.to_profile}
+									</Typography>
+									{currentUser?.email && (
+										<Typography
+											variant="caption"
+											color="text.secondary"
+										>
+											{currentUser.email}
+										</Typography>
+									)}
+								</Box>
+							</Box>
+						</MenuItem>
+						<MenuItem onClick={handleLogout}>
+							<LoginIcon
+								fontSize="small"
+								sx={{ mr: 1, color: 'red' }}
+							/>
+							{UI_LABELS.BUTTONS.exit}
+						</MenuItem>
+					</Menu>
+				)}
+			</Toolbar>
+		</AppBar>
 	);
 };
 


### PR DESCRIPTION
## Summary
- wrap header content in MUI `AppBar` and `Toolbar`
- add mobile drawer toggled by menu icon and preserve desktop layout

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d6434170832f8166fca74c29e379