### PR TITLE
feat: improve search responsiveness

### DIFF
--- a/client/src/components/search/Search.js
+++ b/client/src/components/search/Search.js
@@ -3,18 +3,25 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import {
-	Alert,
-	Box,
-	Typography,
-	FormControl,
-	InputLabel,
-	Select,
-	MenuItem,
-	Button,
-	CircularProgress,
+Alert,
+Box,
+Typography,
+FormControl,
+InputLabel,
+Select,
+MenuItem,
+Button,
+CircularProgress,
+Accordion,
+AccordionSummary,
+AccordionDetails,
+useMediaQuery,
+Stack,
 } from '@mui/material';
 import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import { useTheme } from '@mui/material/styles';
 
 import Base from '../Base';
 import SearchForm from './SearchForm';
@@ -24,10 +31,12 @@ import { fetchNearbyOutboundFlights, fetchNearbyReturnFlights, fetchSearchFlight
 import { combineLocalDateTime, formatDate, formatNumber, parseDate, parseTime } from '../utils';
 
 const Search = () => {
-	const dispatch = useDispatch();
-	const navigate = useNavigate();
+const dispatch = useDispatch();
+const navigate = useNavigate();
+const theme = useTheme();
+const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
 
-	const {
+const {
 		flights,
 		flightsLoading,
 		nearbyOutboundFlights,
@@ -245,15 +254,16 @@ const Search = () => {
 		}
 	};
 
-	return (
-		<Base>
-			<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-				<SearchForm initialParams={initialParams} />
-			</Box>
-			<Box sx={{ p: 3 }}>
-				<Typography variant='h4' component='h1' gutterBottom sx={{ mt: 2 }}>
-					{UI_LABELS.SEARCH.results}
-				</Typography>
+return (
+<Base>
+<Stack spacing={2}>
+<Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+<SearchForm initialParams={initialParams} />
+</Box>
+<Box sx={{ p: 3 }}>
+<Typography variant='h4' component='h1' gutterBottom sx={{ mt: 2 }}>
+{UI_LABELS.SEARCH.results}
+</Typography>
 
 				{isExact && (
 					<Box
@@ -400,44 +410,88 @@ const Search = () => {
 					</Box>
 				)}
 
-				{!isLoading && flights.length !== 0 && (
-					<Box sx={{ display: 'flex', mb: 2, justifyContent: 'flex-end' }}>
-						<FormControl size='small' sx={{ width: 210, flexShrink: 0 }}>
-							<InputLabel id='sort-label'>{UI_LABELS.SEARCH.sort.label}</InputLabel>
-							<Select
-								labelId='sort-label'
-								value={sortKey}
-								label={UI_LABELS.SEARCH.sort.label}
-								onChange={() => {}}
-							>
-								<MenuItem value='price' onClick={() => handleSort('price')}>
-									{UI_LABELS.SEARCH.sort.price}{' '}
-									{sortKey === 'price' && (sortOrder === 'asc' ? '↑' : '↓')}
-								</MenuItem>
-								<MenuItem value='departure_date' onClick={() => handleSort('departure_date')}>
-									{UI_LABELS.SEARCH.sort.departure_date}{' '}
-									{sortKey === 'departure_date' && (sortOrder === 'asc' ? '↑' : '↓')}
-								</MenuItem>
-								<MenuItem value='departure_time' onClick={() => handleSort('departure_time')}>
-									{UI_LABELS.SEARCH.sort.departure_time}{' '}
-									{sortKey === 'departure_time' && (sortOrder === 'asc' ? '↑' : '↓')}
-								</MenuItem>
-								<MenuItem value='arrival_date' onClick={() => handleSort('arrival_date')}>
-									{UI_LABELS.SEARCH.sort.arrival_date}{' '}
-									{sortKey === 'arrival_date' && (sortOrder === 'asc' ? '↑' : '↓')}
-								</MenuItem>
-								<MenuItem value='arrival_time' onClick={() => handleSort('arrival_time')}>
-									{UI_LABELS.SEARCH.sort.arrival_time}{' '}
-									{sortKey === 'arrival_time' && (sortOrder === 'asc' ? '↑' : '↓')}
-								</MenuItem>
-								<MenuItem value='duration' onClick={() => handleSort('duration')}>
-									{UI_LABELS.SEARCH.sort.duration}{' '}
-									{sortKey === 'duration' && (sortOrder === 'asc' ? '↑' : '↓')}
-								</MenuItem>
-							</Select>
-						</FormControl>
-					</Box>
-				)}
+{!isLoading && flights.length !== 0 && (
+isSmall ? (
+<Accordion sx={{ mb: 2 }}>
+<AccordionSummary expandIcon={<ExpandMoreIcon />}>
+{UI_LABELS.SEARCH.sort.label}
+</AccordionSummary>
+<AccordionDetails>
+<FormControl fullWidth size='small'>
+<InputLabel id='sort-label'>{UI_LABELS.SEARCH.sort.label}</InputLabel>
+<Select
+labelId='sort-label'
+value={sortKey}
+label={UI_LABELS.SEARCH.sort.label}
+onChange={() => {}}
+>
+<MenuItem value='price' onClick={() => handleSort('price')}>
+{UI_LABELS.SEARCH.sort.price}{' '}
+{sortKey === 'price' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='departure_date' onClick={() => handleSort('departure_date')}>
+{UI_LABELS.SEARCH.sort.departure_date}{' '}
+{sortKey === 'departure_date' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='departure_time' onClick={() => handleSort('departure_time')}>
+{UI_LABELS.SEARCH.sort.departure_time}{' '}
+{sortKey === 'departure_time' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='arrival_date' onClick={() => handleSort('arrival_date')}>
+{UI_LABELS.SEARCH.sort.arrival_date}{' '}
+{sortKey === 'arrival_date' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='arrival_time' onClick={() => handleSort('arrival_time')}>
+{UI_LABELS.SEARCH.sort.arrival_time}{' '}
+{sortKey === 'arrival_time' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='duration' onClick={() => handleSort('duration')}>
+{UI_LABELS.SEARCH.sort.duration}{' '}
+{sortKey === 'duration' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+</Select>
+</FormControl>
+</AccordionDetails>
+</Accordion>
+) : (
+<Stack direction='row' justifyContent='flex-end' mb={2}>
+<FormControl size='small' sx={{ width: 210, flexShrink: 0 }}>
+<InputLabel id='sort-label'>{UI_LABELS.SEARCH.sort.label}</InputLabel>
+<Select
+labelId='sort-label'
+value={sortKey}
+label={UI_LABELS.SEARCH.sort.label}
+onChange={() => {}}
+>
+<MenuItem value='price' onClick={() => handleSort('price')}>
+{UI_LABELS.SEARCH.sort.price}{' '}
+{sortKey === 'price' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='departure_date' onClick={() => handleSort('departure_date')}>
+{UI_LABELS.SEARCH.sort.departure_date}{' '}
+{sortKey === 'departure_date' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='departure_time' onClick={() => handleSort('departure_time')}>
+{UI_LABELS.SEARCH.sort.departure_time}{' '}
+{sortKey === 'departure_time' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='arrival_date' onClick={() => handleSort('arrival_date')}>
+{UI_LABELS.SEARCH.sort.arrival_date}{' '}
+{sortKey === 'arrival_date' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='arrival_time' onClick={() => handleSort('arrival_time')}>
+{UI_LABELS.SEARCH.sort.arrival_time}{' '}
+{sortKey === 'arrival_time' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+<MenuItem value='duration' onClick={() => handleSort('duration')}>
+{UI_LABELS.SEARCH.sort.duration}{' '}
+{sortKey === 'duration' && (sortOrder === 'asc' ? '↑' : '↓')}
+</MenuItem>
+</Select>
+</FormControl>
+</Stack>
+)
+)}
 
 				{isLoading ? (
 					<Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
@@ -458,16 +512,17 @@ const Search = () => {
 					<Alert severity='info'>{UI_LABELS.SEARCH.no_results}</Alert>
 				)}
 
-				{visibleCount < sortedGrouped.length && (
-					<Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-						<Button variant='contained' onClick={() => setVisibleCount((v) => v + 10)}>
-							{UI_LABELS.SEARCH.show_more}
-						</Button>
-					</Box>
-				)}
-			</Box>
-		</Base>
-	);
+{visibleCount < sortedGrouped.length && (
+<Stack direction='row' justifyContent='center' mt={2}>
+<Button variant='contained' onClick={() => setVisibleCount((v) => v + 10)}>
+{UI_LABELS.SEARCH.show_more}
+</Button>
+</Stack>
+)}
+</Box>
+</Stack>
+</Base>
+);
 };
 
 export default Search;

--- a/client/src/components/search/SearchResultCard.js
+++ b/client/src/components/search/SearchResultCard.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Card, Box, Typography, Button, Divider, IconButton, Skeleton } from '@mui/material';
+import { Card, Box, Typography, Button, Divider, IconButton, Skeleton, Stack } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import FlightIcon from '@mui/icons-material/Flight';
 import ShareIcon from '@mui/icons-material/Share';
@@ -168,74 +168,77 @@ const SearchResultCard = ({ outbound, returnFlight, isLoading }) => {
 		? `${UI_LABELS.SEARCH.flight_details.price_from.toLowerCase()} ${formatNumber(totalPrice)} ${currencySymbol}`
 		: `${formatNumber(totalPrice)} ${currencySymbol}`;
 
-	return (
-		<>
-			<Card sx={{ display: 'flex', p: 2, mb: 2 }}>
-				<Box
-					sx={{
-						width: 180,
-						textAlign: 'center',
-						pr: 2,
-						borderRight: `1px solid ${theme.palette.grey[100]}`,
-						display: 'flex',
-						flexDirection: 'column',
-						justifyContent: 'center',
-					}}
-				>
-					{isLoading ? (
-						<Skeleton variant='rectangular' width={150} height={40} sx={{ mb: 1, mx: 'auto' }} />
-					) : (
-						<>
-							<Typography variant='h5' sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
-								{priceText}
-							</Typography>
-							<Typography variant='subtitle2' color='text.secondary' sx={{ mb: 1 }}>
-								{UI_LABELS.SEARCH.flight_details.price_per_passenger.toLowerCase()}
-							</Typography>
-						</>
-					)}
-					<Button
-						variant='contained'
-						color='orange'
-						disabled={isLoading}
-						sx={{
-							borderRadius: 2,
-							boxShadow: 'none',
-							textTransform: 'none',
-							whiteSpace: 'nowrap',
-						}}
-						onClick={(e) => {
-							e.currentTarget.blur();
-							setOpenDialog(true);
-						}}
-					>
-						{UI_LABELS.SEARCH.flight_details.select_tariff_title}
-					</Button>
-				</Box>
-				<Box sx={{ flexGrow: 1, pl: 2 }}>
-					{isLoading ? (
-						<>
-							<SegmentSkeleton />
-							{returnFlight && <Divider sx={{ my: 1 }} />}
-							{returnFlight && <SegmentSkeleton />}
-						</>
-					) : (
-						<>
-							<Segment flight={outbound} isOutbound />
-							{returnFlight && <Divider sx={{ my: 1 }} />}
-							{returnFlight && <Segment flight={returnFlight} isOutbound={false} />}
-						</>
-					)}
-				</Box>
-			</Card>
-			<SelectTicketDialog
-				open={openDialog}
-				onClose={() => setOpenDialog(false)}
-				outbound={outbound}
-				returnFlight={returnFlight}
-			/>
-		</>
-	);
+return (
+<>
+<Card sx={{ p: 2, mb: 2 }}>
+<Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+<Box
+sx={{
+width: { md: 180 },
+textAlign: 'center',
+pr: { md: 2 },
+borderRight: { md: `1px solid ${theme.palette.grey[100]}` },
+display: 'flex',
+flexDirection: 'column',
+justifyContent: 'center',
+mb: { xs: 2, md: 0 },
+}}
+>
+{isLoading ? (
+<Skeleton variant='rectangular' width={150} height={40} sx={{ mb: 1, mx: 'auto' }} />
+) : (
+<>
+<Typography variant='h5' sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+{priceText}
+</Typography>
+<Typography variant='subtitle2' color='text.secondary' sx={{ mb: 1 }}>
+{UI_LABELS.SEARCH.flight_details.price_per_passenger.toLowerCase()}
+</Typography>
+</>
+)}
+<Button
+variant='contained'
+color='orange'
+disabled={isLoading}
+sx={{
+borderRadius: 2,
+boxShadow: 'none',
+textTransform: 'none',
+whiteSpace: 'nowrap',
+}}
+onClick={(e) => {
+e.currentTarget.blur();
+setOpenDialog(true);
+}}
+>
+{UI_LABELS.SEARCH.flight_details.select_tariff_title}
+</Button>
+</Box>
+<Box sx={{ flexGrow: 1, pl: { md: 2 } }}>
+{isLoading ? (
+<>
+<SegmentSkeleton />
+{returnFlight && <Divider sx={{ my: 1 }} />}
+{returnFlight && <SegmentSkeleton />}
+</>
+) : (
+<>
+<Segment flight={outbound} isOutbound />
+{returnFlight && <Divider sx={{ my: 1 }} />}
+{returnFlight && <Segment flight={returnFlight} isOutbound={false} />}
+</>
+)}
+</Box>
+</Stack>
+</Card>
+<SelectTicketDialog
+open={openDialog}
+onClose={() => setOpenDialog(false)}
+outbound={outbound}
+returnFlight={returnFlight}
+/>
+</>
+);
 };
 
 export default SearchResultCard;


### PR DESCRIPTION
## Summary
- refactor search results layout for responsive stack
- add mobile-friendly sort accordion

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b32a83f12c832f8dd9c94984e3eda6