### PR TITLE
Ensure booking access tokens are used on client requests

### DIFF
--- a/client/src/components/booking/Confirmation.js
+++ b/client/src/components/booking/Confirmation.js
@@ -67,7 +67,7 @@ const Confirmation = () => {
 	const handlePayment = async (isPayment = true) => {
 		setLoading(true);
 		try {
-			await dispatch(confirmBooking({ publicId, isPayment })).unwrap();
+                        await dispatch(confirmBooking({ publicId, isPayment, accessToken })).unwrap();
 			await dispatch(fetchBookingAccess({ publicId, accessToken })).unwrap();
 			const query = accessToken ? `?access_token=${accessToken}` : '';
 			navigate(`/booking/${publicId}/payment${query}`);

--- a/client/src/components/booking/Passengers.js
+++ b/client/src/components/booking/Passengers.js
@@ -251,13 +251,14 @@ const Passengers = () => {
 		try {
 			const apiPassengers = (passengerData || []).map(toApiPassenger);
 			const apiBuyer = toApiBuyer(buyer);
-			await dispatch(
-				processBookingPassengers({
-					public_id: publicId,
-					buyer: apiBuyer,
-					passengers: apiPassengers,
-				})
-			).unwrap();
+                        await dispatch(
+                                processBookingPassengers({
+                                        public_id: publicId,
+                                        buyer: apiBuyer,
+                                        passengers: apiPassengers,
+                                        accessToken,
+                                })
+                        ).unwrap();
 			await dispatch(fetchBookingDetails({ publicId, accessToken })).unwrap();
 			await dispatch(fetchBookingAccess({ publicId, accessToken })).unwrap();
 			const query = accessToken ? `?access_token=${accessToken}` : '';

--- a/client/src/components/search/SelectTicketDialog.js
+++ b/client/src/components/search/SelectTicketDialog.js
@@ -254,9 +254,10 @@ const SelectTicketDialog = ({ open, onClose, outbound, returnFlight }) => {
 			payload.return_id = returnFlight.id;
 			payload.return_tariff_id = returnTariffId;
 		}
-		const res = await dispatch(processBookingCreate(payload)).unwrap();
-		navigate(`/booking/${res.public_id}/passengers`);
-	};
+                const res = await dispatch(processBookingCreate(payload)).unwrap();
+                const query = res.access_token ? `?access_token=${res.access_token}` : '';
+                navigate(`/booking/${res.public_id}/passengers${query}`);
+        };
 
 	const [tariffDetails, setTariffDetails] = useState({ terms: '', hand_luggage: null, baggage: null });
 	const [showTariffDetails, setShowTariffDetails] = useState(false);

--- a/client/src/redux/actions/bookingProcess.js
+++ b/client/src/redux/actions/bookingProcess.js
@@ -3,24 +3,25 @@ import { serverApi } from '../../api';
 import { getErrorData } from '../utils';
 
 export const processBookingCreate = createAsyncThunk('bookingProcess/create', async (data, { rejectWithValue }) => {
-	try {
-		const res = await serverApi.post('/booking/create', data);
-		return { ...data, ...res.data };
-	} catch (err) {
-		return rejectWithValue(getErrorData(err));
-	}
+        try {
+                const res = await serverApi.post('/booking/create', data);
+                return { ...data, ...res.data };
+        } catch (err) {
+                return rejectWithValue(getErrorData(err));
+        }
 });
 
 export const processBookingPassengers = createAsyncThunk(
-	'bookingProcess/passengers',
-	async (data, { rejectWithValue }) => {
-		try {
-			const res = await serverApi.post('/booking/passengers', data);
-			return res.data;
-		} catch (err) {
-			return rejectWithValue(getErrorData(err));
-		}
-	}
+        'bookingProcess/passengers',
+        async (arg, { rejectWithValue }) => {
+                try {
+                        const { accessToken, ...data } = arg || {};
+                        const res = await serverApi.post('/booking/passengers', data, buildAccessParams(accessToken));
+                        return res.data;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
 );
 
 const buildAccessParams = (accessToken) => (accessToken ? { params: { access_token: accessToken } } : {});
@@ -59,17 +60,17 @@ export const downloadBookingPdf = createAsyncThunk('bookingProcess/downloadPdf',
 });
 
 export const confirmBooking = createAsyncThunk(
-	'bookingProcess/confirm',
-	async ({ publicId, isPayment = true }, { rejectWithValue }) => {
-		try {
-			const payload = {
-				public_id: publicId,
-				is_payment: isPayment,
-			};
-			const res = await serverApi.post('/booking/confirm', payload);
-			return res.data;
-		} catch (err) {
-			return rejectWithValue(getErrorData(err));
-		}
-	}
+        'bookingProcess/confirm',
+        async ({ publicId, isPayment = true, accessToken }, { rejectWithValue }) => {
+                try {
+                        const payload = {
+                                public_id: publicId,
+                                is_payment: isPayment,
+                        };
+                        const res = await serverApi.post('/booking/confirm', payload, buildAccessParams(accessToken));
+                        return res.data;
+                } catch (err) {
+                        return rejectWithValue(getErrorData(err));
+                }
+        }
 );


### PR DESCRIPTION
## Summary
- append the booking access token to passenger and confirmation navigation links so subsequent pages retain it
- include the access token with passenger and confirmation API requests when present
- keep booking process state updates unchanged while ensuring protected endpoints receive the token

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f21b981b10832f98e3a5df75d32462