### PR TITLE
feat: localize date picker fields

### DIFF
--- a/client/src/components/utils/formField.js
+++ b/client/src/components/utils/formField.js
@@ -18,6 +18,7 @@ import 'quill/dist/quill.snow.css';
 
 import {
 	dateLocale,
+	datePickerLocaleText,
 	DATE_FORMAT,
 	TIME_FORMAT,
 	DEFAULT_EMAIL,
@@ -49,7 +50,17 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 
 		switch (type) {
 			case FIELD_TYPES.EMAIL: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+					disabled,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -73,7 +84,17 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.PHONE: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+					disabled,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -97,7 +118,17 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.TEXT: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+					disabled,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -115,7 +146,17 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.TEXT_AREA: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+					disabled,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}
@@ -138,14 +179,28 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.RICH_TEXT: {
-				const { value = '', onChange, fullWidth, error, helperText, sx, rows, disabled } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					sx,
+					rows,
+					disabled,
+				} = allProps;
 				const editorRows = rows || field.rows || 20;
 				const editorMinHeight = editorRows * 24;
 				const modules = {
 					toolbar: [
 						[{ header: [1, 2, false] }],
 						['bold', 'italic', 'underline', 'strike', 'blockquote'],
-						[{ list: 'ordered' }, { list: 'bullet' }, { indent: '-1' }, { indent: '+1' }],
+						[
+							{ list: 'ordered' },
+							{ list: 'bullet' },
+							{ indent: '-1' },
+							{ indent: '+1' },
+						],
 						['link', 'clean'],
 					],
 				};
@@ -174,7 +229,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 					>
 						<InputLabel shrink>{field.label}</InputLabel>
 						<ReactQuill
-							theme='snow'
+							theme="snow"
 							value={value}
 							onChange={onChange}
 							modules={modules}
@@ -187,7 +242,17 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.NUMBER: {
-				const { value = '', onChange, fullWidth, error, helperText, inputProps, sx, size, disabled } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					inputProps,
+					sx,
+					size,
+					disabled,
+				} = allProps;
 
 				const step = field.inputProps?.step ?? (field.float ? 0.01 : 1);
 				const min = field.inputProps?.min ?? 0;
@@ -195,7 +260,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 
 				return (
 					<TextField
-						type='number'
+						type="number"
 						label={field.label}
 						fullWidth={fullWidth}
 						error={error}
@@ -206,8 +271,12 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 						onBlur={(e) => {
 							const num = e.target.valueAsNumber;
 							if (!isNaN(num)) {
-								const clamped = Math.min(Math.max(min, num), max);
-								const rounded = Math.round(clamped / step) * step;
+								const clamped = Math.min(
+									Math.max(min, num),
+									max,
+								);
+								const rounded =
+									Math.round(clamped / step) * step;
 								onChange(rounded);
 							}
 						}}
@@ -238,11 +307,17 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 					disabled,
 				} = allProps;
 				return (
-					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
+					<LocalizationProvider
+						dateAdapter={AdapterDateFns}
+						adapterLocale={dateLocale}
+						localeText={datePickerLocaleText}
+					>
 						<DatePicker
 							label={field.label}
 							value={value ? parseDate(value) : null}
-							onChange={(date) => onChange(formatDate(date, DATE_API_FORMAT))}
+							onChange={(date) =>
+								onChange(formatDate(date, DATE_API_FORMAT))
+							}
 							minDate={minDate ? parseDate(minDate) : undefined}
 							maxDate={maxDate ? parseDate(maxDate) : undefined}
 							format={field.dateFormat || DATE_FORMAT}
@@ -255,8 +330,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 									sx,
 									size,
 									disabled,
+									placeholder:
+										field.dateFormat || DATE_FORMAT,
 									...textFieldProps,
 								},
+								field: { clearable: true },
 							}}
 						/>
 					</LocalizationProvider>
@@ -264,10 +342,24 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.TIME: {
-				const { value, onChange, fullWidth, error, helperText, sx, textFieldProps, size, disabled } = allProps;
+				const {
+					value,
+					onChange,
+					fullWidth,
+					error,
+					helperText,
+					sx,
+					textFieldProps,
+					size,
+					disabled,
+				} = allProps;
 
 				return (
-					<LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={dateLocale}>
+					<LocalizationProvider
+						dateAdapter={AdapterDateFns}
+						adapterLocale={dateLocale}
+						localeText={datePickerLocaleText}
+					>
 						<TimePicker
 							label={field.label}
 							value={value ? parseTime(value) : null}
@@ -286,6 +378,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 									disabled,
 									...textFieldProps,
 								},
+								field: { clearable: true },
 							}}
 						/>
 					</LocalizationProvider>
