### PR TITLE
feat: add home page poster carousel

### DIFF
--- a/client/public/images/posters/loyalty.svg
+++ b/client/public/images/posters/loyalty.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 150'>
+<rect width='300' height='150' fill='#ff9800'/>
+<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='#fff'>Loyalty</text>
+</svg>

--- a/client/public/images/posters/routes.svg
+++ b/client/public/images/posters/routes.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 150'>
+<rect width='300' height='150' fill='#4caf50'/>
+<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='#fff'>New Routes</text>
+</svg>

--- a/client/public/images/posters/winter.svg
+++ b/client/public/images/posters/winter.svg
@@ -1,0 +1,4 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 300 150'>
+<rect width='300' height='150' fill='#2196f3'/>
+<text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-size='24' fill='#fff'>Winter Deals</text>
+</svg>

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -2,13 +2,25 @@ import React from 'react';
 import { Box } from '@mui/material';
 import Base from './Base';
 import SearchForm from './search/SearchForm';
+import PosterCarousel from './home/PosterCarousel';
 
 const Home = () => {
 	return (
 		<Base maxWidth='xl'>
-			<Box sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
-				<Box sx={{ width: '100%', px: { xs: 1, sm: 2 } }}>
+			<Box
+				sx={{
+					display: 'flex',
+					flexDirection: { xs: 'column', md: 'row' },
+					justifyContent: 'center',
+					alignItems: 'center',
+					gap: 2,
+				}}
+			>
+				<Box sx={{ width: '100%', px: { xs: 1, sm: 2 }, flex: 1 }}>
 					<SearchForm loadLocalStorage />
+				</Box>
+				<Box sx={{ width: '100%', flex: 1, mt: { xs: 2, md: 0 } }}>
+					<PosterCarousel />
 				</Box>
 			</Box>
 		</Base>

--- a/client/src/components/home/PosterCarousel.js
+++ b/client/src/components/home/PosterCarousel.js
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Link, Typography } from '@mui/material';
+import POSTERS from '../../constants/posters';
+
+const PosterCarousel = () => {
+	const [index, setIndex] = useState(0);
+
+	useEffect(() => {
+		const id = setInterval(() => {
+			setIndex((prev) => (prev + 1) % POSTERS.length);
+		}, 5000);
+		return () => clearInterval(id);
+	}, []);
+
+	const poster = POSTERS[index];
+
+	return (
+		<Box sx={{ position: 'relative', width: '100%', height: { xs: 150, sm: 200 }, overflow: 'hidden' }}>
+			<Link href={poster.href} sx={{ display: 'block', width: '100%', height: '100%' }}>
+				<Box
+					component='img'
+					src={poster.src}
+					alt={poster.title}
+					sx={{ width: '100%', height: '100%', objectFit: 'cover' }}
+				/>
+				<Typography
+					variant='h5'
+					sx={{
+						position: 'absolute',
+						bottom: 16,
+						left: 16,
+						color: '#fff',
+						textShadow: '0 0 4px rgba(0,0,0,0.6)',
+					}}
+				>
+					{poster.title}
+				</Typography>
+			</Link>
+		</Box>
+	);
+};
+
+export default PosterCarousel;

--- a/client/src/constants/index.js
+++ b/client/src/constants/index.js
@@ -3,3 +3,4 @@ export { default as ENUM_LABELS, getEnumOptions } from './enumLabels';
 export { default as UI_LABELS } from './uiLabels';
 export { default as VALIDATION_MESSAGES } from './validationMessages';
 export * from './formats';
+export { default as POSTERS } from './posters';

--- a/client/src/constants/posters.js
+++ b/client/src/constants/posters.js
@@ -1,0 +1,19 @@
+const POSTERS = [
+	{
+		src: '/images/posters/winter.svg',
+		title: 'Winter Deals',
+		href: '/deals',
+	},
+	{
+		src: '/images/posters/routes.svg',
+		title: 'New Routes',
+		href: '/routes',
+	},
+	{
+		src: '/images/posters/loyalty.svg',
+		title: 'Loyalty Program',
+		href: '/loyalty',
+	},
+];
+
+export default POSTERS;


### PR DESCRIPTION
## Summary
- add constants for promotional posters and placeholder images
- create `PosterCarousel` component to rotate promos
- show poster carousel beside the home page search form

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b4452ff46c832f9e4afa70e1fa3392