### PR TITLE
Improve footer responsiveness and accessibility

### DIFF
--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -30,11 +30,12 @@ const Footer = () => {
 				<Stack
 					direction={{ xs: 'column', sm: 'row' }}
 					justifyContent='space-between'
-					alignItems='center'
-					spacing={3}
+					alignItems={{ xs: 'flex-start', sm: 'center' }}
+					spacing={{ xs: 2, sm: 3 }}
+					textAlign={{ xs: 'left', sm: 'center' }}
 				>
 					<Stack>
-						<Typography variant='body2' color='text.secondary' align='center'>
+						<Typography variant='body2' color='text.secondary'>
 							© {currentYear}, {companyName}. {UI_LABELS.ABOUT.all_rights_reserved}
 						</Typography>
 					</Stack>
@@ -47,7 +48,14 @@ const Footer = () => {
 								component={RouterLink}
 								color='inherit'
 								underline='hover'
-								sx={{ px: 1 }}
+								sx={{
+									display: 'inline-flex',
+									alignItems: 'center',
+									justifyContent: 'center',
+									minWidth: 48,
+									minHeight: 48,
+									px: 1,
+								}}
 							>
 								<Typography variant='body2'>{label}</Typography>
 							</Link>


### PR DESCRIPTION
## Summary
- align footer layout for mobile and desktop with responsive Stack props
- enlarge link touch areas to 48px minimum for better mobile usability

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d649944c832fb851050ce4682160