@@ -309,20 +402,34 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 					disabled,
 				} = allProps;
 
-				const resolvedValue = value !== undefined && value !== null ? value : field.defaultValue;
-				const isValidValue = options.some((o) => o.value === resolvedValue);
+				const resolvedValue =
+					value !== undefined && value !== null
+						? value
+						: field.defaultValue;
+				const isValidValue = options.some(
+					(o) => o.value === resolvedValue,
+				);
 				const safeValue = isValidValue ? resolvedValue : '';
 
 				if (!simpleSelect && options.length > 100) {
-					const valueObj = options.find((o) => o.value === value) || null;
+					const valueObj =
+						options.find((o) => o.value === value) || null;
 					return (
 						<Autocomplete
 							options={options}
 							value={valueObj}
-							onChange={(e, val) => onChange(val ? val.value : '')}
+							onChange={(e, val) =>
+								onChange(val ? val.value : '')
+							}
 							filterOptions={(opts, state) =>
 								opts
-									.filter((o) => o.label.toLowerCase().includes(state.inputValue.toLowerCase()))
+									.filter((o) =>
+										o.label
+											.toLowerCase()
+											.includes(
+												state.inputValue.toLowerCase(),
+											),
+									)
 									.slice(0, 100)
 							}
 							getOptionLabel={(o) => o.label}
@@ -356,7 +463,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 							disabled={disabled}
 						>
 							{options.map((option) => (
-								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
+								<MenuItem
+									key={option.value}
+									value={option.value}
+									{...MenuItemProps}
+								>
 									{option.label}
 								</MenuItem>
 							))}
@@ -365,7 +476,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 				}
 
 				return (
-					<FormControl fullWidth={fullWidth} error={!!error} size={size}>
+					<FormControl
+						fullWidth={fullWidth}
+						error={!!error}
+						size={size}
+					>
 						<InputLabel>{field.label}</InputLabel>
 						<Select
 							value={safeValue}
@@ -378,7 +493,11 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 							disabled={disabled}
 						>
 							{options.map((option) => (
-								<MenuItem key={option.value} value={option.value} {...MenuItemProps}>
+								<MenuItem
+									key={option.value}
+									value={option.value}
+									{...MenuItemProps}
+								>
 									{option.label}
 								</MenuItem>
 							))}
@@ -396,7 +515,7 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 							<Checkbox
 								checked={!!value}
 								onChange={(e) => onChange(e.target.checked)}
-								color='primary'
+								color="primary"
 								disabled={disabled}
 							/>
 						}
@@ -408,10 +527,19 @@ export const createFieldRenderer = (field, defaultProps = {}) => {
 			}
 
 			case FIELD_TYPES.CUSTOM:
-				return (customProps) => field.renderField({ ...allProps, ...customProps });
+				return (customProps) =>
+					field.renderField({ ...allProps, ...customProps });
 
 			default: {
-				const { value = '', onChange, fullWidth, inputProps, sx, size, disabled } = allProps;
+				const {
+					value = '',
+					onChange,
+					fullWidth,
+					inputProps,
+					sx,
+					size,
+					disabled,
+				} = allProps;
 				return (
 					<TextField
 						label={field.label}

--- a/client/src/constants/formats.js
+++ b/client/src/constants/formats.js
@@ -1,8 +1,11 @@
 import { set } from 'date-fns';
 import { ru } from 'date-fns/locale';
+import { ruRU } from '@mui/x-date-pickers/locales';
 import numeral from 'numeral';
 
 export const dateLocale = ru;
+export const datePickerLocaleText =
+	ruRU.components.MuiLocalizationProvider.defaultProps.localeText;
 
 export const DATE_FORMAT = 'dd.MM.yyyy';
 export const DATE_API_FORMAT = 'yyyy-MM-dd';


### PR DESCRIPTION
## Summary
- localize date and time pickers for Russian users
- enable clearing date/time fields and add date format placeholder
- centralize MUI date picker locale text in constants

## Testing
- `npx prettier -c client/src/components/utils/formField.js client/src/constants/formats.js --use-tabs --tab-width 4 --single-quote`
- `npx eslint client/src/components/utils/formField.js client/src/constants/formats.js` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*
- `cd client && npm test -- --watchAll=false --passWithNoTests && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68b446c01c30832f8e7e16d7605e252d